### PR TITLE
Add delay during postStart if directory is not yet created by flexvolume container

### DIFF
--- a/charts/hpe-flexvolume-driver/v3.1.0/templates/hpe-flexvolume-plugin.yaml
+++ b/charts/hpe-flexvolume-driver/v3.1.0/templates/hpe-flexvolume-plugin.yaml
@@ -31,8 +31,8 @@ spec:
         {{- if eq .Values.flavor "rke"}}
           postStart:
             exec:
-              command: [ "/bin/cp", "-a", "/etc/hpe-storage/{{ .Values.pluginType }}.json",
-                       "/var/lib/kubelet/volumeplugins/hpe.com~{{ .Values.pluginType }}/{{ .Values.pluginType }}.json" ]
+              command: [ "/bin/bash", "-c",
+                       "while [[ ! -d /var/lib/kubelet/volumeplugins/hpe.com~{{ .Values.pluginType }} ]] || [[ ! -f /etc/hpe-storage/{{ .Values.pluginType }}.json ]]; do sleep 1; done; cp -a /etc/hpe-storage/{{ .Values.pluginType }}.json /var/lib/kubelet/volumeplugins/hpe.com~{{ .Values.pluginType }}/{{ .Values.pluginType }}.json" ]
         {{- end }}
         env:
         - name: LOG_LEVEL


### PR DESCRIPTION
During post-start hook, we expect that flexvolume exec directory is already created, but it might not be if flexvolume container is not yet initialized. Hence add a delay loop to wait until the directory is created.
Signed-off-by: Shiva Krishna, Merla <shivakrishna.merla@hpe.com>