### PR TITLE
Update drone lint-chart image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ platform:
 steps:
 - name: lint-charts
   pull: default
-  image: guangbo/chart-testing:v2.0.2-rancher1
+  image: ranchercharts/chart-testing:v2.0.2-rancher2
   commands:
   - git remote add rancher-charts https://github.com/rancher/charts
   - git fetch rancher-charts master


### PR DESCRIPTION
Update the Drone lint-chart image to `v2.0.2-rancher2`, it adds skipping the `helm dep` check since we already add the sub-charts directly in our git repo, and the [CI]((https://drone-pr.rancher.io/rancher/charts/194/1/2)) will fail if we use uncompressed sub-charts.