### PR TITLE
Add partner labels and fix neuvector logo

### DIFF
--- a/charts/neuvector/v1.2.3/Chart.yaml
+++ b/charts/neuvector/v1.2.3/Chart.yaml
@@ -4,7 +4,7 @@ version: 1.2.3
 appVersion: 2.4.2
 description: NeuVector Container Security Platform includes layer 7 container firewall, end-to-end vulnerability scanning, and container process/file monitoring.
 home: https://neuvector.com
-icon: https://github.com/neuvector/kubernetes-cis-benchmark/blob/master/NeuVector-Logo.png
+icon: file://../NeuVector-Logo.png
 maintainers:
   - name: Sun
     email: xfsun@neuvector.com

--- a/charts/redskyops/v0.1.1/questions.yml
+++ b/charts/redskyops/v0.1.1/questions.yml
@@ -1,5 +1,6 @@
 labels:
   io.cattle.role: cluster # options are cluster/project
+  io.rancher.certified: partner
 questions:
 - variable: defaultImage
   default: true

--- a/charts/redskyops/v0.1.2/questions.yml
+++ b/charts/redskyops/v0.1.2/questions.yml
@@ -1,5 +1,6 @@
 labels:
   io.cattle.role: cluster # options are cluster/project
+  io.rancher.certified: partner
 questions:
 - variable: defaultImage
   default: true

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -2,7 +2,8 @@ categories:
 - Proxy
 - Loadbalancer
 labels:
-- io.cattle.role: project
+  io.cattle.role: project
+  io.rancher.certified: partner
 questions:
 - variable: defaultImage
   default: true


### PR DESCRIPTION
**Problem:**
Add missing partner label to `redskyops` and `traefik`, add neuvector logo using local path since the current URL is not showable.