### PR TITLE
Add empty array check of webhook extraArg

### DIFF
--- a/charts/cert-manager/v0.9.1/charts/webhook/templates/deployment.yaml
+++ b/charts/cert-manager/v0.9.1/charts/webhook/templates/deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - --secure-port=6443
           - --tls-cert-file=/certs/tls.crt
           - --tls-private-key-file=/certs/tls.key
-        {{- if .Values.extraArgs }}
+        {{- if and .Values.extraArgs (ne (.Values.extraArgs | toString) "[]") }}
 {{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}
           env:


### PR DESCRIPTION
address `to error converting YAML to JSON: yaml: line 35: could not find expected ':'` as v0.5.2 cert-manger will set string `[]`.