### PR TITLE
New chart: Jenkins SSH Slave

### DIFF
--- a/charts/jenkins-ssh-slave/latest/.helmignore
+++ b/charts/jenkins-ssh-slave/latest/.helmignore
@@ -1,0 +1,3 @@
+.git
+# OWNERS file for Kubernetes
+OWNERS

--- a/charts/jenkins-ssh-slave/latest/Chart.yaml
+++ b/charts/jenkins-ssh-slave/latest/Chart.yaml
@@ -1,0 +1,15 @@
+name: jenkins-ssh-slave
+version: 0.0.1
+appVersion: latest
+description: A Jenkins slave using SSH to establish connection.
+icon: https://d33np9n32j53g7.cloudfront.net/assets/stacks/jenkins/img/jenkins-stack-220x234-ef694d84df5715062481cb67aa2b853c.png
+keywords:
+- development
+- continous integration
+home: https://jenkins.io/
+sources:
+- https://github.com/jenkinsci/docker-ssh-slave.git
+maintainers:
+- name: fhossfel
+  email: support@thoughtgang.de
+engine: gotpl

--- a/charts/jenkins-ssh-slave/latest/OWNERS
+++ b/charts/jenkins-ssh-slave/latest/OWNERS
@@ -1,0 +1,2 @@
+maintainers:
+  - fhossfel

