### PR TITLE
Chart version 1.0.19

### DIFF
--- a/charts/instana-agent/v1.0.19/.helmignore
+++ b/charts/instana-agent/v1.0.19/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+# OWNERS file for helm
+OWNERS

--- a/charts/instana-agent/v1.0.19/Chart.yaml
+++ b/charts/instana-agent/v1.0.19/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: instana-agent
-version: 1.0.18
+version: 1.0.19
 appVersion: 1.0
 description: Instana Agent for Kubernetes
 home: https://www.instana.com/

--- a/charts/instana-agent/v1.0.19/Chart.yaml
+++ b/charts/instana-agent/v1.0.19/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+name: instana-agent
+version: 1.0.18
+appVersion: 1.0
+description: Instana Agent for Kubernetes
+home: https://www.instana.com/
+icon: file://../stan_icon_front_black_big.png
+sources:
+  - https://github.com/instana/instana-agent-docker
+maintainers:
+  - name: jbrisbin
+    email: jon.brisbin@instana.com
+  - name: wiggzz
+    email: william.james@instana.com
+  - name: JeroenSoeters
+    email: jeroen.soeters@instana.com
+  - name: fstab
+    email: fabian.staeber@instana.com
+  - name: mdonkers
+    email: miel.donkers@instana.com
+  - name: dlbock
+    email: dahlia.bock@instana.com
+  - name: nfisher
+    email: nathan.fisher@instana.com

--- a/charts/instana-agent/v1.0.19/OWNERS
+++ b/charts/instana-agent/v1.0.19/OWNERS
@@ -1,0 +1,16 @@
+approvers:
+- jbrisbin
+- wiggzz
+- JeroenSoeters
+- fstab
+- mdonkers
+- dlbock
+- nfisher
+reviewers:
+- jbrisbin
+- wiggzz
+- JeroenSoeters
+- fstab
+- mdonkers
+- dlbock
+- nfisher

