### PR TITLE
Add externalIP option to traefik

### DIFF
--- a/charts/traefik/v1.7/Chart.yaml
+++ b/charts/traefik/v1.7/Chart.yaml
@@ -16,4 +16,4 @@ name: traefik
 sources:
 - https://github.com/containous/traefik
 - https://github.com/helm/charts/tree/master/stable/traefik
-version: 1.0.0
+version: 1.0.1

--- a/charts/traefik/v1.7/questions.yml
+++ b/charts/traefik/v1.7/questions.yml
@@ -24,10 +24,19 @@ questions:
     - "LoadBalancer"
     - "NodePort"
     - "ClusterIP"
+    - "externalIP"
   default: "LoadBalancer"
   description: "Service Type for Traefik"
   label: Service Type
   group: "General Settings"
+  show_subquestion_if: "ExternalIP"
+  subquestions:
+  - variable: externalIP
+    default: null
+    description: "External IP address"
+    type: string
+    required: true
+    label: External IP address
 - variable: debug.enabled
   type: boolean
   default: false

--- a/charts/traefik/v1.7/templates/service.yaml
+++ b/charts/traefik/v1.7/templates/service.yaml
@@ -19,7 +19,9 @@ metadata:
   {{- end }}
   {{- end }}
 spec:
+  {{- if (not (eq .Values.serviceType "ExternalIP")) }}
   type: {{ .Values.serviceType }}
+  {{- end }}
   {{- if .Values.loadBalancerIP }}
   loadBalancerIP: {{ .Values.loadBalancerIP }}
   {{- end }}
@@ -33,7 +35,7 @@ spec:
     - {{ $cidr }}
     {{- end }}
   {{- end }}
-  {{- if .Values.externalTrafficPolicy }}
+  {{- if (and (eq .Values.serviceType "LoadBalancer") .Values.externalTrafficPolicy) }}
   externalTrafficPolicy: {{ .Values.externalTrafficPolicy }}
   {{- end }}
   selector:

--- a/charts/traefik/v1.7/values.yaml
+++ b/charts/traefik/v1.7/values.yaml
@@ -15,6 +15,7 @@ testFramework:
 
 ## can switch the service type to NodePort if required
 serviceType: LoadBalancer
+externalIP: null
 # loadBalancerIP: ""
 # loadBalancerSourceRanges: []
 whiteListSourceRange: []


### PR DESCRIPTION
I was having issues with using the rancher UI to deploy the traefik chart on custom infrastructure. There was no way to specify an external IP in the rancher UI. There was a way to specify an external IP in the values.yaml file, but it broke the `spec.serviceType`. I added some conditions to make the `spec.serviceType` to be handled correctly when there is an externalIP specified.

I've added the option to specify an externalIP in the traefik questions.yml. Would this merit a patch version bump? 1.0.0 -> 1.0.1?