### PR TITLE
fixed service.type (grafana, alertmanager)

### DIFF
--- a/charts/prometheus/v6.2.1/questions.yml
+++ b/charts/prometheus/v6.2.1/questions.yml
@@ -181,7 +181,7 @@ questions:
     type: hostname
     required: true
     label: Hostname
-- variable: grafana.server.type
+- variable: grafana.service.type
   default: "NodePort"
   description: "Grafana service type"
   type: enum
@@ -255,7 +255,7 @@ questions:
     required: true
     label: Hostname
     show_if: "alertmanager.enabled=true"
-- variable: alertmanager.server.type
+- variable: alertmanager.service.type
   default: "ClusterIP"
   description: "Alertmanager service type"
   type: enum


### PR DESCRIPTION
fixed: using .service.type instead of .server.type for grafana and alertmanager type in questions.yml