--- a/charts/instana-agent/v1.0.19/README.md
+++ b/charts/instana-agent/v1.0.19/README.md
@@ -1,0 +1,133 @@
+# Instana
+
+Instana is an [APM solution(https://www.instana.com/) built for microservices that enables IT Ops to build applications faster and deliver higher quality services by automating monitoring, tracing and root cause analysis. This solution is optimized for [Kubernetes](https://www.instana.com/automatic-kubernetes-monitoring/).
+
+## Introduction
+
+This chart adds the Instana Agent to all schedulable nodes in your cluster via a `DaemonSet`.
+
+## Prerequisites
+
+Kubernetes 1.9.x - 1.14.x
+
+Working `helm` and `tiller`.
+
+_Note:_ Tiller may need a service account and role binding if RBAC is enabled in your cluster.
+
+## Installing the Chart
+
+To configure the installation you can either specify the options on the command line using the **--set** switch, or you can edit **values.yaml**. Either way you should ensure that you set values for:
+
+* agent.key
+* zone.name or cluster.name
+
+For most users, setting the `zone.name` is sufficient. However, if you would like to be able group your hosts based on the availability zone rather than cluster name, then you can specify the cluster name using the `cluster.name` instead of the `zone.name` setting. If you omit the `zone.name` the host zone will be automatically determined by the availability zone information on the host.
+
+If you're in the EU, you'll probably also want to set the regional equivalent values for:
+
+* agent.endpointHost
+* agent.endpointPort
+
+_Note:_ Check the values for the endpoint entries in the [agent backend configuration](https://docs.instana.io/quick_start/agent_configuration/#backend).
+
+Optionally, if your infrastructure uses a proxy, you should ensure that you set values for:
+
+* agent.pod.proxyHost
+* agent.pod.proxyPort
+* agent.pod.proxyProtocol
+* agent.pod.proxyUser
+* agent.pod.proxyPassword
+* agent.pod.proxyUseDNS
+
+Optionally, if your infrastructure has multiple networks defined, you might need to allow the agent to listen on all addresses (typically with value set to '*'):
+
+* agent.listenAddress
+
+If your agent requires download key, you should ensure that you set values for it:
+
+* agent.downloadKey
+
+Agent can have APM, INFRASTRUCTURE or AWS mode. Default is APM and if you want to override that, ensure you set value:
+
+* agent.mode
+
+To install the chart with the release name `instana-agent` and set the values on the command line run:
+
+```bash
+$ helm install --name instana-agent --namespace instana-agent \
+--set agent.key=INSTANA_AGENT_KEY \
+--set agent.endpointHost=HOST \
+--set zone.name=ZONE_NAME \
+stable/instana-agent
+```
+
+To install the chart with the release name `instana-agent` after editing the **values.yaml** file, run:
+
+```bash
+$ helm install --name instana-agent --namespace instana-agent stable/instana-agent
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `instana-agent` daemon set:
+
+```bash
+$ helm del --purge instana-agent
+```
+
+## Configuration
+
+### Helm Chart
+
+The following table lists the configurable parameters of the Instana chart and their default values.
+
+|             Parameter              |            Description                                                  |                    Default                                                                                  |
+|------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `agent.configuration_yaml`         | Custom content for the agent configuration.yaml file                    | `nil` See [below](#agent) for more details                                                                  |
+| `agent.downloadKey`                | Your Instana Download key                                               | `nil` Usually not required                                                                                  |
+| `agent.endpointHost`               | Instana Agent backend endpoint host                                     | `saas-us-west-2.instana.io`                                                                                 |
+| `agent.endpointPort`               | Instana Agent backend endpoint port                                     | `443`                                                                                                       |
+| `agent.image.name`                 | The image name to pull                                                  | `instana/agent`                                                                                             |
+| `agent.image.tag`                  | The image tag to pull                                                   | `1.0.29`                                                                                                    |
+| `agent.image.pullPolicy`           | Image pull policy                                                       | `IfNotPresent`                                                                                              |
+| `agent.key`                        | Your Instana Agent key                                                  | `nil` You must provide your own key                                                                         |
+| `agent.leaderElectorPort`          | Instana leader elector sidecar port                                     | `42655`                                                                                                     |
+| `agent.listenAddress`              | List of addresses to listen on, or "*" for all interfaces               | `nil`                                                                                                       |
+| `agent.mode`                       | Agent mode (Supported values are APM, INFRASTRUCTURE, AWS)              | `APM`                                                                                                       |
+| `agent.pod.annotations`            | Additional annotations to apply to the pod                              | `{}`                                                                                                        |
+| `agent.pod.limits.cpu`             | Container cpu limits in cpu cores                                       | `1.5`                                                                                                       |
+| `agent.pod.limits.memory`          | Container memory limits in MiB                                          | `512`                                                                                                       |
+| `agent.pod.proxyHost`              | Hostname/address of a proxy                                             | `nil`                                                                                                       |
+| `agent.pod.proxyPort`              | Port of a proxy                                                         | `nil`                                                                                                       |
+| `agent.pod.proxyProtocol`          | Proxy protocol (Supported proxy types are "http", "socks4", "socks5")   | `nil`                                                                                                       |
+| `agent.pod.proxyUser`              | Username of the proxy auth                                              | `nil`                                                                                                       |
+| `agent.pod.proxyPassword`          | Password of the proxy auth                                              | `nil`                                                                                                       |
+| `agent.pod.proxyUseDNS`            | Boolean if proxy also does DNS                                          | `nil`                                                                                                       |
+| `agent.pod.requests.memory`        | Container memory requests in MiB                                        | `512`                                                                                                       |
+| `agent.pod.requests.cpu`           | Container cpu requests in cpu cores                                     | `0.5`                                                                                                       |
+| `agent.pod.tolerations`            | Tolerations for pod assignment                                          | `[]`                                                                                                        |
+| `agent.redactKubernetesSecrets`    | Enable additional secrets redaction for selected Kubernetes resources   | `nil` See [Kubernetes secrets](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#secrets) for more details.   |
+| `cluster.name`                     | Display name of the monitored cluster                                   | Value of `zone.name`                                                                                        |
+| `podSecurityPolicy.enable`         | Whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to be `true` as well. | `false` See [PodSecurityPolicy](https://docs.instana.io/quick_start/agent_setup/container/kubernetes/#podsecuritypolicy) for more details. |
+| `podSecurityPolicy.name`           | Name of an _existing_ PodSecurityPolicy to authorize for the Instana Agent pods. If not provided and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created for you. | `nil` |
+| `rbac.create`                      | Whether RBAC resources should be created                                | `true`                                                                                                      |
+| `serviceAccount.create`            | Whether a ServiceAccount should be created                              | `true`                                                                                                      |
+| `serviceAccount.name`              | Name of the ServiceAccount to use                                       | `instana-agent`                                                                                             |
+| `zone.name`                        | Zone that detected technologies will be assigned to                     | `nil` You must provide either `zone.name` or `cluster.name`, see [above](#installing-the-chart) for details |
+
+#### Development and debugging options
+
+These options will be rarely used outside of development or debugging of the agent.
+
+|             Parameter              |            Description                                                  |                    Default                                                                                  |
+|------------------------------------|-------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `agent.host.repository`            | Host path to mount as the agent maven repository                        | `nil`                                                                                                       |
+
+### Agent
+
+To configure the agent, you can either:
+
+- edit the [config map](templates/configmap.yaml), or
+- provide the configuration via the `agent.configuration_yaml` parameter in [values.yaml](values.yaml)
+
+This configuration will be used for all Instana Agents on all nodes. Visit the [agent configuration documentation](https://docs.instana.io/quick_start/agent_configuration/#configuration) for more details on configuration options.

--- a/charts/instana-agent/v1.0.19/app-readme.md
+++ b/charts/instana-agent/v1.0.19/app-readme.md
@@ -1,0 +1,5 @@
+# Instana
+
+Instana is an [APM solution(https://www.instana.com/) built for microservices that enables IT Ops to build applications faster and deliver higher quality services by automating monitoring tracing and root cause analysis. This solution is optimized for [Rancher](https://www.instana.com/rancher/).
+
+This chart adds the Instana Agent to all schedulable nodes in your cluster via a `DaemonSet`.

--- a/charts/instana-agent/v1.0.19/questions.yml
+++ b/charts/instana-agent/v1.0.19/questions.yml
@@ -1,0 +1,227 @@
+name: instana-agent
+rancher_min_version: 2.3.0-rc1
+labels:
+  io.cattle.role: cluster
+  io.rancher.certified: partner
+questions:
+# Basic agent configuration
+- variable: agent.key
+  label: agent.key
+  description: "Your Instana Agent key is the secret token which your agent uses to authenticate to Instana's servers"
+  type: string
+  required: true
+  group: "Agent Configuration"
+- variable: agent.endpointHost
+  label: agent.endpointHost
+  description: "The hostname of the Instana server your agents will connect to"
+  type: string
+  required: true
+  default: "saas-us-west-2.instana.io"
+  group: "Agent Configuration"
+- variable: zone.name
+  label: zone.name
+  description: "Custom zone that detected technologies will be assigned to"
+  type: string
+  required: true
+  group: "Agent Configuration"
+# Advanced agent configuration
+- variable: advancedAgentConfiguration
+  description: "Show advanced configuration for the Instana Agent"
+  label: Show advanced configuration
+  type: boolean
+  default: false
+  show_subquestion_if: true
+  group: "Advanced Agent Configuration"
+  subquestions:
+  - variable: agent.configuration_yaml
+    label: agent.configuration_yaml (Optional)
+    description: "Custom content for the agent configuration.yaml file in YAML format. Please use the 'Edit as YAML' feature in the Rancher UI for the best editing experience."
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.downloadKey
+    label: agent.downloadKey (Optional)
+    description: "Your Instana download key"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.endpointPort
+    label: agent.endpointPort
+    description: "The Agent backend port number (as a string) of the Instana server your agents will connect to"
+    type: string
+    required: true
+    default: "443"
+    group: "Advanced Agent Configuration"
+  - variable: agent.image.name
+    label: agent.image.name
+    description: "The name of the container image of the Instana Agent"
+    type: string
+    required: true
+    default: "instana/agent"
+    group: "Advanced Agent Configuration"
+  - variable: agent.image.tag
+    label: agent.image.tag
+    description: "The tag name of the Instana Agent container image"
+    type: string
+    required: true
+    default: "1.0.29"
+    group: "Advanced Agent Configuration"
+  - variable: agent.image.pullPolicy
+    label: agent.image.pullPolicy
+    description: "Specifies when to pull the Instana Agent image container"
+    type: string
+    required: true
+    default: "IfNotPresent"
+    group: "Advanced Agent Configuration"
+  - variable: agent.leaderElectorPort
+    label: agent.leaderElectorPort
+    description: "The port on which the leader elector sidecar is exposed"
+    type: int
+    required: true
+    default: 42655
+    group: "Advanced Agent Configuration"
+  - variable: agent.listenAddress
+    label: agent.listenAddress (Optional)
+    description: "The IP address the agent HTTP server will listen to, or '*' for all interfaces"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.mode
+    label: agent.mode (Optional)
+    description: "Agent mode. Possible options are: APM, INFRASTRUCTURE or AWS"
+    type: enum
+    options:
+    - "APM"
+    - "INFRASTRUCTURE"
+    - "AWS"
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.annotations
+    label: agent.pod.annotations (Optional)
+    description: "Additional annotations to be added to the agent pods in YAML format. Please use the 'Edit as YAML' feature in the Rancher UI for the best editing experience."
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.limits.cpu
+    label: agent.pod.limits.cpu
+    description: "CPU units allocation limits for the agent pods"
+    type: string
+    required: true
+    default: "1.5"
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.limits.memory
+    label: agent.pod.limits.memory
+    description: "Memory allocation limits in MiB for the agent pods"
+    type: int
+    required: true
+    default: 512
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.proxyHost
+    label: agent.pod.proxyHost (Optional)
+    description: "Hostname/address of a proxy. Sets the INSTANA_AGENT_PROXY_HOST environment variable"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.proxyPort
+    label: agent.pod.proxyPort (Optional)
+    description: "Port of a proxy. Sets the INSTANA_AGENT_PROXY_PORT environment variable"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.proxyProtocol
+    label: agent.pod.proxyProtocol (Optional)
+    description: "Proxy protocol. Sets the INSTANA_AGENT_PROXY_PROTOCOL environment variable. Supported proxy types are http, socks4, socks5"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.proxyUser
+    label: agent.pod.proxyUser (Optional)
+    description: "Username of the proxy auth. Sets the INSTANA_AGENT_PROXY_USER environment variable"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.proxyPassword
+    label: agent.pod.proxyPassword (Optional)
+    description: "Password of the proxy auth. Sets the INSTANA_AGENT_PROXY_PASSWORD environment variable"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.proxyUseDNS
+    label: agent.pod.proxyUseDNS. (Optional)
+    description: "Boolean if proxy also does DNS. Sets the INSTANA_AGENT_PROXY_USE_DNS environment variable"
+    type: enum
+    options:
+      - "true"
+      - "false"
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.requests.cpu
+    label: agent.pod.requests.cpu
+    description: "Requested CPU units allocation for the agent pods"
+    type: string
+    required: true
+    default: "0.5"
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.requests.memory
+    label: agent.pod.requests.memory
+    description: "Requested memory allocation in MiB for the agent pods"
+    type: int
+    required: true
+    default: 512
+    group: "Advanced Agent Configuration"
+  - variable: agent.pod.tolerations
+    label: agent.pod.tolerations (Optional)
+    description: "Tolerations to influence agent pod assignment in YAML format. Please use the 'Edit as YAML' feature in the Rancher UI for the best editing experience."
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+  - variable: agent.redactKubernetesSecrets
+    label: agent.redactKubernetesSecrets (Optional)
+    description: "Enable additional secrets redaction for selected Kubernetes resources"
+    type: boolean
+    required: false
+    default: false
+    group: "Advanced Agent Configuration"
+  - variable: cluster.name
+    label: cluster.name (Optional)
+    description: "The name that will be assigned to this cluster in Instana. See the 'Installing the Chart' section in the 'Detailed Descriptions' tab for more details"
+    type: string
+    required: false
+    group: "Advanced Agent Configuration"
+- variable: podSecurityPolicy.enable
+  label: podSecurityPolicy.enable (Optional)
+  description: "Specifies whether a PodSecurityPolicy should be authorized for the Instana Agent pods. Requires `rbac.create` to also be `true`"
+  type: boolean
+  show_if: "rbac.create=true"
+  required: false
+  default: false
+  group: "Pod Security Policy Configuration"
+- variable: podSecurityPolicy.name
+  label: podSecurityPolicy.name (Optional)
+  description: "The name of an existing PodSecurityPolicy you would like to authorize for the Instana Agent pods. If not set and `podSecurityPolicy.enable` is `true`, a PodSecurityPolicy will be created with a name generated using the fullname template"
+  type: string
+  show_if: "rbac.create=true&&podSecurityPolicy.enable=true"
+  required: false
+  group: "Pod Security Policy Configuration"
+- variable: rbac.create
+  label: rbac.create
+  description: "Specifies whether RBAC resources should be created"
+  type: boolean
+  required: true
+  default: true
+  group: "RBAC Configuration"
+- variable: serviceAccount.create
+  label: serviceAccount.create
+  description: "Specifies whether a ServiceAccount should be created"
+  type: boolean
+  required: true
+  default: true
+  show_subquestion_if: true
+  group: "RBAC Configuration"
+  subquestions:
+  - variable: serviceAccount.name
+    label: Name of the ServiceAccount (Optional)
+    description: "The name of the ServiceAccount to use. If not set and `serviceAccount.create` is true, a name is generated using the fullname template."
+    type: string
+    required: false
+    group: "RBAC Configuration"

--- a/charts/instana-agent/v1.0.19/templates/NOTES.txt
+++ b/charts/instana-agent/v1.0.19/templates/NOTES.txt
@@ -1,0 +1,66 @@
+{{- if (and (not .Values.agent.key) (and (not .Values.zone.name) (not .Values.cluster.name))) }}
+##############################################################################
+####    ERROR: You did not specify your secret agent key.                 ####
+####    ERROR: You also did not specify a zone or name for this cluster.  ####
+##############################################################################
+
+This agent deployment will be incomplete until you set your agent key and zone or name for this cluster:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set agent.key=$(YOUR_SECRET_AGENT_KEY) \
+        --set zone.name=$(YOUR_ZONE_NAME) stable/instana-agent
+
+Alternatively, you may specify a cluster name and the zone will be detected from availability zone information on the host:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set agent.key=$(YOUR_SECRET_AGENT_KEY) \
+        --set cluster.name=$(YOUR_CLUSTER_NAME) stable/instana-agent
+
+- YOUR_SECRET_AGENT_KEY can be obtained from the Management Portal section of your Instana installation.
+- YOUR_ZONE_NAME should be the zone that detected technologies will be assigned to.
+- YOUR_CLUSTER_NAME should be the custom name of your cluster.
+
+At least one of zone.name or cluster.name is required. This cluster will be reported with the name of the zone unless you specify a cluster name.
+
+{{- else if (and (not .Values.zone.name) (not .Values.cluster.name))  }}
+##############################################################################
+####    ERROR: You did not specify a zone or name for this cluster.       ####
+##############################################################################
+
+This agent deployment will be incomplete until you set a zone for this cluster:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set zone.name=$(YOUR_ZONE_NAME) stable/instana-agent
+
+Alternatively, you may specify a cluster name and the zone will be detected from availability zone information on the host:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set cluster.name=$(YOUR_CLUSTER_NAME) stable/instana-agent
+
+- YOUR_ZONE_NAME should be the zone that detected technologies will be assigned to.
+- YOUR_CLUSTER_NAME should be the custom name of your cluster.
+
+At least one of zone.name or cluster.name is required. This cluster will be reported with the name of the zone unless you specify a cluster name.
+
+{{- else if not .Values.agent.key }}
+##############################################################################
+####    ERROR: You did not specify your secret agent key.                 ####
+##############################################################################
+
+This agent deployment will be incomplete until you set your agent key:
+
+    helm upgrade {{ .Release.Name }} --reuse-values \
+        --set agent.key=$(YOUR_SECRET_AGENT_KEY) stable/instana-agent
+
+- YOUR_SECRET_AGENT_KEY can be obtained from the Management Portal section of your Instana installation.
+
+{{- else -}}
+It may take a few moments for the agents to fully deploy. You can see what agents are running by listing resources in the {{ .Release.Namespace }} namespace:
+
+    kubectl get all -n {{ .Release.Namespace }}
+
+You can get the logs for all of the agents with `kubectl logs`:
+
+    kubectl logs -l app.kubernetes.io/instance={{ .Release.Name }} -n {{ .Release.Namespace }} -c instana-agent
+
+{{- end }}

--- a/charts/instana-agent/v1.0.19/templates/_helpers.tpl
+++ b/charts/instana-agent/v1.0.19/templates/_helpers.tpl
@@ -1,0 +1,70 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "instana-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "instana-agent.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "instana-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the ServiceAccount used.
+*/}}
+{{- define "instana-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "instana-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The name of the PodSecurityPolicy used.
+*/}}
+{{- define "instana-agent.podSecurityPolicyName" -}}
+{{- if .Values.podSecurityPolicy.enable -}}
+    {{ default (include "instana-agent.fullname" .) .Values.podSecurityPolicy.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Add Helm metadata to resource labels.
+*/}}
+{{- define "instana-agent.commonLabels" -}}
+app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ include "instana-agent.chart" . }}
+{{- end -}}
+
+{{/*
+Add Helm metadata to selector labels specifically for deployments/daemonsets/statefulsets.
+*/}}
+{{- define "instana-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "instana-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/instana-agent/v1.0.19/templates/agentsecret.yaml
+++ b/charts/instana-agent/v1.0.19/templates/agentsecret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.agent.key }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "instana-agent.fullname" . }}-agent-secret
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+type: Opaque
+data:
+  key: {{ .Values.agent.key | b64enc | quote }}
+{{- end }}

--- a/charts/instana-agent/v1.0.19/templates/clusterrole.yaml
+++ b/charts/instana-agent/v1.0.19/templates/clusterrole.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "instana-agent.fullname" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+rules:
+- nonResourceURLs:
+    - "/version"
+    - "/healthz"
+  verbs: ["get"]
+- apiGroups: ["batch"]
+  resources:
+    - "jobs"
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+    - "deployments"
+    - "replicasets"
+    - "ingresses"
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+    - "deployments"
+    - "replicasets"
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+    - "namespaces"
+    - "events"
+    - "services"
+    - "endpoints"
+    - "nodes"
+    - "pods"
+    - "replicationcontrollers"
+    - "componentstatuses"
+    - "resourcequotas"
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources:
+    - "endpoints"
+  verbs: ["create", "update", "patch"]
+{{- if .Values.podSecurityPolicy.enable}}
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  verbs:     ["use"]
+  resourceNames:
+  - {{ template "instana-agent.podSecurityPolicyName" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/instana-agent/v1.0.19/templates/clusterrolebinding.yaml
+++ b/charts/instana-agent/v1.0.19/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "instana-agent.fullname" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "instana-agent.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "instana-agent.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/charts/instana-agent/v1.0.19/templates/configmap.yaml
+++ b/charts/instana-agent/v1.0.19/templates/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "instana-agent.fullname" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+data:
+  configuration.yaml: |
+    # Manual a-priori configuration. Configuration will be only used when the sensor
+    # is actually installed by the agent.
+    # The commented out example values represent example configuration and are not
+    # necessarily defaults. Defaults are usually 'absent' or mentioned separately.
+    # Changes are hot reloaded unless otherwise mentioned.
+
+    # It is possible to create files called 'configuration-abc.yaml' which are
+    # merged with this file in file system order. So 'configuration-cde.yaml' comes
+    # after 'configuration-abc.yaml'. Only nested structures are merged, values are
+    # overwritten by subsequent configurations.
+
+    # Secrets
+    # To filter sensitive data from collection by the agent, all sensors respect
+    # the following secrets configuration. If a key collected by a sensor matches
+    # an entry from the list, the value is redacted.
+    #com.instana.secrets:
+    #  matcher: 'contains-ignore-case' # 'contains-ignore-case', 'contains', 'regex'
+    #  list:
+    #    - 'key'
+    #    - 'password'
+    #    - 'secret'
+
+    # Host
+    #com.instana.plugin.host:
+    #  tags:
+    #    - 'dev'
+    #    - 'app1'
+
+    # Hardware & Zone
+    #com.instana.plugin.generic.hardware:
+    #  enabled: true # disabled by default
+    #  availability-zone: 'zone'
+  {{- if .Values.agent.configuration_yaml -}}
+  {{ .Values.agent.configuration_yaml | nindent 4 }}
+  {{- end }}

--- a/charts/instana-agent/v1.0.19/templates/daemonset.yaml
+++ b/charts/instana-agent/v1.0.19/templates/daemonset.yaml
@@ -1,0 +1,188 @@
+{{- if .Values.agent.key -}}
+{{- if or .Values.zone.name .Values.cluster.name -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "instana-agent.fullname" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "instana-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "instana-agent.commonLabels" . | nindent 8 }}
+      {{- if .Values.agent.pod.annotations }}
+      annotations:
+        {{- toYaml .Values.agent.pod.annotations | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ template "instana-agent.serviceAccountName" . }}
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      containers:
+        - name: {{ template "instana-agent.name" . }}
+          image: "{{ .Values.agent.image.name }}:{{ .Values.agent.image.tag }}"
+          imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
+          env:
+            - name: INSTANA_AGENT_LEADER_ELECTOR_PORT
+              value: {{ .Values.agent.leaderElectorPort | quote }}
+            - name: INSTANA_ZONE
+              value: {{ .Values.zone.name | quote }}
+            - name: INSTANA_KUBERNETES_CLUSTER_NAME
+              value: {{ .Values.cluster.name | quote }}
+            - name: INSTANA_AGENT_ENDPOINT
+              value: {{ .Values.agent.endpointHost | quote }}
+            - name: INSTANA_AGENT_ENDPOINT_PORT
+              value: {{ .Values.agent.endpointPort | quote }}
+            - name: INSTANA_AGENT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "instana-agent.fullname" . }}-agent-secret
+                  key: key
+            {{- if .Values.agent.mode }}
+            - name: INSTANA_AGENT_MODE
+              value: {{ .Values.agent.mode | quote }}
+            {{- end }}
+            {{- if .Values.agent.downloadKey }}
+            - name: INSTANA_DOWNLOAD_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "instana-agent.fullname" . }}-download-secret
+                  key: key
+            {{- end }}
+            {{- if .Values.agent.proxyHost }}
+            - name: INSTANA_AGENT_PROXY_HOST
+              value: {{ .Values.agent.proxyHost | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyPort }}
+            - name: INSTANA_AGENT_PROXY_PORT
+              value: {{ .Values.agent.proxyPort | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyProtocol }}
+            - name: INSTANA_AGENT_PROXY_PROTOCOL
+              value: {{ .Values.agent.proxyProtocol | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyUser }}
+            - name: INSTANA_AGENT_PROXY_USER
+              value: {{ .Values.agent.proxyUser | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyPassword }}
+            - name: INSTANA_AGENT_PROXY_PASSWORD
+              value: {{ .Values.agent.proxyPassword | quote }}
+            {{- end }}
+            {{- if .Values.agent.proxyUseDNS }}
+            - name: INSTANA_AGENT_PROXY_USE_DNS
+              value: {{ .Values.agent.proxyUseDNS | quote }}
+            {{- end }}
+            {{- if .Values.agent.listenAddress }}
+            - name: INSTANA_AGENT_HTTP_LISTEN
+              value: {{ .Values.agent.listenAddress | quote }}
+            {{- end }}
+            {{- if .Values.agent.redactKubernetesSecrets }}
+            - name: INSTANA_KUBERNETES_REDACT_SECRETS
+              value: {{ .Values.agent.redactKubernetesSecrets | quote }}
+            {{- end }}
+            - name: JAVA_OPTS
+              value: "-Xmx{{ div (default 512 .Values.agent.pod.requests.memory) 3 }}M -XX:+ExitOnOutOfMemoryError"
+            - name: INSTANA_AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: dev
+              mountPath: /dev
+            - name: run
+              mountPath: /run
+            - name: var-run
+              mountPath: /var/run
+            - name: sys
+              mountPath: /sys
+            - name: var-log
+              mountPath: /var/log
+            - name: machine-id
+              mountPath: /etc/machine-id
+            - name: configuration
+              subPath: configuration.yaml
+              mountPath: /root/configuration.yaml
+            {{- if .Values.agent.host.repository }}
+            - name: repo
+              mountPath: /opt/instana/agent/data/repo
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 42699
+            initialDelaySeconds: 75
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "{{ default 512 .Values.agent.pod.requests.memory }}Mi"
+              cpu: {{ default 0.5 .Values.agent.pod.requests.cpu }}
+            limits:
+              memory: "{{ default 512 .Values.agent.pod.limits.memory }}Mi"
+              cpu: {{ default 1.5 .Values.agent.pod.limits.cpu }}
+          ports:
+            - containerPort: 42699
+        - name: {{ template "instana-agent.name" . }}-leader-elector
+          image: instana/leader-elector:0.5.4
+          env:
+            - name: INSTANA_AGENT_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          command:
+            - "/app/server"
+            - "--election=instana"
+            - "--http=localhost:{{ default 42655 .Values.agent.leaderElectorPort }}"
+            - "--id=$(INSTANA_AGENT_POD_NAME)"
+          resources:
+            requests:
+              cpu: 0.1
+              memory: 64Mi
+          livenessProbe:
+            httpGet:
+              path: /status
+              port: 42699
+            initialDelaySeconds: 75
+            periodSeconds: 5
+          ports:
+            - containerPort: {{ .Values.agent.leaderElectorPort }}
+      {{- if .Values.agent.pod.tolerations }}
+      tolerations:
+        {{- toYaml .Values.agent.pod.tolerations | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: dev
+          hostPath:
+            path: /dev
+        - name: run
+          hostPath:
+            path: /run
+        - name: var-run
+          hostPath:
+            path: /var/run
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: var-log
+          hostPath:
+            path: /var/log
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
+        - name: configuration
+          configMap:
+            name: {{ template "instana-agent.fullname" . }}
+        {{- if .Values.agent.host.repository }}
+        - name: repo
+          hostPath:
+            path: {{ .Values.agent.host.repository }}
+        {{- end }}
+{{- end -}}
+{{- end -}}

--- a/charts/instana-agent/v1.0.19/templates/daemonset.yaml
+++ b/charts/instana-agent/v1.0.19/templates/daemonset.yaml
@@ -105,6 +105,8 @@ spec:
               mountPath: /sys
             - name: var-log
               mountPath: /var/log
+            - name: var-lib
+              mountPath: /var/lib/containers/storage
             - name: machine-id
               mountPath: /etc/machine-id
             - name: configuration
@@ -116,6 +118,7 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /status
               port: 42699
             initialDelaySeconds: 75
@@ -147,6 +150,7 @@ spec:
               memory: 64Mi
           livenessProbe:
             httpGet:
+              host: 127.0.0.1
               path: /status
               port: 42699
             initialDelaySeconds: 75
@@ -173,6 +177,9 @@ spec:
         - name: var-log
           hostPath:
             path: /var/log
+        - name: var-lib
+          hostPath:
+            path: /var/lib/containers/storage
         - name: machine-id
           hostPath:
             path: /etc/machine-id

--- a/charts/instana-agent/v1.0.19/templates/downloadsecret.yaml
+++ b/charts/instana-agent/v1.0.19/templates/downloadsecret.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.agent.downloadKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "instana-agent.fullname" . }}-download-secret
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+type: Opaque
+data:
+  key: {{ .Values.agent.downloadKey | b64enc | quote }}
+{{- end }}

--- a/charts/instana-agent/v1.0.19/templates/podsecuritypolicy.yaml
+++ b/charts/instana-agent/v1.0.19/templates/podsecuritypolicy.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.rbac.create -}}
+{{- if (and .Values.podSecurityPolicy.enable (not .Values.podSecurityPolicy.name)) -}}
+kind: PodSecurityPolicy
+apiVersion: policy/v1beta1
+metadata:
+  name: {{ template "instana-agent.podSecurityPolicyName" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+spec:
+  privileged: true
+  allowPrivilegeEscalation: true
+  volumes:
+    - configMap
+    - downwardAPI
+    - emptyDir
+    - persistentVolumeClaim
+    - secret
+    - projected
+    - hostPath
+  allowedHostPaths:
+    - pathPrefix: "/dev"
+      readOnly: false
+    - pathPrefix:  "/run"
+      readOnly: false
+    - pathPrefix: "/var/run"
+      readOnly: false
+    - pathPrefix: "/sys"
+      readOnly: false
+    - pathPrefix: "/var/log"
+      readOnly: false
+    - pathPrefix: "/etc/machine-id"
+      readOnly: false
+    {{- if .Values.agent.host.repository }}
+    - pathPrefix: {{ .Values.agent.host.repository }}
+      readOnly: false
+    {{- end }}
+  hostNetwork: true
+  hostPorts:
+    - min: 0
+      max: 65535
+  hostIPC: true
+  hostPID: true
+  runAsUser:
+    rule: "RunAsAny"
+  seLinux:
+    rule: "RunAsAny"
+  supplementalGroups:
+    rule: "RunAsAny"
+  fsGroup:
+    rule: "RunAsAny"
+{{- end -}}
+{{- end -}}

--- a/charts/instana-agent/v1.0.19/templates/podsecuritypolicy.yaml
+++ b/charts/instana-agent/v1.0.19/templates/podsecuritypolicy.yaml
@@ -30,6 +30,8 @@ spec:
       readOnly: false
     - pathPrefix: "/etc/machine-id"
       readOnly: false
+    - pathPrefix: "/var/lib/containers/storage"
+      readOnly: false
     {{- if .Values.agent.host.repository }}
     - pathPrefix: {{ .Values.agent.host.repository }}
       readOnly: false

--- a/charts/instana-agent/v1.0.19/templates/serviceaccount.yaml
+++ b/charts/instana-agent/v1.0.19/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "instana-agent.serviceAccountName" . }}
+  labels:
+    {{- include "instana-agent.commonLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/instana-agent/v1.0.19/values.yaml
+++ b/charts/instana-agent/v1.0.19/values.yaml
@@ -1,0 +1,96 @@
+# name is the value which will be used as the base resource name for various resources associated with the agent.
+# name: instana-agent
+
+zone:
+  # zone.name is the custom zone that detected technologies will be assigned to
+  name: null
+
+agent:
+  # agent.key is the secret token which your agent uses to authenticate to Instana's servers.
+  key: null
+  # agent.mode is used to set agent mode and it can be APM, INFRASTRUCTURE or AWS
+  # mode: APM
+  # agent.downloadKey is optional, if used it doesn't have to match agent.key
+  # downloadKey: null
+  # agent.listenAddress is the IP address the agent HTTP server will listen to.
+  # listenAddress: *
+  # agent.leaderElectorPort is the port on which the leader elector sidecar is exposed.
+  leaderElectorPort: 42655
+
+  # agent.endpointHost is the hostname of the Instana server your agents will connect to.
+  endpointHost: saas-us-west-2.instana.io
+  # agent.endpointPort is the port number (as a String) of the Instana server your agents will connect to.
+  endpointPort: 443
+
+  image:
+    # agent.image.name is the name of the container image of the Instana agent.
+    name: instana/agent
+    # agent.image.tag is the tag name of the agent container image.
+    tag: 1.0.29
+    # agent.image.pullPolicy specifies when to pull the image container.
+    pullPolicy: IfNotPresent
+
+  pod:
+    # agent.pod.annotations are additional annotations to be added to the agent pods.
+    annotations: {}
+
+    # agent.pod.tolerations are tolerations to influence agent pod assignment.
+    #   https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    tolerations: []
+
+    requests:
+      # agent.pod.requests.memory is the requested memory allocation in MiB for the agent pods.
+      memory: 512
+      # agent.pod.requests.cpu are the requested CPU units allocation for the agent pods.
+      cpu: 0.5
+    limits:
+      # agent.pod.limits.memory set the memory allocation limits in MiB for the agent pods.
+      memory: 512
+      # agent.pod.limits.cpu sets the CPU units allocation limits for the agent pods.
+      cpu: 1.5
+
+  # agent.proxyHost sets the INSTANA_AGENT_PROXY_HOST environment variable.
+  # proxyHost: null
+  # agent.proxyPort sets the INSTANA_AGENT_PROXY_PORT environment variable.
+  # proxyPort: null
+  # agent.proxyProtocol sets the INSTANA_AGENT_PROXY_PROTOCOL environment variable.
+  # proxyProtocol: null
+  # agent.proxyUser sets the INSTANA_AGENT_PROXY_USER environment variable.
+  # proxyUser: null
+  # agent.proxyPassword sets the INSTANA_AGENT_PROXY_PASSWORD environment variable.
+  # proxyPassword: null
+  # agent.proxyUseDNS sets the INSTANA_AGENT_PROXY_USE_DNS environment variable.
+  # proxyUseDNS: null
+
+  configuration_yaml: |
+    # Place agent configuration here
+
+  # agent.redactKubernetesSecrets sets the INSTANA_KUBERNETES_REDACT_SECRETS environment variable.
+  # redactKubernetesSecrets: null
+
+  # agent.host.repository sets a host path to be mounted as the agent maven repository (for debugging or development purposes)
+  host:
+    repository: null
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and `create` is true, a name is generated using the fullname template
+  # name: instana-agent
+
+podSecurityPolicy:
+  # Specifies whether a PodSecurityPolicy should be authorized for the Instana Agent pods.
+  # Requires `rbac.create` to be `true` as well.
+  enable: false
+  # The name of an existing PodSecurityPolicy you would like to authorize for the Instana Agent pods.
+  # If not set and `enable` is true, a PodSecurityPolicy will be created with a name generated using the fullname template.
+  name: null
+
+cluster:
+  # cluster.name represents the name that will be assigned to this cluster in Instana
+  name: null

--- a/charts/instana-agent/v1.0.19/values.yaml
+++ b/charts/instana-agent/v1.0.19/values.yaml
@@ -26,7 +26,7 @@ agent:
     # agent.image.name is the name of the container image of the Instana agent.
     name: instana/agent
     # agent.image.tag is the tag name of the agent container image.
-    tag: 1.0.29
+    tag: 1.0.42
     # agent.image.pullPolicy specifies when to pull the image container.
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
This changeset includes:
- Mount `/var/lib/containers/storage` in the `DaemonSet` for CRI-O support
- Specify host in the `livenessProbe` for both the `instana-agent` and `leader-elector` containers
- Update the `instana/agent` image tag to the latest available `1.0.42` that's on DockerHub as of Dec 16 2019 (https://hub.docker.com/r/instana/agent/tags)