### PR TITLE
longhorn: Allow up to Rancher v2.3.5 for Longhorn v0.6.2

### DIFF
--- a/charts/longhorn/v0.6.2/questions.yml
+++ b/charts/longhorn/v0.6.2/questions.yml
@@ -1,4 +1,4 @@
-rancher_max_version: 2.3.1
+rancher_max_version: 2.3.5
 categories:
 - storage
 namespace: longhorn-system


### PR DESCRIPTION
Keep it for the upgrade purpose from v0.5.0.

Signed-off-by: Sheng Yang <sheng.yang@rancher.com>