### PR TITLE
Fixed ingress for Grafana

### DIFF
--- a/charts/grafana/v0.0.30/templates/ingress.yaml
+++ b/charts/grafana/v0.0.30/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
           - path: "{{ $routePrefix }}"
             backend:
               serviceName: {{ printf "%s-%s" $releaseName "grafana" | trunc 63 }}
-              servicePort: 80
+              servicePort: 3000
     {{- end -}}              
 {{- if .Values.ingress.tls }}
   tls:


### PR DESCRIPTION
Grafana is listening on port 3000 (set in grafana-deployment.yaml) so default 80 doesn't work.