### PR TITLE
[openebs]: remove pre-install hook from secret and pod labels

### DIFF
--- a/charts/openebs/latest/README.md
+++ b/charts/openebs/latest/README.md
@@ -65,6 +65,7 @@ The following table lists the configurable parameters of the OpenEBS chart and t
 | `ndm.sparse.count`                      | Number of sparse files to be created          | `1`                                       |
 | `ndm.filters.excludeVendors`            | Exclude devices with specified vendor         | `CLOUDBYT,OpenEBS`                        |
 | `ndm.filters.excludePaths`              | Exclude devices with specified path patterns  | `loop,fd0,sr0,/dev/ram,/dev/dm-,/dev/md`  |
+| `ndm.filters.includePaths`              | Include devices with specified path patterns  | `""`                                      |
 | `jiva.image`                            | Image for Jiva                                | `quay.io/openebs/jiva`                    |
 | `jiva.imageTag`                         | Image Tag for Jiva                            | `0.9.0`                                   |
 | `jiva.replicas`                         | Number of Jiva Replicas                       | `3`                                       |

--- a/charts/openebs/latest/templates/cm-node-disk-manager.yaml
+++ b/charts/openebs/latest/templates/cm-node-disk-manager.yaml
@@ -12,7 +12,7 @@ metadata:
     component: ndm-config
 data:
   # udev-probe is default or primary probe which should be enabled to run ndm
-  # filterconfigs contains configs of filters - in the form of include
+  # filterconfigs contails configs of filters - in ther form fo include
   # and exclude comma separated strings
   node-disk-manager.config: |
     probeconfigs:
@@ -38,6 +38,6 @@ data:
       - key: path-filter
         name: path filter
         state: true
-        include: ""
+        include: "{{ .Values.ndm.filters.includePaths }}"
         exclude: "{{ .Values.ndm.filters.excludePaths }}"
 ---

--- a/charts/openebs/latest/templates/daemonset-ndm.yaml
+++ b/charts/openebs/latest/templates/daemonset-ndm.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: ndm
-    openebs.io/component-name: ndm
 spec:
   updateStrategy:
     type: "RollingUpdate"
@@ -23,6 +22,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: ndm
+        openebs.io/component-name: ndm
+        name: openebs-ndm
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/charts/openebs/latest/templates/deployment-admission-server.yaml
+++ b/charts/openebs/latest/templates/deployment-admission-server.yaml
@@ -8,8 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: admission-webhook
-    name: admission-webhook
-    openebs.io/component-name: maya-apiserver
 spec:
   replicas: {{ .Values.webhook.replicas }}
   selector:
@@ -19,7 +17,9 @@ spec:
     metadata:
       labels:
         app: admission-webhook
+        name: admission-webhook
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: admission-webhook
     spec:
 {{- if .Values.webhook.nodeSelector }}
       nodeSelector:

--- a/charts/openebs/latest/templates/deployment-local-provisioner.yaml
+++ b/charts/openebs/latest/templates/deployment-local-provisioner.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: localpv-provisioner
-    openebs.io/component-name: openebs-localpv-provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:
@@ -21,7 +20,9 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: localpv-provisioner
+        name: openebs-localpv-provisioner
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: openebs-localpv-provisioner
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:

--- a/charts/openebs/latest/templates/deployment-maya-apiserver.yaml
+++ b/charts/openebs/latest/templates/deployment-maya-apiserver.yaml
@@ -9,7 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
     component: apiserver
     name: maya-apiserver
-    openebs.io/component-name: maya-apiserver
 spec:
   replicas: {{ .Values.apiserver.replicas }}
   selector:
@@ -23,6 +22,7 @@ spec:
         release: {{ .Release.Name }}
         component: apiserver
         name: maya-apiserver
+        openebs.io/component-name: maya-apiserver
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
@@ -48,6 +48,8 @@ spec:
         # If "true" a default cstor sparse pool will be configured, if "false" it will not be configured.
         - name: OPENEBS_IO_INSTALL_DEFAULT_CSTOR_SPARSE_POOL
           value: "{{ .Values.apiserver.sparse.enabled }}"
+        - name: OPENEBS_IO_CSTOR_POOL_SPARSE_DIR
+          value: "{{ .Values.ndm.sparse.path }}"
         # OPENEBS_NAMESPACE provides the namespace of this deployment as an
         # environment variable
         - name: OPENEBS_NAMESPACE

--- a/charts/openebs/latest/templates/deployment-maya-provisioner.yaml
+++ b/charts/openebs/latest/templates/deployment-maya-provisioner.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: provisioner
-    openebs.io/component-name: openebs-provisioner
 spec:
   replicas: {{ .Values.provisioner.replicas }}
   selector:
@@ -21,6 +20,8 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: provisioner
+        name: openebs-provisioner
+        openebs.io/component-name: openebs-provisioner
         openebs.io/version: {{ .Values.release.version }}
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}

--- a/charts/openebs/latest/templates/deployment-maya-snapshot-operator.yaml
+++ b/charts/openebs/latest/templates/deployment-maya-snapshot-operator.yaml
@@ -8,7 +8,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
     component: snapshot-operator
-    openebs.io/component-name: openebs-snapshot-operator
 spec:
   replicas: {{ .Values.snapshotOperator.replicas }}
   selector:
@@ -23,7 +22,9 @@ spec:
         app: {{ template "openebs.name" . }}
         release: {{ .Release.Name }}
         component: snapshot-operator
+        name: openebs-snapshot-operator
         openebs.io/version: {{ .Values.release.version }}
+        openebs.io/component-name: openebs-snapshot-operator
     spec:
       serviceAccountName: {{ template "openebs.serviceAccountName" . }}
       containers:

--- a/charts/openebs/latest/templates/validationwebhook.yaml
+++ b/charts/openebs/latest/templates/validationwebhook.yaml
@@ -42,13 +42,6 @@ metadata:
     chart: {{ template "openebs.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  # Helm hook annotations in order to ensure that the certs
-  # will only be generated on chart install. This will
-  # prevent overriding the certs anytime we upgrade the chart’s
-  # released instance.
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
 {{- if .Values.webhook.generateTLS }}


### PR DESCRIPTION

 - Updated README
 - Updated chart version
 - Updated values.yaml
 - Update pod labels for deployments

 `pre-install` hook: Executes after templates are rendered,
  but before any resources are created in Kubernetes.

  This hook has been added to the secret , will only be generated
  on chart install, to prevent overriding the certs anytime we upgrade
  the chart’s released instance.

  Thus `pre-install hook` prevents the secret creation if someone uses
  the older version of charts and upgraded to new version.

Signed-off-by: prateekpandey14 <prateek.pandey@openebs.io>