### PR TITLE
typo: doamin -> domain

### DIFF
--- a/charts/drone/v2.0.7/questions.yml
+++ b/charts/drone/v2.0.7/questions.yml
@@ -45,7 +45,7 @@ questions:
   default: ""
   type: string
   description: "Set drone server host e.g drone.domain.io, if not set, it will be autofilled with the cluster host."
-  label: Drone Host Doamin
+  label: Drone Host Domain
   required: true
   group: "Drone Settings"
 - variable: server.adminUser


### PR DESCRIPTION
Fixing a small typo in the questions template. doamin -> domain. 