### PR TITLE
Update Traefik chart to be v3 compatible

### DIFF
--- a/charts/traefik/v1.7/Chart.yaml
+++ b/charts/traefik/v1.7/Chart.yaml
@@ -16,4 +16,4 @@ name: traefik
 sources:
 - https://github.com/containous/traefik
 - https://github.com/helm/charts/tree/master/stable/traefik
-version: 1.0.0
+version: 1.1.0

--- a/charts/traefik/v1.7/Chart.yaml
+++ b/charts/traefik/v1.7/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 1.7.14
 description: A Traefik based Kubernetes ingress controller with Let's Encrypt support
 engine: gotpl


### PR DESCRIPTION
This PR:

- Updates the apiVersion of the `Chart.yaml` file to v2, to be helm v3 compatible.

There are no functions in the chart that should not be v3 compatible.

There are also no dependencies in this chart to manage.