### PR TITLE
Fix traefik typo and update chartmuseum default pv setting

### DIFF
--- a/charts/cert-manager/v0.9.1/questions.yml
+++ b/charts/cert-manager/v0.9.1/questions.yml
@@ -1,4 +1,5 @@
 namespace: kube-system
+rancher_min_version: 2.3.0
 labels:
   io.cattle.role: "cluster"
 questions:

--- a/charts/chartmuseum/v2.3.1/questions.yml
+++ b/charts/chartmuseum/v2.3.1/questions.yml
@@ -152,7 +152,7 @@ questions:
   group: "Storage Secret"
 # Local Storage Settings
 - variable: persistence.enabled
-  default: true
+  default: false
   type: boolean
   description: "use a PVC for persistent storage for local storage"
   label: Enable Persistent Storage For Local Storage

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -23,7 +23,7 @@ questions:
     - "LoadBalancer"
     - "NodePort"
     - "ClusterIP"
-  default: "Loadbalancer"
+  default: "LoadBalancer"
   description: "Service Type for Traefik"
   label: Service Type
   group: "General Settings"


### PR DESCRIPTION
**Problem**
Fix traefik typo and update chartmuseum default pv setting


**Related Issue:**
https://github.com/rancher/rancher/issues/23070#event-2660039893
https://github.com/rancher/rancher/issues/23072#event-2660051332