--- a/charts/jenkins-ssh-slave/latest/README.md
+++ b/charts/jenkins-ssh-slave/latest/README.md
@@ -1,0 +1,47 @@
+# Jenkins SSH slave Docker image
+
+[`jenkins/ssh-slave`](https://hub.docker.com/r/jenkins/ssh-slave/)
+
+A [Jenkins](https://jenkins-ci.org) slave using SSH to establish connection.
+
+See [Jenkins Distributed builds](https://wiki.jenkins-ci.org/display/JENKINS/Distributed+builds) for more info.
+
+## Running
+
+To run a Docker container
+
+```bash
+docker run jenkins/ssh-slave "<public key>"
+```
+
+You'll then be able to connect this slave using ssh-slaves-plugin as "jenkins" with the matching private key.
+
+### How to use this image with Docker Plugin
+
+To use this image with [Docker Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Docker+Plugin), you need to
+pass the public SSH key using environment variable `JENKINS_SLAVE_SSH_PUBKEY` and not as a startup argument.
+
+In _Environment_ field of the Docker Template (advanced section), just add:
+
+    JENKINS_SLAVE_SSH_PUBKEY=<YOUR PUBLIC SSH KEY HERE>
+
+Don't put quotes around the public key. You should be all set.
+
+
+## Configuration
+
+The following table lists the configurable parameters of the Jenkins SSH Slave chart and their default values.
+
+| Parameter                            | Description                                | Default                                                    |
+| ------------------------------------ | ------------------------------------------ | ---------------------------------------------------------- |
+| `image.registry`                     | Jenkins SSH Slave image registry           | `docker.io`                                                |
+| `image.repository`                   | Jenkins SSH Slave image name               | `jenkinsci/ssh-slave`                                      |
+| `image.tag`                          | WordPress image tag                        | `{VERSION}`                                                |
+| `image.pullPolicy`                   | Image pull policy                          | `Always` if `imageTag` is `latest`, else `IfNotPresent`    |
+| `image.pullSecrets`                  | Specify image pull secrets                 | `nil`                                                      |
+| `jenkinsSSHPublicKey`                | Public SSH Key to access this node         | `nil`                                                      |
+| `serviceType`                        | Service type (either Nodeport or ClusterIP)| `nil`                                                      |
+| `nodePorts.ssh`                      | Nodeport (automatically addined if `nil`   | `nil`                                                      |
+
+> **Protip**: Use ClusterIP only if your Jenkins instance is running on the same cluster as 
+> the SSH Slaves. Otherwise use NodePort.

--- a/charts/jenkins-ssh-slave/latest/app-readme.md
+++ b/charts/jenkins-ssh-slave/latest/app-readme.md
@@ -1,0 +1,5 @@
+# Jenkins SSH Slave
+	
+The leading open source automation server, [Jenkins](https://jenkins.io) provides hundreds of plugins to support building, deploying and automating any project.
+	
+This chart bootstraps a [Jenkins SSH Slave](https://wiki.jenkins.io/display/JENKINS/SSH+Slaves+plugin).

--- a/charts/jenkins-ssh-slave/latest/questions.yml
+++ b/charts/jenkins-ssh-slave/latest/questions.yml
@@ -1,0 +1,55 @@
+categories:
+- Development
+- Continous Integration
+questions:
+- variable: defaultImage
+  default: true
+  description: "Use default Docker image"
+  label: Use Default Image
+  type: boolean
+  show_subquestion_if: false
+  group: "Container Images"
+  subquestions:
+  - variable: image.repository
+    default: "jenkinsci/ssh-slave"
+    description: "Jenkins SSH Slave image name"
+    type: string
+    label: "Jenkins SSH Slave Image Name"
+  - variable: image.tag
+    default: "latest"
+    description: "Jenkins SSH Slave image tag"
+    type: string
+    label: "Jenkins SSH Slave Image Name Image Tag"
+- variable: jenkinsSSHPublicKey
+  description: "Public SSH Key used by the Jenkins Server to access this node"
+  type: string
+  label: SSH Public Key
+- variable: serviceType
+  default: "NodePort"
+  label: Jenkins SSH Slave Service Type
+  description: "Service type of Jenkins SSH Slave"
+  show_subquestion_if: "NodePort"
+  type: enum
+  options:
+    - "ClusterIP"
+    - "NodePort"
+  required: true
+  subquestions:
+  - variable: nodePorts.ssh
+    default: ""
+    description: "NodePort to connect through SSH (to set explicitly, choose port between 30000-32767)"
+    type: int
+    min: 30000
+    max: 32767
+    label: NodePort SSH Port
+    show_if: "serviceType=NodePort"
+- variable: resources.limits.memory
+  description: "Memory limit of during builds in mega bytes"
+  type: int
+  min: 30000
+  max: 32767
+  label: Memory limit (MB)
+- variable: resources.limits.cpu
+  description: "CPU limit in Kubernetes CPU units. Use the suffix m to mean milli."
+  type: string
+  label: CPU limit

--- a/charts/jenkins-ssh-slave/latest/templates/NOTES.txt
+++ b/charts/jenkins-ssh-slave/latest/templates/NOTES.txt
@@ -1,0 +1,40 @@
+
+Testing your Jenkins SSH Slave:
+-------------------------------
+1. Test logging into your SSH Slave
+
+{{- if eq .Values.serviceType  "NodePort" }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  ssh -i <path to your private key> -p $NODE_PORT jenkins@$NODE_IP
+
+Note down the NODE_PORT and NODE_IP.
+{{- else if eq .Values.serviceType "ClusterIP"}}
+  On any cluster node run:
+  export CLUSTER_IP=$(kubectl get services --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].spec.clusterIP}")
+  ssh -i <path to your private key> $CLUSTER_IP
+
+Note down your cluster IP
+{{- end }}
+
+Adding the Jenkins SSH Slave to your Jenkins Server:
+----------------------------------------------------
+1. Make sure the SSH Slaves plugin is installed
+2. Open Jenkins and go to "Credentials". Create add new global credentials for the user jenkins with the private SSH key.
+3. Open jenkins and go the "Manage Nodes" screen. Create a new node with the following properties:
+    - Name: The name you want to assign this node
+    - # of executors: 1
+    - Start Agent via SSH
+{{- if eq .Values.serviceType "NodePort" }}
+    - Hostname: Hostname of the node or NODE_IP (as note above) 
+{{- else if eq .Values.serviceType "ClusterIP"}}
+    - Hostname: ClusterIP
+{{- end }}
+    - Credentials: Choose the SSH key you created above.
+    - Host Key Verification Strategy: Manually trusted key Verification Strategy
+    - Require manual verification of initial connection: yes
+{{- if eq .Values.serviceType "NodePort" }}
+    - Advanced->Port: NODE_PORT (as note above) 
+{{- end }}
+
+Enjoy!

--- a/charts/jenkins-ssh-slave/latest/templates/_helpers.tpl
+++ b/charts/jenkins-ssh-slave/latest/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "mariadb.fullname" -}}
+{{- printf "%s-%s" .Release.Name "mariadb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/jenkins-ssh-slave/latest/templates/deployment.yaml
+++ b/charts/jenkins-ssh-slave/latest/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+    spec:
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+      - name: {{ template "fullname" . }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy | quote }}
+        env:
+        - name: JENKINS_SLAVE_SSH_PUBKEY
+          value: {{ .Values.jenkinsSSHPublicKey | quote }}
+        ports:
+        - name: ssh
+          containerPort: 22
+        livenessProbe:
+          tcpSocket:
+            port: ssh
+          initialDelaySeconds: 15
+          periodSeconds: 20
+{{ toYaml .Values.livenessProbe | indent 10 }}
+        readinessProbe:
+          tcpSocket:
+            port: ssh
+          initialDelaySeconds: 5
+          periodSeconds: 10
+{{ toYaml .Values.readinessProbe | indent 10 }}
+        {{- if or .Values.resources.limits.memory .Values.resources.limits.cpu }}
+        resources:
+          {{- if ne .Values.resources.limits.memory "" }}
+            memory: {{ .Values.resources.limits.memory | quote }}
+          {{- end }}
+          {{- if .Values.resources.limits.cpu }}
+            cpu: {{ .Values.resources.limits.cpu | quote }}
+          {{- end }}
+        {{- end }}
+#{{ toYaml .Values.resources | indent 10 }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end -}}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/jenkins-ssh-slave/latest/templates/service.yaml
+++ b/charts/jenkins-ssh-slave/latest/templates/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    app: {{ template "fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+spec:
+  type: {{ .Values.serviceType }}
+  {{- if eq .Values.serviceType "NodePort" }}
+  externalTrafficPolicy: {{ .Values.serviceExternalTrafficPolicy | quote }}
+  {{- end }}
+  ports:
+    - name: ssh
+      port: 22
+      targetPort: ssh
+      {{- if (and (eq .Values.serviceType "NodePort") (not (empty .Values.nodePorts.ssh)))}}
+      nodePort: {{ .Values.nodePorts.ssh }}
+      {{- end }}
+  selector:
+    app: {{ template "fullname" . }}

--- a/charts/jenkins-ssh-slave/latest/values.yaml
+++ b/charts/jenkins-ssh-slave/latest/values.yaml
@@ -1,0 +1,85 @@
+## Bitnami WordPress image version
+## ref: https://hub.docker.com/r/bitnami/wordpress/tags/
+##
+image:
+  # registry: docker.io
+  repository: "jenkinsci/ssh-slave"
+  tag: latest
+  ## Specify a imagePullPolicy
+  ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+  ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+  ##
+  pullPolicy: IfNotPresent
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  # pullSecrets:
+  #   - myRegistrKeySecretName
+
+## User of the application
+## ref: https://github.com/bitnami/bitnami-docker-wordpress#environment-variables
+##
+jenkinsSSHPublicKey: ""
+
+replicaCount: 1
+
+## Kubernetes configuration
+## For minikube, set this to NodePort, elsewhere use LoadBalancer or ClusterIP
+##
+## serviceType: NodePort
+serviceType: NodePort
+##
+## serviceType: NodePort
+## nodePorts:
+##   ssh: <to set explicitly, choose port between 30000-32767>
+nodePorts:
+  ssh: ""
+## Enable client source IP preservation
+## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+##
+serviceExternalTrafficPolicy: Cluster
+
+## Allow health checks to be pointed at the https port
+healthcheckHttps: false
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+#  requests:
+#    memory: 512Mi
+#    cpu: 300m
+  limits:
+#    memory:
+#    cpu:
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}


### PR DESCRIPTION
I have packaged the [Jenkins SSH Slave](https://hub.docker.com/r/jenkinsci/ssh-slave/) image to run with Kubernetes. The setup should work with either a node port setup if you running your Jenkins outside your cluster or with an internal cluster IP.