### PR TITLE
Enable metric env for enpterise image only

### DIFF
--- a/charts/kafka/v0.8.0/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/kafka/v0.8.0/charts/cp-kafka/templates/statefulset.yaml
@@ -119,10 +119,12 @@ spec:
           value: {{ include "cp-kafka.cp-zookeeper.service-name" . | quote }}
         - name: KAFKA_LOG_DIRS
           value: {{ include "cp-kafka.log.dirs" . | quote }}
+        {{- if .Values.global.enterprise }}
         - name: KAFKA_METRIC_REPORTERS
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
           value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}


### PR DESCRIPTION
Enable metric env for enpterise image only

**Related Issue:**
https://github.com/rancher/rancher/issues/23460