### PR TITLE
Traefik : add HostPort, NodePort ports selection, DaemonSet

### DIFF
--- a/charts/traefik/v1.7/Chart.yaml
+++ b/charts/traefik/v1.7/Chart.yaml
@@ -16,4 +16,4 @@ name: traefik
 sources:
 - https://github.com/containous/traefik
 - https://github.com/helm/charts/tree/master/stable/traefik
-version: 1.0.0
+version: 1.1.0

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -30,6 +30,12 @@ questions:
   label: RBAC
   type: boolean
   group: "General Settings"
+- variable: kind.daemonset
+  default: false
+  description: "The pod will be duplicated on each node"
+  label: Enable DaemonSet
+  type: boolean
+  group: "General Settings"
 - variable: serviceType
   type: enum
   options:

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -18,16 +18,6 @@ questions:
     description: "Traefik Image Tag"
     type: string
     label: Traefik Image Tag
-- variable: serviceType
-  type: enum
-  options:
-    - "LoadBalancer"
-    - "NodePort"
-    - "ClusterIP"
-  default: "LoadBalancer"
-  description: "Service Type for Traefik"
-  label: Service Type
-  group: "General Settings"
 - variable: debug.enabled
   type: boolean
   default: false
@@ -40,6 +30,35 @@ questions:
   label: RBAC
   type: boolean
   group: "General Settings"
+- variable: serviceType
+  type: enum
+  options:
+    - "LoadBalancer"
+    - "NodePort"
+    - "ClusterIP"
+  default: "LoadBalancer"
+  description: "Service Type for Traefik"
+  label: Service Type
+  group: "Services and Load Balancing"
+  show_subquestion_if: "NodePort"
+  group: "Services and Load Balancing"
+  subquestions:
+  - variable: service.nodePorts.http
+    default: ""
+    description: "NodePort http port(to set explicitly, choose port between 30000-32767)"
+    type: int
+    min: 30000
+    max: 32767
+    show_if: "serviceType=NodePort"
+    label: NodePort Http Port
+  - variable: service.nodePorts.https
+    default: ""
+    description: "NodePort https port(to set explicitly, choose port between 30000-32767)"
+    type: int
+    min: 30000
+    max: 32767
+    show_if: "serviceType=NodePort"
+    label: NodePort Https Port
 - variable: ssl.enabled
   type: boolean
   default: false

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -139,7 +139,7 @@ questions:
     default: "tls-alpn-01"
     description: "Challengetype to use for Lets Encrypt Certificates"
     label: Challengetype
-  - variable: persistence.enabled
+  - variable: acme.persistence.enabled
     type: boolean
     default: true
     description: "Enable Persistence for Lets Encrypt Certificates"

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -59,6 +59,24 @@ questions:
     max: 32767
     show_if: "serviceType=NodePort"
     label: NodePort Https Port
+- variable: deployment.hostPort.enabled
+  default: false
+  description: "Enable Host Port"
+  label: HostPort
+  type: boolean
+  group: "Host Port"
+  show_subquestion_if: "true"
+  subquestions:
+  - variable: deployment.hostPort.httpEnabled
+    default: true
+    description: "Enable HostPort https"
+    type: boolean
+    label: Enable HostPort http
+  - variable: deployment.hostPort.httpsEnabled
+    default: true
+    description: "Enable HostPort https"
+    type: boolean
+    label: Enable HostPort https
 - variable: ssl.enabled
   type: boolean
   default: false

--- a/charts/traefik/v1.7/templates/deployment.yaml
+++ b/charts/traefik/v1.7/templates/deployment.yaml
@@ -3,7 +3,11 @@ apiVersion: apps/v1
 {{- else }}
 apiVersion: apps/v1beta1
 {{- end }}
+{{- if .Values.kind.daemonset }}
+kind: DaemonSet
+{{- else }}
 kind: Deployment
+{{- end }}
 metadata:
   name: {{ template "traefik.fullname" . }}
   labels:

--- a/charts/traefik/v1.7/templates/service.yaml
+++ b/charts/traefik/v1.7/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.serviceType "" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -59,3 +60,4 @@ spec:
     name: metrics
     targetPort: dash
   {{- end }}
+{{- end }}

--- a/charts/traefik/v1.7/values.yaml
+++ b/charts/traefik/v1.7/values.yaml
@@ -420,6 +420,8 @@ deployment:
     # httpPort: 80
     # httpsPort: 443
     # dashboardPort: 8080
+kind:
+  daemons: false
 sendAnonymousUsage: false
 tracing:
   enabled: false


### PR DESCRIPTION
Let the possibility for users to input http and https port instead to have random ports