### PR TITLE
Disable proxy body size limit

### DIFF
--- a/charts/docker-registry/latest/values.yaml
+++ b/charts/docker-registry/latest/values.yaml
@@ -32,6 +32,7 @@ ingress:
   hosts:
     - chart-example.local
   annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 0
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   tls:


### PR DESCRIPTION
When pushing docker images, some of the layers can be quite big. Hence disabling this limit altogether.