### PR TITLE
Deprecate aws-event-sources chart v0.1.0

### DIFF
--- a/charts/aws-event-sources/v0.1.0/questions.yml
+++ b/charts/aws-event-sources/v0.1.0/questions.yml
@@ -1,3 +1,7 @@
+# This chart has been moved to the rancher/helm3-charts repository
+# https://github.com/rancher/helm3-charts/pull/21
+rancher_max_version: 2.4.5
+rancher_min_version: 2.4.5
 categories:
   - Knative
   - faas


### PR DESCRIPTION
**Problem:**
The aws-event-sources chart is a Helm 3 chart and its CRDs will not install correctly when using Helm 2.

**Solution:**
Move chart to the [rancher/helm3-charts](https://github.com/rancher/helm3-charts) repository.

**Related PR:** https://github.com/rancher/helm3-charts/pull/21

