### PR TITLE
Bump to storageos-operator 1.2.0 and node 1.2.1

### DIFF
--- a/proposed/storageos-operator/Chart.yaml
+++ b/proposed/storageos-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.1.0"
+appVersion: "1.2.0"
 description: Cloud Native storage for containers
 name: storageos-operator
-version: 0.1.0
+version: 0.2.0
 keywords:
 - storage
 - block-storage

--- a/proposed/storageos-operator/README.md
+++ b/proposed/storageos-operator/README.md
@@ -148,9 +148,9 @@ Operator chart and their default values.
 
 Parameter | Description | Default
 --------- | ----------- | -------
-`operator.image.repository` | StorageOSCluster container image repository | `storageos/cluster-operator`
-`operator.image.tag` | StorageOSCluster container image tag | `1.1.0`
-`operator.image.pullPolicy` | StorageOSCluster container image pull policy | `IfNotPresent`
+`operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
+`operator.image.tag` | StorageOS Operator container image tag | `1.2.0`
+`operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
 `podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
 `podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
 `cluster.create` | If true, auto-create the StorageOS cluster | `true`
@@ -171,8 +171,9 @@ Parameter | Description | Default
 `cluster.toleration.value` | Value of the pod toleration parameter |
 `cluster.disableTelemetry` | If true, no telemetry data will be collected from the cluster | `false`
 `cluster.images.node.repository` | StorageOS Node container image repository | `storageos/node`
-`cluster.images.node.tag` | StorageOS Node container image tag | `1.2.0`
+`cluster.images.node.tag` | StorageOS Node container image tag | `1.2.1`
 `cluster.csi.enable` | If true, CSI driver is enabled | `true`
+`cluster.csi.deploymentStrategy` | Whethe CSI helpers should be deployed as a `deployment` or `statefulset` | `deployment`
 
 ## Deleting a StorageOS Cluster
 

--- a/proposed/storageos-operator/questions.yml
+++ b/proposed/storageos-operator/questions.yml
@@ -32,7 +32,7 @@ questions:
     type: string
     label: StorageOS Operator Image Name
   - variable: operator.image.tag
-    default: "1.1.0"
+    default: "1.2.0"
     description: "StorageOS Operator image tag"
     type: string
     label: StorageOS Operator Image Tag
@@ -73,7 +73,7 @@ questions:
     type: string
     label: StorageOS Node Container Image Name
   - variable: cluster.images.node.tag
-    default: "1.2.0"
+    default: "1.2.1"
     description: "StorageOS Node container image tag"
     type: string
     label: StorageOS Node Container Image Tag

--- a/proposed/storageos-operator/templates/cleanup.yaml
+++ b/proposed/storageos-operator/templates/cleanup.yaml
@@ -124,6 +124,7 @@ spec:
           {{- range .command }}
           - {{ . | quote }}
           {{- end }}
+          - --ignore-not-found=true
       restartPolicy: Never
   backoffLimit: 4
 

--- a/proposed/storageos-operator/templates/rbac.yaml
+++ b/proposed/storageos-operator/templates/rbac.yaml
@@ -22,6 +22,7 @@ rules:
   resources:
   - statefulsets
   - daemonsets
+  - deployments
   verbs:
   - "*"
 - apiGroups:
@@ -99,7 +100,20 @@ rules:
   verbs:
   - create
   - delete
-
+# OpenShift specific rule.
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - update
+  - get
+  - use
+  resourceNames:
+  - privileged
+  
 ---
 
 # Bind operator service account to storageos-operator role

--- a/proposed/storageos-operator/templates/storageoscluster_cr.yaml
+++ b/proposed/storageos-operator/templates/storageoscluster_cr.yaml
@@ -22,6 +22,7 @@ spec:
 
   csi:
     enable: {{ .Values.cluster.csi.enable }}
+    deploymentStrategy: {{ .Values.cluster.csi.deploymentStrategy }}
 
   {{- if .Values.cluster.sharedDir }}
   sharedDir: {{ .Values.cluster.sharedDir }}

--- a/proposed/storageos-operator/templates/storageoscluster_crd.yaml
+++ b/proposed/storageos-operator/templates/storageoscluster_crd.yaml
@@ -41,6 +41,8 @@ spec:
               type: string
             namespace:
               type: string
+            k8sDistro:
+              type: string
             disableFencing:
               type: boolean
             disableTelemetry:
@@ -57,6 +59,8 @@ spec:
                   type: string
                 csiExternalAttacherContainer:
                   type: string
+                csiLivenessProbeContainer:
+                  type: string
             csi:
               properties:
                 enable:
@@ -67,6 +71,8 @@ spec:
                   type: boolean
                 enableNodePublishCreds:
                   type: boolean
+                deploymentStrategy:
+                  type: string
             service:
               properties:
                 name:

--- a/proposed/storageos-operator/values.yaml
+++ b/proposed/storageos-operator/values.yaml
@@ -27,7 +27,7 @@ operator:
 
   image:
     repository: storageos/cluster-operator
-    tag: 1.1.0
+    tag: 1.2.0
     pullPolicy: IfNotPresent
 
 # cluster-specific configuation parameters.
@@ -88,10 +88,11 @@ cluster:
     # [Docker Hub](https://hub.docker.com/r/storageos/node/).
     node:
       repository: storageos/node
-      tag: 1.2.0
+      tag: 1.2.1
 
   csi:
     enable: true
+    deploymentStrategy: deployment
 
 # The following is used for cleaning up unmanaged cluster resources when
 # auto-install is enabled.
@@ -104,6 +105,10 @@ cleanup:
     command:
       - "statefulset"
       - "storageos-statefulset"
+  - name: csi-helper
+    command:
+      - "deployment"
+      - "storageos-csi-helper"
   - name: serviceaccount
     command:
       - "serviceaccount"


### PR DESCRIPTION
We released an new version of the operator and base image yesterday.  The operator supports a new field, `csi.deploymentStrategy` which determines whether the CSI helpers are deployed by the Operator as StafefulSets (previous) or Deployments (new default).  The cleanup jobs have been amended to support both and ignore whichever wasn't created.