### PR TITLE
[Portworx] Bump version of Portworx release to 2.5.5

### DIFF
--- a/charts/portworx-essentials/v1.0.1/Chart.yaml
+++ b/charts/portworx-essentials/v1.0.1/Chart.yaml
@@ -1,0 +1,22 @@
+name: portworx-essentials
+appVersion: 1.0.1
+version: 1.0.1
+description: A Helm chart for installing Portworx Essentials on Kubernetes.
+keywords:
+  - Storage
+  - ICP
+  - persistent disk
+  - pvc
+  - cloud native storage
+  - persistent storage
+  - portworx
+  - amd64
+  - portworx essentials
+  - free
+home: https://portworx.com/
+maintainers:
+  - name: sharma-tapas
+    email: tapas@portworx.com
+sources:
+  - https://github.com/portworx/helm
+icon: file://../px-logo.png

--- a/charts/portworx-essentials/v1.0.1/README.md
+++ b/charts/portworx-essentials/v1.0.1/README.md
@@ -1,0 +1,57 @@
+# Portworx Essentials
+[Portworx Essentials](https://docs.portworx.com/concepts/portworx-essentials/) is a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured PX-Enterprise version of Portworx.
+
+The Portworx Essentials license requires that your clusters be connected to the internet and send usage data to PX-Central. Portworx Essentials clusters connect with PX-Central once per hour to renew license leases. Lease periods last for 24 hours, ensuring that any temporary interruptions to your connectivity do not impact your cluster.
+
+## **Pre-requisites**
+
+The minimum supported size for a Portworx cluster is three nodes. Each node must meet the following hardware, software, and network requirements:
+
+### Hardware & Software
+	
+|Resource|Requirements|
+|--------|------------|
+|CPU|4 cores|
+|RAM|4GB|
+|Disk (/var)| 2GB free|
+|Backing drive|8GB (minimum required) 128 GB (minimum recommended)|
+|Storage drives| Minimum: 1 node with a storage drive. Storage drives must be unmounted block storage: raw disks, drive partitions, LVM, or cloud block storage. |
+|Ethernet NIC card| 10 GB (recommended)|
+|Linux kernel| 	Version 3.10 or greater.|
+|Docker| 	Version 1.13.1 or greater.|
+|Disable swap| 	Please disable swap on all nodes that will run the Portworx software. Ensure that the swap device is not automatically mounted on server reboot.|
+
+### Network 	
+Open needed ports :	TCP ports 9001-9022 and UDP port 9002 on all Portworx nodes. Also open the KVDB port. (As an example, etcd typically runs on port 2379). If you intend to use Portworx with sharedV4 volumes, you may need to open your NFS ports.
+
+Please read [this link](https://docs.portworx.com/concepts/portworx-essentials/) before installing to understand the pre-requisites.
+
+## **Limitations**
+* The portworx helm chart can only be deployed in the kube-system namespace. Hence use "kube-system" in the "Target namespace" during configuration.
+
+## **Uninstalling the Chart**
+
+#### You can uninstall Portworx using one of the following methods:
+
+#### **1. Delete all the Kubernetes components associated with the chart and the release.**
+
+> **Note** > The Portworx configuration files under `/etc/pwx/` directory are preserved, and will not be deleted.
+
+To perform this operation simply delete the application from the Apps page
+
+#### **2. Wipe your Portworx installation**
+> **Note** > The commands in this section are disruptive and will lead to data loss. Please use caution..
+
+See more details [here](https://docs.portworx.com/portworx-install-with-kubernetes/install-px-helm/#uninstall)
+
+## **Documentation**
+* [Portworx docs site](https://docs.portworx.com/install-with-other/rancher/rancher-2.x/#step-1-install-rancher)
+* [Portworx interactive tutorials](https://docs.portworx.com/scheduler/kubernetes/px-k8s-interactive.html)
+
+## **Installing the Chart using the CLI**
+
+See the installation details [here](https://docs.portworx.com/portworx-install-with-kubernetes/install-px-helm/)
+
+## **Installing Portworx on AWS**
+
+See the installation details [here](https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws)

--- a/charts/portworx-essentials/v1.0.1/app-readme.md
+++ b/charts/portworx-essentials/v1.0.1/app-readme.md
@@ -1,0 +1,26 @@
+# Portworx Essentials
+
+[Portworx Essentials](https://portworx.com/) is a free Portworx license with limited functionality that allows you to run small production or proof-of-concept workloads. Essentials limits capacity and advanced features, but otherwise functions the same way as the fully-featured PX-Enterprise version of Portworx such as
+
+  *  Run containerized stateful applications that are highly-available (HA) across multiple nodes, cloud instances, regions, data centers or even clouds
+  *  Migrate workflows between multiple clusters running across same or hybrid clouds
+  *  Run hyperconverged workloads where the data resides on the same host as the applications
+  *  Have programmatic control on your storage resources
+
+----
+## Full Features
+  * Free forever
+  * 5 nodes
+  * 500 volumes
+  * Cloud Drive provisioning
+  * Failures across nodes/racks/AZ 
+
+----
+## Limited features
+  * Application consistent Snapshots (5 per volume)
+  * Cloud Snapshots (1 per volume per day)
+  * BYOK Encryption (cluster key only)
+  * Single user cluster management UI (single user, single cluster) 
+
+For more information [Click Here](https://portworx.com/products/features/)
+The Portworx Essentials license requires that your clusters be connected to the internet and send usage data to PX-Central. Portworx Essentials clusters connect with PX-Central once per hour to renew license leases. Lease periods last for 24 hours, ensuring that any temporary interruptions to your connectivity do not impact your cluster.

--- a/charts/portworx-essentials/v1.0.1/ci/test-values.yaml
+++ b/charts/portworx-essentials/v1.0.1/ci/test-values.yaml
@@ -1,0 +1,1 @@
+etcdType: Built-in

--- a/charts/portworx-essentials/v1.0.1/questions.yml
+++ b/charts/portworx-essentials/v1.0.1/questions.yml
@@ -1,0 +1,841 @@
+categories:
+- storage
+namespace: kube-system
+labels:
+  io.rancher.certified: partner
+questions:
+
+################################### Essentials options ################################
+- variable: essentialID
+  type: string
+  required: true
+  default: "none"
+  label: "Essentials Entitlement ID"
+  description: "Get your free essentials entitlement ID from https://central.portworx.com/profile"
+  group: "license parameters"
+
+
+################################### Storage options ################################
+- variable: environment
+  description: "Select your environment"
+  label: "Environment"
+  type: enum
+  default: "OnPrem"
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "OnPrem"
+    - "Cloud"
+
+- variable: provider
+  show_if: "environment=Cloud"
+  description: "Select cloud platform"
+  label: "Cloud provider"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "AWS"
+    - "Google cloud/GKE"
+
+- variable: onpremStorage
+  show_if: "environment=OnPrem"
+  type: enum
+  default: "Automatically scan disks"
+  label: "Select type of OnPrem storage"
+  group: "Storage Parameters"
+  required: true
+  options:
+    - "Automatically scan disks"
+    - "Manually specify disks"
+
+- variable: deviceConfig
+  show_if: "environment=Cloud"
+  description: "If you plan to use EC2 instance storage or plan to manage EBS volumes your own way, select 'Consume unused' or 'Use Existing disks'."
+  label: "Select a type of disk"
+  type: enum
+  default: "Create Using a Spec"
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "Create Using a Spec"
+    - "Consume Unused"
+    - "Use Existing Disks"
+    -
+- variable: journalDevice
+  description: "This allows PX to create it’s own journal partition on the best drive to absorb PX metadata writes. Journal writes are small with frequent syncs and hence a separate journal partition will enable better performance. Use value 'auto' if you want Portworx to create it's own journal partition."
+  type: string
+  label: "Journal Device"
+  group: "Storage Parameters"
+
+############ Consume unused ##############
+- variable: usedrivesAndPartitions
+  show_if: "deviceConfig=Consume Unused||onpremStorage=Automatically scan disks"
+  label: "Use unmounted drives and partitions"
+  descrition: "Use unmounted disks even if they have a partition or filesystem on it. PX will never use a drive or partition that is mounted."
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+
+############ Use Exising Disks ##############
+- variable: existingDisk1
+  show_if: "deviceConfig=Use Existing Disks||onpremStorage=Manually specify disks"
+  label: "Drive/Device1"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk2
+  show_if: "deviceConfig=Use Existing Disks||onpremStorage=Manually specify disks"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk2
+  show_if: "addExistingDisk2=true"
+  label: "Drive/Device2"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk3
+  show_if: "addExistingDisk2=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk3
+  show_if: "addExistingDisk3=true"
+  label: "Drive/Device3"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk4
+  show_if: "addExistingDisk3=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk4
+  show_if: "addExistingDisk4=true"
+  label: "Drive/Device4"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk5
+  show_if: "addExistingDisk4=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk5
+  show_if: "addExistingDisk5=true"
+  label: "Drive/Device5"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+##################################################### Cloud ################################
+
+##################################################### AWS ################################
+
+### Section 1 AWS
+- variable: drive_1.aws.type
+  show_if: "provider=AWS&&deviceConfig=Create Using a Spec"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  default: "GP2"
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+  - "GP2"
+  - "IO1"
+  subquestions:
+  - variable: drive_1.aws.iops
+    required: true
+    description: "*IOPS required from EBS volume"
+    type: int
+    label: IOPS
+
+- variable: drive_1.aws.size
+  show_if: "provider=AWS&&deviceConfig=Create Using a Spec"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  default: 150
+  required: true
+  group: "Storage Parameters"
+
+### Section 2 AWS
+- variable: addEBSDrive_2
+  show_if: "provider=AWS&&deviceConfig=Create Using a Spec"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_2.aws.type
+  show_if: "addEBSDrive_2=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_2.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_2.aws.size
+  show_if: "addEBSDrive_2=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+  ### Section 3 AWS
+- variable: addEBSDrive_3
+  show_if: "addEBSDrive_2=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_3.aws.type
+  show_if: "addEBSDrive_3=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_3.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_3.aws.size
+  show_if: "addEBSDrive_3=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+### Section 4 AWS
+- variable: addEBSDrive_4
+  show_if: "addEBSDrive_3=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_4.aws.type
+  show_if: "addEBSDrive_4=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_4.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_4.aws.size
+  show_if: "addEBSDrive_4=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 5 AWS
+- variable: addEBSDrive_5
+  show_if: "addEBSDrive_4=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_5.aws.type
+  show_if: "addEBSDrive_5=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_5.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_5.aws.size
+  show_if: "addEBSDrive_5=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 6 AWS
+- variable: addEBSDrive_6
+  show_if: "addEBSDrive_5=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_6.aws.type
+  show_if: "addEBSDrive_6=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_6.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_6.aws.size
+  show_if: "addEBSDrive_6=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 7 AWS
+- variable: addEBSDrive_7
+  show_if: "addEBSDrive_6=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_7.aws.type
+  show_if: "addEBSDrive_7=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_7.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_7.aws.size
+  show_if: "addEBSDrive_7=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 8 AWS
+- variable: addEBSDrive_8
+  show_if: "addEBSDrive_7=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_8.aws.type
+  show_if: "addEBSDrive_8=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_8.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_8.aws.size
+  show_if: "addEBSDrive_8=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 9 AWS
+- variable: addEBSDrive_9
+  show_if: "addEBSDrive_8=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_9.aws.type
+  show_if: "addEBSDrive_9=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_9.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_9.aws.size
+  show_if: "addEBSDrive_9=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 10 AWS
+- variable: addEBSDrive_10
+  show_if: "addEBSDrive_9=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_10.aws.type
+  show_if: "addEBSDrive_10=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_10.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_10.aws.size
+  show_if: "addEBSDrive_10=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+##################################################### GOOGLE CLOUD ################################
+
+#### Section 1 GC
+- variable: drive_1.gc.type
+  show_if: "provider=Google cloud/GKE&&deviceConfig=Create Using a Spec"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  default: "standard"
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_1.gc.size
+  show_if: "provider=Google cloud/GKE&&deviceConfig=Create Using a Spec"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  default: 150
+  required: true
+  group: "Storage Parameters"
+
+#### Section 2 GC
+- variable: addGCDrive_2
+  show_if: "provider=Google cloud/GKE&&deviceConfig=Create Using a Spec"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_2.gc.type
+  show_if: "addGCDrive_2=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_2.gc.size
+  show_if: "addGCDrive_2=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 3 GC
+- variable: addGCDrive_3
+  show_if: "addGCDrive_2=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_3.gc.type
+  show_if: "addGCDrive_3=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_3.gc.size
+  show_if: "addGCDrive_3=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 4 GC
+- variable: addGCDrive_4
+  show_if: "addGCDrive_3=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_4.gc.type
+  show_if: "addGCDrive_4=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_4.gc.size
+  show_if: "addGCDrive_4=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 5 GC
+- variable: addGCDrive_5
+  show_if: "addGCDrive_4=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_5.gc.type
+  show_if: "addGCDrive_5=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_5.gc.size
+  show_if: "addGCDrive_5=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 6 GC
+- variable: addGCDrive_6
+  show_if: "addGCDrive_5=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_6.gc.type
+  show_if: "addGCDrive_6=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_6.gc.size
+  show_if: "addGCDrive_6=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 7 GC
+- variable: addGCDrive_7
+  show_if: "addGCDrive_6=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_7.gc.type
+  show_if: "addGCDrive_6=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_7.gc.size
+  show_if: "addGCDrive_7=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 8 GC
+- variable: addGCDrive_8
+  show_if: "addGCDrive_7=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_8.gc.type
+  show_if: "addGCDrive_8=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_8.gc.size
+  show_if: "addGCDrive_8=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 9 GC
+- variable: addGCDrive_9
+  show_if: "addGCDrive_8=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_9.gc.type
+  show_if: "addGCDrive_9=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_9.gc.size
+  show_if: "addGCDrive_9=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 10 GC
+- variable: addGCDrive_10
+  show_if: "addGCDrive_9=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_10.gc.type
+  show_if: "addGCDrive_10=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_10.gc.size
+  show_if: "addGCDrive_10=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+- variable: maxStorageNodes
+  show_if: "environment=Cloud&&deviceConfig=Create Using a Spec"
+  description: "Max storage nodes per availability zone"
+  label: "Max storage nodes (Optional)"
+  type: int
+  group: "Storage Parameters"
+
+################################### Network options ################################
+- variable: dataInterface
+  description: "Specify your data network interface (example: `eth1`). If set to `auto`, Portworx will automatically select the first routable interface."
+  type: string
+  label: "Data Network Interface"
+  default: auto
+  group: "Network Parameters"
+- variable: managementInterface
+  description: "Specify your management network interface (example: `eth1`). If set to `auto`, Portworx will automatically select the first routable interface."
+  type: string
+  default: auto
+  label: "Management Network Interface"
+  group: "Network Parameters"
+
+################################### Platform options ################################
+- variable: platformOptions
+  type: enum
+  label: "Platform"
+  group: "Platform Parameters"
+  options:
+    - "AKS"
+    - "EKS"
+    - "GKE"
+
+################################### Registry settings options ################################
+- variable: customRegistry
+  label: "Use a custom container registry?"
+  type: boolean
+  default: false
+  group: "Container Registry Parameters"
+
+- variable: registrySecret
+  show_if: "customRegistry=true"
+  description: "Specify a custom Kubernetes secret that will be used to authenticate with a container registry. Must be defined in kube-system namespace. (example: regcred)"
+  type: string
+  label: "Registry Kubernetes Secret"
+  group: "Container Registry Parameters"
+- variable: customRegistryURL
+  show_if: "customRegistry=true"
+  description: "Specify a custom container registry server (including repository) that will be used instead of index.docker.io to download Docker images. (example: dockerhub.acme.net:5443 or myregistry.com/myrepository/)"
+  label: "Custom Registry URL"
+  type: string
+  group: "Container Registry Parameters"
+
+
+
+################################## Optional features ############################
+# TODO: Once we have a stable CSI release, we will default this to enabled
+#- variable: csi
+#  description: "Select if you want to enable CSI (Container Storage Interface). CSI is still in ALPHA."
+#  type: boolean
+#  label: "Enable CSI"
+#  default: false
+#  required: false
+#  group: "Advanced parameters"
+
+- variable: storkVersion
+  default: "2.4.2.1"
+  label: "Stork version"
+  type: string
+  group: "Advanced parameters"
+
+- variable: envVars
+  label: "Environment variables"
+  description: "Enter your environment variables separated by semicolons (example: MYENV1=val1;MYENV2=val2). These environment variables will be exported to Portworx."
+  type: string
+  group: "Advanced parameters"
+
+- variable: imageVersion
+  default: "2.5.5"
+  type: string
+  label: Portworx version to be deployed.
+  group: "Advanced parameters"
+
+- variable: clusterName
+  type: string
+  label: Portworx cluster name
+  default: mycluster
+  group: "Advanced parameters"

--- a/charts/portworx-essentials/v1.0.1/templates/NOTES.txt
+++ b/charts/portworx-essentials/v1.0.1/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Your Release is named {{ .Release.Name | quote }}
+
+Portworx Pods should be running on each node in your cluster.
+
+Portworx would create a unified pool of the disks attached to your Kubernetes nodes. No further action should be required and you are ready to consume Portworx Volumes as part of your application data requirements.
+
+For further information on usage of the Portworx, refer to following doc pages.
+
+- For dynamically provisioning volumes: https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
+- For preprovisioned volumes: https://docs.portworx.com/scheduler/kubernetes/preprovisioned-volumes.html
+- To use Stork (Storage Orchestration Runtime for Kubernetes) for hyperconvergence and snapshots: https://docs.portworx.com/scheduler/kubernetes/stork.html
+- For stateful application solutions using Portworx: https://docs.portworx.com/scheduler/kubernetes/k8s-px-app-samples.html
+- For interactive tutorials on using Portworx on Kubernetes: https://docs.portworx.com/scheduler/kubernetes/px-k8s-interactive.html

--- a/charts/portworx-essentials/v1.0.1/templates/_helpers.tpl
+++ b/charts/portworx-essentials/v1.0.1/templates/_helpers.tpl
@@ -1,0 +1,405 @@
+{{/* Gets the correct API Version based on the version of the cluster
+*/}}
+
+{{- define "rbac.apiVersion" -}}
+{{- if semverCompare ">= 1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+"rbac.authorization.k8s.io/v1"
+{{- else -}}
+"rbac.authorization.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}
+
+
+{{- define "px.labels" -}}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}
+
+{{- define "driveOpts" }}
+{{ $v := .Values.installOptions.drives | split "," }}
+{{$v._0}}
+{{- end -}}
+
+{{- define "px.kubernetesVersion" -}}
+{{$version := .Capabilities.KubeVersion.GitVersion | regexFind "^v\\d+\\.\\d+\\.\\d+"}}{{$version}}
+{{- end -}}
+
+
+{{- define "px.getImage" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{- if .Values.openshiftInstall -}}
+            {{ cat (trim .Values.customRegistryURL) "/px-monitor" | replace " " ""}}
+        {{- else -}}
+            {{ cat (trim .Values.customRegistryURL) "/oci-monitor" | replace " " ""}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.openshiftInstall -}}
+            {{cat (trim .Values.customRegistryURL) "/portworx/px-monitor" | replace " " ""}}
+        {{- else -}}
+            {{cat (trim .Values.customRegistryURL) "/portworx/oci-monitor" | replace " " ""}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.openshiftInstall -}}
+        {{ "registry.connect.redhat.com/portworx/px-monitor" }}
+    {{- else -}}
+        {{ "portworx/oci-monitor" }}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getStorkImage" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ cat (trim .Values.customRegistryURL) "/stork" | replace " " ""}}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/openstorage/stork" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+    {{ "openstorage/stork" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getk8sImages" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/gcr.io/google_containers" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "gcr.io/google_containers" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getcsiImages" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/quay.io/k8scsi" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "quay.io/k8scsi" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getLighthouseImages" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/portworx/" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "portworx" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getPauseImage" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/k8s.gcr.io" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "k8s.gcr.io" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.registryConfigType" -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+".dockerconfigjson"
+{{- else -}}
+".dockercfg"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for hooks
+*/}}
+{{- define "px.hookServiceAccount" -}}
+    {{- printf "%s-hook" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the cluster role to use for hooks
+*/}}
+{{- define "px.hookClusterRole" -}}
+    {{- printf "%s-hook" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the cluster role binding to use for hooks
+*/}}
+{{- define "px.hookClusterRoleBinding" -}}
+    {{- printf "%s-hook" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+ String concatenation for drives in AWS section
+*/}}
+{{- define "px.storage" -}}
+{{- $awsType1 := .Values.drive_1.aws.type -}}
+{{- $awsType2 := .Values.drive_2.aws.type -}}
+{{- $awsType3 := .Values.drive_3.aws.type -}}
+{{- $awsType4 := .Values.drive_4.aws.type -}}
+{{- $awsType5 := .Values.drive_5.aws.type -}}
+{{- $awsType6 := .Values.drive_6.aws.type -}}
+{{- $awsType7 := .Values.drive_7.aws.type -}}
+{{- $awsType8 := .Values.drive_8.aws.type -}}
+{{- $awsType9 := .Values.drive_9.aws.type -}}
+{{- $awsType10 := .Values.drive_10.aws.type -}}
+
+{{- $awsSize1 := .Values.drive_1.aws.size -}}
+{{- $awsSize2 := .Values.drive_2.aws.size -}}
+{{- $awsSize3 := .Values.drive_3.aws.size -}}
+{{- $awsSize4 := .Values.drive_4.aws.size -}}
+{{- $awsSize5 := .Values.drive_5.aws.size -}}
+{{- $awsSize6 := .Values.drive_6.aws.size -}}
+{{- $awsSize7 := .Values.drive_7.aws.size -}}
+{{- $awsSize8 := .Values.drive_8.aws.size -}}
+{{- $awsSize9 := .Values.drive_9.aws.size -}}
+{{- $awsSize10 := .Values.drive_10.aws.size -}}
+
+{{- $awsIops1 := .Values.drive_1.aws.iops -}}
+{{- $awsIops2 := .Values.drive_2.aws.iops -}}
+{{- $awsIops3 := .Values.drive_3.aws.iops -}}
+{{- $awsIops4 := .Values.drive_4.aws.iops -}}
+{{- $awsIops5 := .Values.drive_5.aws.iops -}}
+{{- $awsIops6 := .Values.drive_6.aws.iops -}}
+{{- $awsIops7 := .Values.drive_7.aws.iops -}}
+{{- $awsIops8 := .Values.drive_8.aws.iops -}}
+{{- $awsIops9 := .Values.drive_9.aws.iops -}}
+{{- $awsIops10 := .Values.drive_10.aws.iops -}}
+
+{{- $gcType1 := .Values.drive_1.gc.type -}}
+{{- $gcType2 := .Values.drive_2.gc.type -}}
+{{- $gcType3 := .Values.drive_3.gc.type -}}
+{{- $gcType4 := .Values.drive_4.gc.type -}}
+{{- $gcType5 := .Values.drive_5.gc.type -}}
+{{- $gcType6 := .Values.drive_6.gc.type -}}
+{{- $gcType7 := .Values.drive_7.gc.type -}}
+{{- $gcType8 := .Values.drive_8.gc.type -}}
+{{- $gcType9 := .Values.drive_9.gc.type -}}
+{{- $gcType10 := .Values.drive_10.gc.type -}}
+
+{{- $gcSize1 := .Values.drive_1.gc.size -}}
+{{- $gcSize2 := .Values.drive_2.gc.size -}}
+{{- $gcSize3 := .Values.drive_3.gc.size -}}
+{{- $gcSize4 := .Values.drive_4.gc.size -}}
+{{- $gcSize5 := .Values.drive_5.gc.size -}}
+{{- $gcSize6 := .Values.drive_6.gc.size -}}
+{{- $gcSize7 := .Values.drive_7.gc.size -}}
+{{- $gcSize8 := .Values.drive_8.gc.size -}}
+{{- $gcSize9 := .Values.drive_9.gc.size -}}
+{{- $gcSize10 := .Values.drive_10.gc.size -}}
+
+{{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
+{{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
+{{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
+
+{{- if eq "OnPrem" .Values.environment -}}
+    {{- if eq "Manually specify disks" .Values.onpremStorage }}
+            {{- if ne "none" .Values.existingDisk1 }}
+                "-s", "{{- .Values.existingDisk1 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk2 -}}
+                "-s", "{{- .Values.existingDisk2 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk3 -}}
+                "-s", "{{- .Values.existingDisk3 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk4 -}}
+                "-s", "{{- .Values.existingDisk4 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk5 }}
+                "-s", "{{- .Values.existingDisk5 }}",
+            {{- end }}
+    {{- else if eq "Automatically scan disks" .Values.onpremStorage -}}
+       {{- if or $usedrivesAndPartitions $deployEnvironmentIKS }}
+           "-f",
+       {{- end }}
+       {{- if eq $usedrivesAndPartitions true }}
+           "-A",
+       {{- else }}
+           "-a",
+       {{- end -}}
+    {{- end -}}
+
+{{- else if eq "Cloud" .Values.environment -}}
+    {{- if eq "Consume Unused" .Values.deviceConfig -}}
+       {{- if or $usedrivesAndPartitions $deployEnvironmentIKS }}
+           "-f",
+       {{- end }}
+       {{- if eq $usedrivesAndPartitions true }}
+           "-A",
+       {{- else }}
+           "-a",
+       {{- end -}}
+    {{- end }}
+{{/*------------------- ----------------- Google cloud/GKE -------------- --------------- */}}
+    {{- if eq "Google cloud/GKE" .Values.provider -}}
+        {{- if eq "Use Existing Disks" .Values.deviceConfig -}}
+            {{- if .Values.existingDisk1 -}}
+                "-s", "{{- .Values.existingDisk1 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk2 -}}
+                "-s", "{{- .Values.existingDisk2 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk3 -}}
+                "-s", "{{- .Values.existingDisk3 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk4 -}}
+                "-s", "{{- .Values.existingDisk4 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk5 -}}
+                "-s", "{{- .Values.existingDisk5 -}}",
+            {{- end -}}
+        {{- else if eq "Create Using a Spec" .Values.deviceConfig -}}
+            {{- if $gcType1 }}
+                "-s", "type=pd-{{$gcType1 | lower}},size={{$gcSize1}}",
+            {{- end }}
+            {{/*------------------- DRIVE 2 --------------- */}}
+            {{- if $gcType2 -}}
+                "-s", "type=pd-{{$gcType2 | lower}},size={{$gcSize2}}",
+            {{- end }}
+            {{/*------------------- DRIVE 3 --------------- */}}
+            {{- if $gcType3 -}}
+                "-s", "type=pd-{{$gcType3 | lower}},size={{$gcSize3}}",
+            {{- end }}
+            {{/*------------------- DRIVE 4 --------------- */}}
+            {{- if $gcType4 -}}
+                "-s", "type=pd-{{$gcType4 | lower}},size={{$gcSize4}}",
+            {{- end }}
+            {{/*------------------- DRIVE 5 --------------- */}}
+            {{- if $gcType5 -}}
+                "-s", "type=pd-{{$gcType5 | lower}},size={{$gcSize5}}",
+            {{- end }}
+            {{/*------------------- DRIVE 6 --------------- */}}
+            {{- if $gcType6 -}}
+                "-s", "type=pd-{{$gcType6 | lower}},size={{$gcSize6}}",
+            {{- end }}
+            {{/*------------------- DRIVE 7 --------------- */}}
+            {{- if $gcType7 -}}
+                "-s", "type=pd-{{$gcType7 | lower}},size={{$gcSize7}}",
+            {{- end }}
+            {{/*------------------- DRIVE 8 --------------- */}}
+            {{- if $gcType8 -}}
+                "-s", "type=pd-{{$gcType8 | lower}},size={{$gcSize8}}",
+            {{- end }}
+            {{/*------------------- DRIVE 9 --------------- */}}
+            {{- if $gcType9 -}}
+                "-s", "type=pd-{{$gcType9 | lower}},size={{$gcSize9}}",
+            {{- end }}
+            {{/*------------------- DRIVE 10 --------------- */}}
+            {{- if $gcType10 -}}
+                "-s", "type=pd-{{$gcType1 | lower}},size={{$gcSize10}}",
+            {{- end }}
+        {{- end -}}
+{{/*------------------- ----------------- AWS -------------- --------------- */}}
+    {{- else if eq "AWS" .Values.provider -}}
+        {{- if eq "Use Existing Disks" .Values.deviceConfig -}}
+            {{- if ne "none" .Values.existingDisk1 -}}
+                "-s", "{{ .Values.existingDisk1 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk2 -}}
+                "-s", "{{ .Values.existingDisk2 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk3 -}}
+                "-s", "{{ .Values.existingDisk3 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk4 -}}
+                "-s", "{{ .Values.existingDisk4 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk5 -}}
+                "-s", "{{ .Values.existingDisk5 }}",
+            {{- end -}}
+        {{- else if eq "Create Using a Spec" .Values.deviceConfig -}}
+            {{- if ne "none" $awsType1 }}
+                {{- if eq "GP2" $awsType1 -}}
+                    "-s", "type={{$awsType1 | lower}},size={{$awsSize1}}",
+                {{- else if eq "IO1" $awsType1 -}}
+                    "-s", "type={{$awsType1 | lower}},size={{$awsSize1}},iops={{$awsIops1}}",
+                {{- end }}
+            {{- end }}
+            {{/*------------------- DRIVE 2 --------------- */}}
+            {{- if ne "none" $awsType2 -}}
+                {{- if eq "GP2" $awsType2 -}}
+                    "-s", "type={{$awsType2 | lower}},size={{$awsSize2}}",
+                {{- else if eq "IO1" $awsType2 -}}
+                    "-s", "type={{$awsType2 | lower}},size={{$awsSize2}},iops={{$awsIops2}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 3 --------------- */}}
+            {{- if ne "none" $awsType3 }}
+                {{- if eq "GP2" $awsType3 -}}
+                    "-s", "type={{$awsType3 | lower}},size={{$awsSize3}}",
+                {{- else if eq "IO1" $awsType3 -}}
+                    "-s", "type={{$awsType3 | lower}},size={{$awsSize3}},iops={{$awsIops3}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 4 --------------- */}}
+            {{- if ne "none" $awsType4 }}
+                {{- if eq "GP2" $awsType4 -}}
+                    "-s", "type={{$awsType4 | lower}},size={{$awsSize4}}",
+                {{- else if eq "IO1" $awsType4 -}}
+                    "-s", "type={{$awsType4 | lower}},size={{$awsSize4}},iops={{$awsIops4}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 5 --------------- */}}
+            {{- if ne "none" $awsType5 }}
+                {{- if eq "GP2" $awsType5 -}}
+                    "-s", "type={{$awsType5 | lower}},size={{$awsSize5}}",
+                {{- else if eq "IO1" $awsType5 -}}
+                    "-s", "type={{$awsType5 | lower}},size={{$awsSize5}},iops={{$awsIops5}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 6 --------------- */}}
+            {{- if ne "none" $awsType6 }}
+                {{- if eq "GP2" $awsType6 -}}
+                    "-s", "type={{$awsType6 | lower}},size={{$awsSize6}}",
+                {{- else if eq "IO1" $awsType6 -}}
+                    "-s", "type={{$awsType6 | lower}},size={{$awsSize6}},iops={{$awsIops6}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 7 --------------- */}}
+            {{- if ne "none" $awsType7 }}
+                {{- if eq "GP2" $awsType7 -}}
+                    "-s", "type={{$awsType7 | lower}},size={{$awsSize7}}",
+                {{- else if eq "IO1" $awsType7 -}}
+                    "-s", "type={{$awsType7 | lower}},size={{$awsSize7}},iops={{$awsIops7}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 8 --------------- */}}
+            {{- if ne "none" $awsType8 }}
+                {{- if eq "GP2" $awsType8 -}}
+                    "-s", "type={{$awsType8 | lower}},size={{$awsSize8}}",
+                {{- else if eq "IO1" $awsType8 -}}
+                    "-s", "type={{$awsType8 | lower}},size={{$awsSize8}},iops={{$awsIops8}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 9 --------------- */}}
+            {{- if ne "none" $awsType9 }}
+                {{- if eq "GP2" $awsType9 -}}
+                    "-s", "type={{$awsType9 | lower}},size={{$awsSize9}}",
+                {{- else if eq "IO1" $awsType9 -}}
+                    "-s", "type={{$awsType9 | lower}},size={{$awsSize9}},iops={{$awsIops9}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 10 --------------- */}}
+            {{- if ne "none" $awsType10 }}
+                {{- if eq "GP2" $awsType10 -}}
+                    "-s", "type={{$awsType10 | lower}},size={{$awsSize10}}",
+                {{- else if eq "IO1" $awsType10 -}}
+                    "-s", "type={{$awsType10 | lower}},size={{$awsSize10}},iops={{$awsIops10}}",
+                {{- end -}}
+            {{- end }}
+        {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end }}
+

--- a/charts/portworx-essentials/v1.0.1/templates/hooks/post-delete/px-postdelete-unlabelnode.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/hooks/post-delete/px-postdelete-unlabelnode.yaml
@@ -1,0 +1,40 @@
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kube-system
+  name: px-hook-postdelete-unlabelnode
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{ if semverCompare ">= 1.8-0" .Capabilities.KubeVersion.GitVersion }}
+  backoffLimit: 0
+{{ else }}
+  activeDeadlineSeconds: 30
+{{ end }}
+  template:
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      restartPolicy: Never
+      serviceAccountName: {{ template "px.hookServiceAccount" . }}
+      containers:
+      - name: post-delete-job
+        {{- if eq $customRegistryURL "none" }}
+        image: "lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- else}}
+        image: "{{ $customRegistryURL }}/lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- end}}
+        args: ['label','nodes','--all','px/enabled-']

--- a/charts/portworx-essentials/v1.0.1/templates/hooks/pre-delete/px-predelete-nodelabel.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/hooks/pre-delete/px-predelete-nodelabel.yaml
@@ -1,0 +1,40 @@
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kube-system
+  name: px-hook-predelete-nodelabel
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{ if semverCompare ">= 1.8-0" .Capabilities.KubeVersion.GitVersion }}
+  backoffLimit: 0
+{{ else }}
+  activeDeadlineSeconds: 30
+{{ end }}
+  template:
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      serviceAccountName: {{ template "px.hookServiceAccount" . }}
+      restartPolicy: Never
+      containers:
+      - name: pre-delete-job
+        {{- if eq $customRegistryURL "none" }}
+        image: "lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- else}}
+        image: "{{ $customRegistryURL }}/lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- end}}
+        args: ['label','nodes','--all','px/enabled=remove','--overwrite']

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-controller.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-controller.yaml
@@ -1,0 +1,128 @@
+{{- if or ((.Values.openshiftInstall) and (eq .Values.openshiftInstall true)) ((.Values.AKSorEKSInstall) and (eq .Values.AKSorEKSInstall true)) ((.Capabilities.KubeVersion.GitVersion | regexMatch "gke")) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portworx-pvc-controller-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+   name: portworx-pvc-controller-role
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["create","delete","get","list","update","watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "update", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "delete", "get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["create", "delete", "get", "update"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "create", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: portworx-pvc-controller-role-binding
+subjects:
+- kind: ServiceAccount
+  name: portworx-pvc-controller-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: portworx-pvc-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: portworx-pvc-controller
+  namespace: kube-system
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: portworx-pvc-controller
+        tier: control-plane
+    spec:
+      {{- if not (empty .Values.registrySecret) }}
+      imagePullSecrets:
+        - name: {{ .Values.registrySecret }}
+     {{- end }}
+      containers:
+      - command:
+        - kube-controller-manager
+        - --leader-elect=true
+        - --address=0.0.0.0
+        - --controllers=persistentvolume-binder,persistentvolume-expander
+        - --use-service-account-credentials=true
+        - --leader-elect-resource-lock=configmaps
+        image: "{{ template "px.getk8sImages" . }}/kube-controller-manager-amd64:{{ template "px.kubernetesVersion" . }}"
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 10252
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 15
+        name: portworx-pvc-controller-manager
+        resources:
+          requests:
+            cpu: 200m
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                    - portworx-pvc-controller
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: portworx-pvc-controller-account
+{{- end }}

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-csi.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-csi.yaml
@@ -1,0 +1,96 @@
+{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: px-csi-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+   name: px-csi-role
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: px-csi-role-binding
+subjects:
+- kind: ServiceAccount
+  name: px-csi-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: px-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: px-csi-service
+  namespace: kube-system
+spec:
+  clusterIP: None
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: px-csi-ext
+  namespace: kube-system
+spec:
+  serviceName: "px-csi-service"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: px-csi-driver
+    spec:
+      serviceAccount: px-csi-account
+      containers:
+        - name: csi-external-provisioner
+          imagePullPolicy: Always
+          image: "{{ template "px.getcsiProvisioner" . }}/csi-provisioner:v0.2.0"
+          args:
+            - "--v=5"
+            - "--provisioner=com.openstorage.pxd"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          imagePullPolicy: Always
+          image: "{{ template "px.getcsiImages" . }}/csi-attacher:v0.2.0"
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/com.openstorage.pxd
+            type: DirectoryOrCreate
+{{- end }}

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-ds.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-ds.yaml
@@ -1,0 +1,441 @@
+{{/* Setting defaults if they are omitted. */}}
+{{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
+{{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
+{{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
+{{- $secretType := .Values.secretType | default "k8s" }}
+{{- $journalDevice := .Values.journalDevice | default "none" }}
+{{- $maxStorageNodes := .Values.maxStorageNodes | default "none" }}
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+
+{{- $dataInterface := .Values.dataInterface | default "none" }}
+{{- $managementInterface := .Values.managementInterface | default "none" }}
+{{- $essentialSecretID := .Values.essentialID | default "none" }}
+
+{{- $envVars := .Values.envVars | default "none" }}
+{{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
+
+{{- $pksInstall := .Values.pksInstall | default false }}
+{{- $internalKVDB := .Values.etcdType | default "none" }}
+{{- $csi := .Values.csi | default false }}
+
+{{- $etcdCredentials := .Values.etcd.credentials | default "none:none" }}
+{{- $etcdCertPath := .Values.etcd.ca | default "none" }}
+{{- $etcdCA := .Values.etcd.ca | default "none" }}
+{{- $etcdCert := .Values.etcd.cert | default "none" }}
+{{- $etcdKey := .Values.etcd.key | default "none" }}
+{{- $consulToken := .Values.consul.token | default "none" }}
+{{- $misc := .Values.misc | default "" | split " " }}
+{{- $etcdEndPoints := .Values.kvdb }}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: portworx
+  namespace: kube-system
+  labels:
+    name: portworx
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: portworx
+      app: portworx
+  template:
+    metadata:
+      labels:
+        app: portworx
+        name: portworx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+              - key: openshift-infra
+                operator: DoesNotExist
+              {{- else if (not .Values.deployOnMaster) or (eq .Values.deployOnMaster false)}}
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+              {{- end }}
+      hostNetwork: true
+      hostPID: true
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      containers:
+      # {{ template "px.getImage"}}
+        - name: portworx
+          image: {{ template "px.getImage" . }}:{{ required "A valid Image tag is required in the SemVer format" .Values.imageVersion }}
+          terminationMessagePath: "/tmp/px-termination-log"
+          imagePullPolicy: Always
+          args:
+            [
+              {{ include "px.storage" . | indent 0 }}
+              {{- with .Values -}}
+              {{- if eq "Built-in" $internalKVDB  }}
+              "-b",
+              {{- end -}}
+
+              {{- if ne $journalDevice "none" }}
+              "-j", "{{ $journalDevice }}",
+              {{- end -}}
+
+              {{- if $etcdEndPoints -}}
+              "-k", "{{ regexReplaceAllLiteral "(;)" .kvdb "," }}",
+              {{- else }}
+                {{- if ne "Built-in" $internalKVDB }}
+                  {{- if eq "US region" .region }}
+                     "-k", "etcd:http://px-etcd1.portworx.com:2379,etcd:http://px-etcd2.portworx.com:2379,etcd:http://px-etcd3.portworx.com:2379",
+                  {{- else if eq "EU region" .region }}
+                     "-k", "etcd:http://px-eu-etcd1.portworx.com:2379,etcd:http://px-eu-etcd2.portworx.com:2379,etcd:http://px-eu-etcd3.portworx.com:2379",
+                  {{- else }}
+                    "{{ required "A valid kvdb url is required." .kvdb }}"
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+              "-c", "{{ required "Clustername cannot be empty" .clusterName }}",
+
+              {{- if ne $secretType "none" }}
+              "-secret_type", "{{ $secretType }}",
+              {{- else }}
+                {{- if $deployEnvironmentIKS }}
+              "-secret_type", "ibm-kp",
+                {{- end -}}
+              {{- end -}}
+
+              {{- if and (ne $dataInterface "none") (ne $dataInterface "auto")}}
+              "-d", "{{ $dataInterface }}",
+              {{- end -}}
+
+              {{- if and (ne $managementInterface "none") (ne $managementInterface "auto") }}
+              "-m", "{{ $managementInterface }}",
+              {{- end -}}
+
+              {{- if ne $etcdCredentials "none:none" }}
+              "-userpwd", "{{ $etcdCredentials }}",
+              {{- end -}}
+
+              {{- if ne $etcdCA "none" }}
+              "-ca", "/etc/pwx/etcdcerts/{{ $etcdCA }}",
+              {{- end -}}
+
+              {{- if ne $etcdCert "none" }}
+              "-cert", "/etc/pwx/etcdcerts/{{ $etcdCert }}",
+              {{- end -}}
+
+              {{- if ne $etcdKey "none" }}
+              "-key", "/etc/pwx/etcdcerts/{{ $etcdKey }}",
+              {{- end -}}
+
+              {{- if ne $consulToken "none" }}
+              "-acltoken", "{{ $consulToken }}",
+              {{- end -}}
+
+              {{- if .misc }}
+                {{- range $index, $name := $misc }}
+              "{{ $name }}",
+                {{- end }}
+              {{ end -}}
+
+              {{- if ne $essentialSecretID "none" }}
+              "--oem", "esse",
+              {{ end -}}              
+              "-marketplace_name","rancher_catalog",
+              "-x", "kubernetes"
+            {{- end -}}
+            ]
+          env:
+            - name: "PX_TEMPLATE_VERSION"
+              value: "v2"
+              {{ if not (eq $envVars "none") }}
+              {{- $vars := $envVars | split ";" }}
+              {{- range $key, $val := $vars }}
+              {{-  $envVariable := $val | split "=" }}
+            - name: {{ $envVariable._0 | trim | quote }}
+              value: {{ $envVariable._1 | trim | quote }}
+              {{ end }}
+              {{- end }}
+
+           {{- if not (eq $registrySecret "none") }}
+            - name: REGISTRY_CONFIG
+              valueFrom:
+                secretKeyRef:
+                {{- if (semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion) or (.Values.openshiftInstall and semverCompare ">=1.8-0" .Capabilities.KubeVersion.GitVersion) }}
+                  key: ".dockerconfigjson"
+                {{- else }}
+                  key: ".dockercfg"
+                {{- end }}
+                  name: "{{ $registrySecret }}"
+            {{- end }}
+
+            {{- if eq $pksInstall true }}
+            - name: "PRE-EXEC"
+              value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
+            {{- end }}
+
+            {{- if eq $csi true }}
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/com.openstorage.pxd/csi.sock
+            {{- end }}
+
+          livenessProbe:
+            periodSeconds: 30
+            initialDelaySeconds: 840 # allow image pull in slow networks
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+          {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
+              path: /health
+              port: 9015
+          {{- else }}
+              path: /v1/cluster/nodehealth
+              port: 9001
+          {{- end}}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          {{- if not (eq $etcdCertPath "none") }}
+            - mountPath: /etc/pwx/etcdcerts
+              name: etcdcerts
+          {{- end }}
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: containerdsock
+              mountPath: /run/containerd
+            - name: etcpwx
+              mountPath: /etc/pwx
+            - name: cores
+              mountPath: /var/cores
+          {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
+            - name: optpwx
+              mountPath: /opt/pwx
+            - name: sysdmount
+              mountPath: /etc/systemd/system
+            - name: journalmount1
+              mountPath: /var/run/log
+              readOnly: true
+            - name: journalmount2
+              mountPath: /var/log
+              readOnly: true
+            - name: dbusmount
+              mountPath: /var/run/dbus
+            - name: hostproc
+              mountPath: /host_proc
+          {{- else if eq (.Values.deploymentType | upper | lower) "docker" }}
+            - name: dev
+              mountPath: /dev
+            - name: optpwx
+              mountPath: /export_bin
+            - name: dockerplugins
+              mountPath: /run/docker/plugins
+            - name: hostproc
+              mountPath: /hostproc
+          {{- if semverCompare "< 1.10-0" .Capabilities.KubeVersion.GitVersion }}
+            - name: libosd
+              mountPath: /var/lib/osd:shared
+          {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+            - name: kubelet
+              mountPath: /var/lib/origin/openshift.local.volumes:shared
+          {{- else }}
+            - name: kubelet
+              mountPath: /var/lib/kubelet:shared
+          {{- end }}
+
+          {{- else }}
+            - name: libosd
+              mountPath: /var/lib/osd
+              mountPropagation: "Bidirectional"
+          {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+            - name: kubelet
+              mountPath: /var/lib/origin/openshift.local.volumes
+              mountPropagation: "Bidirectional"
+          {{- else }}
+            - name: kubelet
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+          {{- end }}
+
+          {{- end }}
+
+          {{- if eq $isCoreOS true}}
+            - name: src
+              mountPath: /lib/modules
+          {{- else }}
+            - name: src
+              mountPath: /usr/src
+          {{- end }}
+          {{- end }}
+
+          {{- if eq $csi true }}
+        - name: csi-driver-registrar
+          imagePullPolicy: Always
+          {{- if eq $customRegistryURL "none" }}
+          image: "quay.io/k8scsi/driver-registrar:v0.2.0"
+          {{- else }}
+          image: "{{ $customRegistryURL }}/quay.io/k8scsi/driver-registrar:v0.2.0"
+          {{- end}}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: csi-driver-path
+              mountPath: /csi
+           {{- end }}
+
+      restartPolicy: Always
+      serviceAccountName: px-account
+      volumes:
+        {{- if ne $etcdCertPath "none" }}
+        - name: etcdcerts
+          secret:
+            secretName: px-etcd-certs
+            items:
+            - key: "{{ $etcdCA }}"
+              path: "{{ $etcdCA }}"
+            - key: "{{ $etcdCert }}"
+              path: "{{ $etcdCert }}"
+            - key: "{{ $etcdKey }}"
+              path: "{{ $etcdKey }}"
+        {{- end}}
+        - name: dockersock
+          hostPath:
+            path: {{if eq $pksInstall true}}/var/vcap/sys/run/docker/docker.sock{{else}}/var/run/docker.sock{{end}}
+        - name: containerdsock
+          hostPath:
+            path: {{if eq $pksInstall true}}/var/vcap/sys/run/containerd{{else}}/run/containerd{{end}}
+          {{- if eq $csi true}}
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/plugins/com.openstorage.pxd
+            type: DirectoryOrCreate
+          {{- end}}
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - name: cores
+          hostPath:
+            path: {{if eq $pksInstall true }}/var/vcap/store/cores{{else}}/var/cores{{end}}
+        {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
+        - name: optpwx
+          hostPath:
+            path: {{if eq $pksInstall true }}/var/vcap/store/opt/pwx{{else}}/opt/pwx{{end}}
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
+        - name: journalmount1
+          hostPath:
+            path: /var/run/log
+        - name: journalmount2
+          hostPath:
+            path: /var/log
+        - name: dbusmount
+          hostPath:
+            path: /var/run/dbus
+        - name: hostproc
+          hostPath:
+            path: /proc
+        {{- else if eq (.Values.deploymentType | upper | lower) "docker" }}
+        - name: libosd
+          hostPath:
+            path: /var/lib/osd
+        - name: optpwx
+          hostPath:
+            path: /opt/pwx/bin
+        - name: dev
+          hostPath:
+            path: /dev
+        {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+        - name: kubelet
+          hostPath:
+            path: /var/lib/origin/openshift.local.volumes
+        {{- else }}
+        - name: kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        {{- end }}
+        {{- if eq $isCoreOS true}}
+        - name: src
+          hostPath:
+            path: /lib/modules
+        {{- else }}
+        - name: src
+          hostPath:
+            path: /usr/src
+        {{- end }}
+        - name: dockerplugins
+          hostPath:
+            path: /run/docker/plugins
+        - name: hostproc
+          hostPath:
+            path: /proc
+        {{- end }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: portworx-api
+  namespace: kube-system
+  labels:
+    name: portworx-api
+spec:
+  selector:
+    matchLabels:
+      name: portworx-api
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+  template:
+    metadata:
+      labels:
+        name: portworx-api
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
+      hostNetwork: true
+      hostPID: false
+      containers:
+        - name: portworx-api
+          image: "{{ template "px.getPauseImage" . }}/pause:3.1"
+          imagePullPolicy: Always
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+      restartPolicy: Always
+      serviceAccountName: px-account

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-essential.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-essential.yaml
@@ -1,0 +1,19 @@
+{{- $essentialSecretID := .Values.essentialID | default "none" }}
+{{- if ne $essentialSecretID "none" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: px-essential
+  namespace: kube-system
+  labels:
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+type: Opaque
+data:
+    px-essen-user-id: {{ $essentialSecretID | b64enc }}
+    px-osb-endpoint: aHR0cHM6Ly9weGVzc2VudGlhbHMucG9ydHdvcnguY29tL29zYi9iaWxsaW5nL3YxL3JlZ2lzdGVy
+    px-essen-market-place: cmFuY2hlci1tYXJrZXRwbGFjZQ==
+{{- end -}}

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-rbac-config.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-rbac-config.yaml
@@ -1,0 +1,56 @@
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: px-account
+  namespace: kube-system
+---
+
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+   name: node-get-put-list-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "get", "update", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete", "get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "update", "create"]
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]
+- apiGroups: ["portworx.io"]
+  resources: ["volumeplacementstrategies"]
+  verbs: ["get", "list"]
+- apiGroups: ["stork.libopenstorage.org"]
+  resources: ["backuplocations"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: node-role-binding
+subjects:
+- kind: ServiceAccount
+  name: px-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: node-get-put-list-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-service.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-service.yaml
@@ -1,0 +1,54 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-service
+  namespace: kube-system
+  labels:
+    name: portworx
+spec:
+  selector:
+    name: portworx
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 9019
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 9020
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 9021
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-api
+  namespace: kube-system
+  labels:
+    name: portworx-api
+spec:
+  selector:
+    name: portworx-api
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 9020
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 9021
+---

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-storageclasses.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-storageclasses.yaml
@@ -1,0 +1,56 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-db-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  io_profile: "db"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-db2-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "3"
+   block_size: "512b"
+   io_profile: "db"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-shared-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "3"
+   shared: "true"
+---
+#
+# NULL StorageClass that documents all possible
+# Portworx StorageClass parameters
+#
+# Please refer to : https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
+#
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-null-sc
+  annotations:
+       params/docs:  'https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html'
+       params/fs:  "Filesystem to be laid out: none|xfs|ext4 "
+       params/block_size: "Block size"
+       params/repl:        "Replication factor for the volume: 1|2|3"
+       params/shared:     "Flag to create a globally shared namespace volume which can be used by multiple pods : true|false"
+       params/priority_io: "IO Priority: low|medium|high"
+       params/io_profile:  "IO Profile can be used to override the I/O algorithm Portworx uses for the volumes. Supported values are [db](/maintain/performance/tuning.html#db), [sequential](/maintain/performance/tuning.html#sequential), [random](/maintain/performance/tuning.html#random), [cms](/maintain/performance/tuning.html#cms)"
+       params/group:       "The group a volume should belong too. Portworx will restrict replication sets of volumes of the same group on different nodes. If the force group option 'fg' is set to true, the volume group rule will be strictly enforced. By default, it's not strictly enforced."
+       params/fg:          "This option enforces volume group policy. If a volume belonging to a group cannot find nodes for it's replication sets which don't have other volumes of same group, the volume creation will fail."
+       params/label:       "List of comma-separated name=value pairs to apply to the Portworx volume"
+       params/nodes:       "Comma-separated Portworx Node ID's to use for replication sets of the volume"
+       params/aggregation_level:     "Specifies the number of replication sets the volume can be aggregated from"
+       params/snap_schedule:     "Snapshot schedule. Following are the accepted formats:  periodic=_mins_,_snaps-to-keep_ daily=_hh:mm_,_snaps-to-keep_ weekly=_weekday@hh:mm_,_snaps-to-keep_  monthly=_day@hh:mm_,_snaps-to-keep_ _snaps-to-keep_ is optional. Periodic, Daily, Weekly and Monthly keep last 5, 7, 5 and 12 snapshots by default respectively"
+       params/sticky:         "Flag to create sticky volumes that cannot be deleted until the flag is disabled"
+       params/journal:         "Flag to indicate if you want to use journal device for the volume's metadata. This will use the journal device that you used when installing Portworx. As of PX version 1.3, it is recommended to use a journal device to absorb PX metadata writes"
+provisioner: kubernetes.io/portworx-volume
+parameters:

--- a/charts/portworx-essentials/v1.0.1/templates/portworx-stork.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/portworx-stork.yaml
@@ -1,0 +1,317 @@
+{{- if (.Values.stork) and (eq .Values.stork true)}}
+  {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
+  {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+  {{- $registrySecret := .Values.registrySecret | default "none" }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stork-config
+  namespace: kube-system
+data:
+  policy.cfg: |-
+    {
+      "kind": "Policy",
+      "apiVersion": "v1",
+{{- if semverCompare "< 1.10-0" .Capabilities.KubeVersion.GitVersion }}
+      "predicates": [
+{{- if semverCompare "< 1.9-0" .Capabilities.KubeVersion.GitVersion }}
+        {"name": "NoVolumeNodeConflict"},
+{{- end}}
+        {"name": "MaxAzureDiskVolumeCount"},
+        {"name": "NoVolumeZoneConflict"},
+        {"name": "PodToleratesNodeTaints"},
+        {"name": "CheckNodeMemoryPressure"},
+        {"name": "MaxEBSVolumeCount"},
+        {"name": "MaxGCEPDVolumeCount"},
+        {"name": "MatchInterPodAffinity"},
+        {"name": "NoDiskConflict"},
+        {"name": "GeneralPredicates"},
+        {"name": "CheckNodeDiskPressure"}
+      ],
+      "priorities": [
+        {"name": "NodeAffinityPriority", "weight": 1},
+        {"name": "TaintTolerationPriority", "weight": 1},
+        {"name": "SelectorSpreadPriority", "weight": 1},
+        {"name": "InterPodAffinityPriority", "weight": 1},
+        {"name": "LeastRequestedPriority", "weight": 1},
+        {"name": "BalancedResourceAllocation", "weight": 1},
+        {"name": "NodePreferAvoidPodsPriority", "weight": 1}
+      ],
+{{- end}}
+      "extenders": [
+        {
+          "urlPrefix": "http://stork-service.kube-system:8099",
+          "apiVersion": "v1beta1",
+          "filterVerb": "filter",
+          "prioritizeVerb": "prioritize",
+          "weight": 5,
+          "enableHttps": false,
+          "nodeCacheCapable": false
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stork-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-role
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: stork-account
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: stork-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: stork-service
+  namespace: kube-system
+spec:
+  selector:
+    name: stork
+  ports:
+    - name: extender
+      protocol: TCP
+      port: 8099
+      targetPort: 8099
+    - name: webhook
+      protocol: TCP
+      port: 443
+      targetPort: 443
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumeplacementstrategies.portworx.io
+spec:
+  group: portworx.io
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: false
+      storage: false
+  scope: Cluster
+  names:
+    plural: volumeplacementstrategies
+    singular: volumeplacementstrategy
+    kind: VolumePlacementStrategy
+    shortNames:
+      - vps
+      - vp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: stork
+  namespace: kube-system
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 3
+  selector:
+    matchLabels:
+      name: stork
+      tier: control-plane
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: stork
+        tier: control-plane
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      containers:
+        - command:
+            - /stork
+            - --driver=pxd
+            - --verbose
+            - --leader-elect=true
+            - --webhook-controller=false
+          imagePullPolicy: Always
+          image: {{ template "px.getStorkImage" . }}:{{ required "A valid Image tag is required in the SemVer format" .Values.storkVersion }}
+          resources:
+            requests:
+              cpu: '0.1'
+          name: stork
+      hostPID: false
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                      - stork
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: stork-account
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: stork-snapshot-sc
+provisioner: stork-snapshot
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stork-scheduler-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-scheduler-role
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resourceNames: ["kube-scheduler"]
+    resources: ["endpoints"]
+    verbs: ["delete", "get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["bindings", "pods/binding"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["patch", "update"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps", "extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "update", "get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-scheduler-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: stork-scheduler-account
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: stork-scheduler-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: scheduler
+    tier: control-plane
+  name: stork-scheduler
+  namespace: kube-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      component: scheduler
+      tier: control-plane
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        tier: control-plane
+      name: stork-scheduler
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/kube-scheduler
+            - --address=0.0.0.0
+            - --leader-elect=true
+            - --scheduler-name=stork
+            - --policy-configmap=stork-config
+            - --policy-configmap-namespace=kube-system
+            - --lock-object-name=stork-scheduler
+          image: "{{ template "px.getk8sImages" . }}/kube-scheduler-amd64:{{ template "px.kubernetesVersion" . }}"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10251
+            initialDelaySeconds: 15
+          name: stork-scheduler
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10251
+          resources:
+            requests:
+              cpu: '0.1'
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                      - stork-scheduler
+              topologyKey: "kubernetes.io/hostname"
+      hostPID: false
+      serviceAccountName: stork-scheduler-account
+  {{- end }}

--- a/charts/portworx-essentials/v1.0.1/templates/serviceaccount-hook.yaml
+++ b/charts/portworx-essentials/v1.0.1/templates/serviceaccount-hook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.hook.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "post-install,pre-delete,post-delete"
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,7 +18,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "post-install,pre-delete,post-delete"
   name: {{ template "px.hookClusterRole" . }}
 rules:
 - apiGroups: [""]
@@ -31,7 +30,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "post-install,pre-delete,post-delete"
   name: {{ template "px.hookClusterRoleBinding" . }}
 subjects:
 - kind: ServiceAccount
@@ -41,4 +40,3 @@ roleRef:
   kind: ClusterRole
   name: {{ template "px.hookClusterRole" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/charts/portworx-essentials/v1.0.1/values.yaml
+++ b/charts/portworx-essentials/v1.0.1/values.yaml
@@ -1,0 +1,151 @@
+# Please uncomment and specify values for these options as per your requirements.
+kvdb:
+ownEtcdOption: none
+etcdAuth: none
+etcdType: "Built-in"                        # KVDB type
+
+etcd:
+  credentials: none:none              # Username and password for ETCD authentication in the form user:password
+  ca: none                            # Name of CA file for ETCD authentication. server.ca
+  cert: none                          # Name of certificate for ETCD authentication. Should be server.crt
+  key: none                           # Name of certificate key for ETCD authentication Should be server.key
+consul:
+  token: none                         # ACL token value used for Consul authentication. (example: 398073a8-5091-4d9c-871a-bbbeb030d1f6)
+region: none                          # US or EU regions for Portworx hosted etcds
+
+dataInterface: none                   # Name of the interface <ethX>
+managementInterface: none             # Name of the interface <ethX>
+platformOptions: none                 # AKS, EKS or GKE platforms
+
+customRegistryURL:
+registrySecret:
+
+clusterName: mycluster                # This is the default. please change it to your cluster name.
+secretType: k8s                      # Defaults to None, but can be AWS / KVDB / Vault.
+envVars: none                         # NOTE: This is a ";" seperated list of environment variables. For eg: MYENV1=myvalue1;MYENV2=myvalue2
+stork: true                           # Use Stork https://docs.portworx.com/scheduler/kubernetes/stork.html for hyperconvergence.
+storkVersion: 2.4.2.1
+
+lighthouse: false
+
+deployOnMaster: false                 # For POC only
+csi: false                            # Enable CSI
+
+serviceAccount:
+  hook:
+    create: true
+    name:
+
+deploymentType: oci                   # accepts "oci" or "docker"
+imageType: none                       #
+imageVersion: 2.5.5                 # Version of the PX Image.
+
+result: none
+environment: none
+onpremStorage: none
+
+maxStorageNodes: none
+journalDevice: none
+
+usefileSystemDrive: false             # true/false Instructs PX to use an unmounted Drive even if it has a filesystem.
+usedrivesAndPartitions: false         # Use unmounted disks even if they have a partition or filesystem on it. PX will never use a drive or partition that is mounted. (useDrivesAndPartitions)
+
+provider: none
+deviceConfig: none
+essentialID: none
+
+drive_1:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: standard
+    size: 1000
+
+drive_2:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_3:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_4:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_5:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_6:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_7:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_8:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_9:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_10:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+existingDisk1: none
+existingDisk2: none
+existingDisk3: none
+existingDisk4: none
+existingDisk5: none

--- a/charts/portworx/v1.0.10/Chart.yaml
+++ b/charts/portworx/v1.0.10/Chart.yaml
@@ -1,0 +1,24 @@
+name: portworx
+appVersion: 1.0.10
+version: 1.0.10
+description: A Helm chart for installing Portworx on Kubernetes.
+keywords:
+  - Storage
+  - ICP
+  - persistent disk
+  - pvc
+  - cloud native storage
+  - persistent storage
+  - portworx
+  - amd64
+home: https://portworx.com/
+maintainers:
+  - name: harsh-px
+    email: harsh@portworx.com
+  - name: trierra
+    email: oksana@portworx.com
+  - name: sharma-tapas
+    email: tapas@portworx.com
+sources:
+  - https://github.com/portworx/helm
+icon: https://raw.githubusercontent.com/portworx/helm/master/doc/media/k8s-porx.png

--- a/charts/portworx/v1.0.10/README.md
+++ b/charts/portworx/v1.0.10/README.md
@@ -1,0 +1,76 @@
+# Portworx
+
+## **Pre-requisites**
+
+Use this Helm chart to deploy [Portworx](https://portworx.com/) and [Stork](https://docs.portworx.com/scheduler/kubernetes/stork.html) to your Kubernetes cluster.
+
+Prerequisites
+
+Refer to the [Install Portworx on Kubernetes via Helm](https://docs.portworx.com/portworx-install-with-kubernetes/install-px-helm/#pre-requisites) page for the list of prerequisites.
+
+## **Limitations**
+* The portworx helm chart can only be deployed in the kube-system namespace. Hence use "kube-system" in the "Target namespace" during configuration.
+
+## **Uninstalling the Chart**
+
+#### You can uninstall Portworx using one of the following methods:
+
+#### **1. Delete all the Kubernetes components associated with the chart and the release.**
+
+> **Note** > The Portworx configuration files under `/etc/pwx/` directory are preserved, and will not be deleted.
+
+To perform this operation simply delete the application from the Apps page
+
+#### **2. Wipe your Portworx installation**
+> **Note** > The commands in this section are disruptive and will lead to data loss. Please use caution..
+
+See more details [here](https://docs.portworx.com/portworx-install-with-kubernetes/install-px-helm/#uninstall)
+
+## **Documentation**
+* [Portworx docs site](https://docs.portworx.com/install-with-other/rancher/rancher-2.x/#step-1-install-rancher)
+* [Portworx interactive tutorials](https://docs.portworx.com/scheduler/kubernetes/px-k8s-interactive.html)
+
+## **Installing the Chart using the CLI**
+
+See the installation details [here](https://docs.portworx.com/portworx-install-with-kubernetes/install-px-helm/)
+
+## **Installing Portworx on AWS**
+ 
+See the installation details [here](https://docs.portworx.com/cloud-references/auto-disk-provisioning/aws)
+
+## ** Giving your etcd certificates to Portworx using Kubernetes Secrets.**
+This is the recommended way of providing etcd certificates, as the certificates will be automatically available to the new nodes joining the cluster
+
+* Create Kubernetes secret
+* Copy all your etcd certificates and key in a directory etcd-secrets/ to create a Kubernetes secret from it. Make sure the file names are the same as you gave above.
+
+```
+# ls -1 etcd-secrets/
+etcd-ca.crt
+etcd.crt
+etcd.key
+```
+
+* Use kubectl to create the secret named px-etcd-certs from the above files:
+```
+# kubectl -n kube-system create secret generic px-etcd-certs --from-file=etcd-secrets/
+```
+
+* Notice that the secret has 3 keys etcd-ca.crt, etcd.crt and etcd.key, corresponding to file names in the etcd-secrets folder. We will use these keys in the Portworx spec file to reference the certificates.
+
+```
+# kubectl -n kube-system describe secret px-etcd-certs
+Name:         px-etcd-certs
+Namespace:    kube-system
+Labels:       <none>
+Annotations:  <none>
+
+Type:  Opaque
+
+Data
+====
+etcd-ca.crt:      1679 bytes
+etcd.crt:  1680 bytes
+etcd.key:  414  bytes
+```
+Once above secret is created, proceed to the next steps.

--- a/charts/portworx/v1.0.10/app-readme.md
+++ b/charts/portworx/v1.0.10/app-readme.md
@@ -1,0 +1,8 @@
+# Portworx
+
+[Portworx](https://portworx.com/)  is a software defined storage overlay that allows you to
+
+  *  Run containerized stateful applications that are highly-available (HA) across multiple nodes, cloud instances, regions, data centers or even clouds
+  *  Migrate workflows between multiple clusters running across same or hybrid clouds
+  *  Run hyperconverged workloads where the data resides on the same host as the applications
+  *  Have programmatic control on your storage resources

--- a/charts/portworx/v1.0.10/ci/test-values.yaml
+++ b/charts/portworx/v1.0.10/ci/test-values.yaml
@@ -1,0 +1,1 @@
+etcdType: Built-in

--- a/charts/portworx/v1.0.10/questions.yml
+++ b/charts/portworx/v1.0.10/questions.yml
@@ -1,0 +1,921 @@
+categories:
+- storage
+namespace: kube-system
+labels:
+  io.rancher.certified: partner
+questions:
+
+################################### KVDB options ################################
+- variable: etcdType
+  label: "Select ETCD"
+  type: enum
+  required: true
+  group: "Key value store parameters (Required)"
+  options:
+    - "Provide your own etcd"
+    - "Built-in"
+
+# ------ "Provide your own etcd" ------
+- variable: ownEtcdOption
+  show_if: "etcdType=Provide your own etcd"
+  label: "Select one of 2 options for your ETCD cluster"
+  type: enum
+  required: true
+  group: "Key value store parameters (Required)"
+  options:
+      - "Your etcd details"
+      - "Portworx hosted (for PoCs only)"
+
+- variable: etcdAuth
+  show_if: "ownEtcdOption=Your etcd details&&etcdType=Provide your own etcd"
+  label: "Select an auth option for your ETCD cluster"
+  type: enum
+  default: "Disable HTTPS"
+  required: true
+  group: "Key value store parameters (Required)"
+  options:
+    - "Disable HTTPS"
+    - "Certificate Auth"
+    - "Password Auth"
+
+- variable: region
+  show_if: "ownEtcdOption=Portworx hosted (for PoCs only)"
+  label: "Select region"
+  type: enum
+  required: true
+  group: "Key value store parameters (Required)"
+  options:
+    - "US region"
+    - "EU region"
+
+# kvdb endpoint
+- variable: kvdb
+  show_if: "ownEtcdOption=Your etcd details"
+  description: "Enter your etcd or Consul endpoints separated by semicolons. Use the following as an example: etcd://myetc1.company.com:2379;etcd://myetc2.company.com.2379. Note: If the `etcdAuth` key is set to 'Disable HTTPS', you must provide HTTP endpoints."
+  type: string
+  label: "Endpoint address"
+  required: true
+  group: "Key value store parameters (Required)"
+
+- variable: etcd.ca
+  show_if: "etcdAuth=Certificate Auth"
+  description: "Name of CA file for ETCD authentication. Example: etcd-ca.crt. Follow https://docs.portworx.com/scheduler/kubernetes/etcd-certs-using-secrets.html to create a Kubernetes secret for the etcd certs."
+  type: string
+  required: true
+  label: "ETCD CA file"
+  group: "Key value store security Parameters (Details in README)"
+
+- variable: etcd.cert
+  show_if: "etcdAuth=Certificate Auth"
+  description: "Name of certificate for ETCD authentication. Example: etcd.crt"
+  type: string
+  required: true
+  label: "ETCD cert file"
+  group: "Key value store security Parameters (Details in README)"
+
+- variable: etcd.key
+  show_if: "etcdAuth=Certificate Auth"
+  description: "Name of certificate key for ETCD authentication Example: etcd.key"
+  type: string
+  required: true
+  label: "ETCD cert key file"
+  group: "Key value store security Parameters (Details in README)"
+
+- variable: etcd.credentials
+  show_if: "etcdAuth=Password Auth"
+  description: "Username and password for ETCD authentication in the form user:password. Not needed if using certificates."
+  type: string
+  required: true
+  label: "ETCD credentials"
+  group: "Key value store security Parameters (Details in README)"
+
+################################### Storage options ################################
+- variable: environment
+  description: "Select your environment"
+  label: "Environment"
+  type: enum
+  default: "OnPrem"
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "OnPrem"
+    - "Cloud"
+
+- variable: provider
+  show_if: "environment=Cloud"
+  description: "Select cloud platform"
+  label: "Cloud provider"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "AWS"
+    - "Google cloud/GKE"
+
+- variable: onpremStorage
+  show_if: "environment=OnPrem"
+  type: enum
+  default: "Automatically scan disks"
+  label: "Select type of OnPrem storage"
+  group: "Storage Parameters"
+  required: true
+  options:
+    - "Automatically scan disks"
+    - "Manually specify disks"
+
+- variable: deviceConfig
+  show_if: "environment=Cloud"
+  description: "If you plan to use EC2 instance storage or plan to manage EBS volumes your own way, select 'Consume unused' or 'Use Existing disks'."
+  label: "Select a type of disk"
+  type: enum
+  default: "Create Using a Spec"
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "Create Using a Spec"
+    - "Consume Unused"
+    - "Use Existing Disks"
+    -
+- variable: journalDevice
+  description: "This allows PX to create it’s own journal partition on the best drive to absorb PX metadata writes. Journal writes are small with frequent syncs and hence a separate journal partition will enable better performance. Use value 'auto' if you want Portworx to create it's own journal partition."
+  type: string
+  label: "Journal Device"
+  group: "Storage Parameters"
+
+############ Consume unused ##############
+- variable: usedrivesAndPartitions
+  show_if: "deviceConfig=Consume Unused||onpremStorage=Automatically scan disks"
+  label: "Use unmounted drives and partitions"
+  descrition: "Use unmounted disks even if they have a partition or filesystem on it. PX will never use a drive or partition that is mounted."
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+
+############ Use Exising Disks ##############
+- variable: existingDisk1
+  show_if: "deviceConfig=Use Existing Disks||onpremStorage=Manually specify disks"
+  label: "Drive/Device1"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk2
+  show_if: "deviceConfig=Use Existing Disks||onpremStorage=Manually specify disks"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk2
+  show_if: "addExistingDisk2=true"
+  label: "Drive/Device2"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk3
+  show_if: "addExistingDisk2=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk3
+  show_if: "addExistingDisk3=true"
+  label: "Drive/Device3"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk4
+  show_if: "addExistingDisk3=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk4
+  show_if: "addExistingDisk4=true"
+  label: "Drive/Device4"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+- variable: addExistingDisk5
+  show_if: "addExistingDisk4=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: existingDisk5
+  show_if: "addExistingDisk5=true"
+  label: "Drive/Device5"
+  description: "Enter the block/device name; eg: /dev/sda"
+  type: string
+  required: true
+  group: "Storage Parameters"
+
+##################################################### Cloud ################################
+
+##################################################### AWS ################################
+
+### Section 1 AWS
+- variable: drive_1.aws.type
+  show_if: "provider=AWS&&deviceConfig=Create Using a Spec"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  default: "GP2"
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+  - "GP2"
+  - "IO1"
+  subquestions:
+  - variable: drive_1.aws.iops
+    required: true
+    description: "*IOPS required from EBS volume"
+    type: int
+    label: IOPS
+
+- variable: drive_1.aws.size
+  show_if: "provider=AWS&&deviceConfig=Create Using a Spec"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  default: 150
+  required: true
+  group: "Storage Parameters"
+
+### Section 2 AWS
+- variable: addEBSDrive_2
+  show_if: "provider=AWS&&deviceConfig=Create Using a Spec"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_2.aws.type
+  show_if: "addEBSDrive_2=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_2.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_2.aws.size
+  show_if: "addEBSDrive_2=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+  ### Section 3 AWS
+- variable: addEBSDrive_3
+  show_if: "addEBSDrive_2=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_3.aws.type
+  show_if: "addEBSDrive_3=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_3.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_3.aws.size
+  show_if: "addEBSDrive_3=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+### Section 4 AWS
+- variable: addEBSDrive_4
+  show_if: "addEBSDrive_3=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_4.aws.type
+  show_if: "addEBSDrive_4=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_4.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_4.aws.size
+  show_if: "addEBSDrive_4=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 5 AWS
+- variable: addEBSDrive_5
+  show_if: "addEBSDrive_4=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_5.aws.type
+  show_if: "addEBSDrive_5=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_5.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_5.aws.size
+  show_if: "addEBSDrive_5=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 6 AWS
+- variable: addEBSDrive_6
+  show_if: "addEBSDrive_5=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_6.aws.type
+  show_if: "addEBSDrive_6=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_6.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_6.aws.size
+  show_if: "addEBSDrive_6=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 7 AWS
+- variable: addEBSDrive_7
+  show_if: "addEBSDrive_6=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_7.aws.type
+  show_if: "addEBSDrive_7=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_7.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_7.aws.size
+  show_if: "addEBSDrive_7=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 8 AWS
+- variable: addEBSDrive_8
+  show_if: "addEBSDrive_7=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_8.aws.type
+  show_if: "addEBSDrive_8=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_8.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_8.aws.size
+  show_if: "addEBSDrive_8=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 9 AWS
+- variable: addEBSDrive_9
+  show_if: "addEBSDrive_8=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_9.aws.type
+  show_if: "addEBSDrive_9=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_9.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_9.aws.size
+  show_if: "addEBSDrive_9=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+### Section 10 AWS
+- variable: addEBSDrive_10
+  show_if: "addEBSDrive_9=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_10.aws.type
+  show_if: "addEBSDrive_10=true"
+  description: "Select the type of EBS volume"
+  label: "EBS volume"
+  type: enum
+  required: true
+  show_subquestion_if: "IO1"
+  group: "Storage Parameters"
+  options:
+    - "GP2"
+    - "IO1"
+  subquestions:
+    - variable: drive_10.aws.iops
+      required: true
+      description: "*IOPS required from EBS volume"
+      type: int
+      label: IOPS
+
+- variable: drive_10.aws.size
+  show_if: "addEBSDrive_10=true"
+  description: "Volume size"
+  label: "Size"
+  required: true
+  type: int
+  group: "Storage Parameters"
+
+##################################################### GOOGLE CLOUD ################################
+
+#### Section 1 GC
+- variable: drive_1.gc.type
+  show_if: "provider=Google cloud/GKE&&deviceConfig=Create Using a Spec"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  default: "standard"
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_1.gc.size
+  show_if: "provider=Google cloud/GKE&&deviceConfig=Create Using a Spec"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  default: 150
+  required: true
+  group: "Storage Parameters"
+
+#### Section 2 GC
+- variable: addGCDrive_2
+  show_if: "provider=Google cloud/GKE&&deviceConfig=Create Using a Spec"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_2.gc.type
+  show_if: "addGCDrive_2=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_2.gc.size
+  show_if: "addGCDrive_2=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 3 GC
+- variable: addGCDrive_3
+  show_if: "addGCDrive_2=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_3.gc.type
+  show_if: "addGCDrive_3=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_3.gc.size
+  show_if: "addGCDrive_3=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 4 GC
+- variable: addGCDrive_4
+  show_if: "addGCDrive_3=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_4.gc.type
+  show_if: "addGCDrive_4=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_4.gc.size
+  show_if: "addGCDrive_4=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 5 GC
+- variable: addGCDrive_5
+  show_if: "addGCDrive_4=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_5.gc.type
+  show_if: "addGCDrive_5=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_5.gc.size
+  show_if: "addGCDrive_5=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 6 GC
+- variable: addGCDrive_6
+  show_if: "addGCDrive_5=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_6.gc.type
+  show_if: "addGCDrive_6=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_6.gc.size
+  show_if: "addGCDrive_6=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 7 GC
+- variable: addGCDrive_7
+  show_if: "addGCDrive_6=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_7.gc.type
+  show_if: "addGCDrive_6=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_7.gc.size
+  show_if: "addGCDrive_7=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 8 GC
+- variable: addGCDrive_8
+  show_if: "addGCDrive_7=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_8.gc.type
+  show_if: "addGCDrive_8=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_8.gc.size
+  show_if: "addGCDrive_8=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 9 GC
+- variable: addGCDrive_9
+  show_if: "addGCDrive_8=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_9.gc.type
+  show_if: "addGCDrive_9=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_9.gc.size
+  show_if: "addGCDrive_9=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+#### Section 10 GC
+- variable: addGCDrive_10
+  show_if: "addGCDrive_9=true"
+  label: "Add another drive?"
+  type: boolean
+  default: false
+  group: "Storage Parameters"
+
+- variable: drive_10.gc.type
+  show_if: "addGCDrive_10=true"
+  description: "Select volume type"
+  label: "Volume"
+  type: enum
+  required: true
+  group: "Storage Parameters"
+  options:
+    - "standard"
+    - "ssd"
+
+- variable: drive_10.gc.size
+  show_if: "addGCDrive_10=true"
+  description: "Volume size"
+  label: "Size"
+  type: int
+  required: true
+  group: "Storage Parameters"
+
+- variable: maxStorageNodes
+  show_if: "environment=Cloud&&deviceConfig=Create Using a Spec"
+  description: "Max storage nodes per availability zone"
+  label: "Max storage nodes (Optional)"
+  type: int
+  group: "Storage Parameters"
+
+################################### Network options ################################
+- variable: dataInterface
+  description: "Specify your data network interface (example: `eth1`). If set to `auto`, Portworx will automatically select the first routable interface."
+  type: string
+  label: "Data Network Interface"
+  default: auto
+  group: "Network Parameters"
+- variable: managementInterface
+  description: "Specify your management network interface (example: `eth1`). If set to `auto`, Portworx will automatically select the first routable interface."
+  type: string
+  default: auto
+  label: "Management Network Interface"
+  group: "Network Parameters"
+
+################################### Platform options ################################
+- variable: platformOptions
+  type: enum
+  label: "Platform"
+  group: "Platform Parameters"
+  options:
+    - "AKS"
+    - "EKS"
+    - "GKE"
+
+################################### Registry settings options ################################
+- variable: customRegistry
+  label: "Use a custom container registry?"
+  type: boolean
+  default: false
+  group: "Container Registry Parameters"
+
+- variable: registrySecret
+  show_if: "customRegistry=true"
+  description: "Specify a custom Kubernetes secret that will be used to authenticate with a container registry. Must be defined in kube-system namespace. (example: regcred)"
+  type: string
+  label: "Registry Kubernetes Secret"
+  group: "Container Registry Parameters"
+- variable: customRegistryURL
+  show_if: "customRegistry=true"
+  description: "Specify a custom container registry server (including repository) that will be used instead of index.docker.io to download Docker images. (example: dockerhub.acme.net:5443 or myregistry.com/myrepository/)"
+  label: "Custom Registry URL"
+  type: string
+  group: "Container Registry Parameters"
+
+
+
+################################## Optional features ############################
+# TODO: Once we have a stable CSI release, we will default this to enabled
+#- variable: csi
+#  description: "Select if you want to enable CSI (Container Storage Interface). CSI is still in ALPHA."
+#  type: boolean
+#  label: "Enable CSI"
+#  default: false
+#  required: false
+#  group: "Advanced parameters"
+
+- variable: storkVersion
+  default: "2.4.2.1"
+  label: "Stork version"
+  type: string
+  group: "Advanced parameters"
+
+- variable: lighthouseVersion
+  default: "2.0.7"
+  type: string
+  label: "Lighthouse version"
+  group: "Advanced parameters"
+
+- variable: envVars
+  label: "Environment variables"
+  description: "Enter your environment variables separated by semicolons (example: API_SERVER=http://lighthouse-new.portworx.com;MYENV1=val1;MYENV2=val2). These environment variables will be exported to Portworx."
+  type: string
+  group: "Advanced parameters"
+
+- variable: imageVersion
+  default: "2.5.5"
+  type: string
+  label: Portworx version to be deployed.
+  group: "Advanced parameters"
+
+- variable: clusterName
+  type: string
+  label: Portworx cluster name
+  default: mycluster
+  group: "Advanced parameters"

--- a/charts/portworx/v1.0.10/templates/NOTES.txt
+++ b/charts/portworx/v1.0.10/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Your Release is named {{ .Release.Name | quote }}
+
+Portworx Pods should be running on each node in your cluster.
+
+Portworx would create a unified pool of the disks attached to your Kubernetes nodes. No further action should be required and you are ready to consume Portworx Volumes as part of your application data requirements.
+
+For further information on usage of the Portworx, refer to following doc pages.
+
+- For dynamically provisioning volumes: https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
+- For preprovisioned volumes: https://docs.portworx.com/scheduler/kubernetes/preprovisioned-volumes.html
+- To use Stork (Storage Orchestration Runtime for Kubernetes) for hyperconvergence and snapshots: https://docs.portworx.com/scheduler/kubernetes/stork.html
+- For stateful application solutions using Portworx: https://docs.portworx.com/scheduler/kubernetes/k8s-px-app-samples.html
+- For interactive tutorials on using Portworx on Kubernetes: https://docs.portworx.com/scheduler/kubernetes/px-k8s-interactive.html

--- a/charts/portworx/v1.0.10/templates/_helpers.tpl
+++ b/charts/portworx/v1.0.10/templates/_helpers.tpl
@@ -1,0 +1,417 @@
+{{/* Gets the correct API Version based on the version of the cluster
+*/}}
+
+{{- define "rbac.apiVersion" -}}
+{{- if semverCompare ">= 1.8-0" .Capabilities.KubeVersion.GitVersion -}}
+"rbac.authorization.k8s.io/v1"
+{{- else -}}
+"rbac.authorization.k8s.io/v1beta1"
+{{- end -}}
+{{- end -}}
+
+
+{{- define "px.labels" -}}
+chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+heritage: {{ .Release.Service | quote }}
+release: {{ .Release.Name | quote }}
+{{- end -}}
+
+{{- define "driveOpts" }}
+{{ $v := .Values.installOptions.drives | split "," }}
+{{$v._0}}
+{{- end -}}
+
+{{- define "px.kubernetesVersion" -}}
+{{$version := .Capabilities.KubeVersion.GitVersion | regexFind "^v\\d+\\.\\d+\\.\\d+"}}{{$version}}
+{{- end -}}
+
+
+{{- define "px.getImage" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{- if .Values.openshiftInstall -}}
+            {{ cat (trim .Values.customRegistryURL) "/px-monitor" | replace " " ""}}
+        {{- else -}}
+            {{ cat (trim .Values.customRegistryURL) "/oci-monitor" | replace " " ""}}
+        {{- end -}}
+    {{- else -}}
+        {{- if .Values.openshiftInstall -}}
+            {{cat (trim .Values.customRegistryURL) "/portworx/px-monitor" | replace " " ""}}
+        {{- else -}}
+            {{cat (trim .Values.customRegistryURL) "/portworx/oci-monitor" | replace " " ""}}
+        {{- end -}}
+    {{- end -}}
+{{- else -}}
+    {{- if .Values.openshiftInstall -}}
+        {{ "registry.connect.redhat.com/portworx/px-monitor" }}
+    {{- else -}}
+        {{ "portworx/oci-monitor" }}
+    {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getStorkImage" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ cat (trim .Values.customRegistryURL) "/stork" | replace " " ""}}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/openstorage/stork" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+    {{ "openstorage/stork" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getk8sImages" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/gcr.io/google_containers" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "gcr.io/google_containers" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getcsiImages" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/quay.io/k8scsi" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "quay.io/k8scsi" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getLighthouseImages" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/portworx/" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "portworx" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.getPauseImage" -}}
+{{- if (.Values.customRegistryURL) -}}
+    {{- if (eq "/" (.Values.customRegistryURL | regexFind "/")) -}}
+        {{ trim .Values.customRegistryURL }}
+    {{- else -}}
+        {{cat (trim .Values.customRegistryURL) "/k8s.gcr.io" | replace " " ""}}
+    {{- end -}}
+{{- else -}}
+        {{ "k8s.gcr.io" }}
+{{- end -}}
+{{- end -}}
+
+{{- define "px.registryConfigType" -}}
+{{- if semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion -}}
+".dockerconfigjson"
+{{- else -}}
+".dockercfg"
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use for hooks
+*/}}
+{{- define "px.hookServiceAccount" -}}
+{{- if .Values.serviceAccount.hook.create -}}
+    {{- printf "%s-hook" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.hook.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the cluster role to use for hooks
+*/}}
+{{- define "px.hookClusterRole" -}}
+{{- if .Values.serviceAccount.hook.create -}}
+    {{- printf "%s-hook" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.hook.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the cluster role binding to use for hooks
+*/}}
+{{- define "px.hookClusterRoleBinding" -}}
+{{- if .Values.serviceAccount.hook.create -}}
+    {{- printf "%s-hook" .Chart.Name | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.hook.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+ String concatenation for drives in AWS section
+*/}}
+{{- define "px.storage" -}}
+{{- $awsType1 := .Values.drive_1.aws.type -}}
+{{- $awsType2 := .Values.drive_2.aws.type -}}
+{{- $awsType3 := .Values.drive_3.aws.type -}}
+{{- $awsType4 := .Values.drive_4.aws.type -}}
+{{- $awsType5 := .Values.drive_5.aws.type -}}
+{{- $awsType6 := .Values.drive_6.aws.type -}}
+{{- $awsType7 := .Values.drive_7.aws.type -}}
+{{- $awsType8 := .Values.drive_8.aws.type -}}
+{{- $awsType9 := .Values.drive_9.aws.type -}}
+{{- $awsType10 := .Values.drive_10.aws.type -}}
+
+{{- $awsSize1 := .Values.drive_1.aws.size -}}
+{{- $awsSize2 := .Values.drive_2.aws.size -}}
+{{- $awsSize3 := .Values.drive_3.aws.size -}}
+{{- $awsSize4 := .Values.drive_4.aws.size -}}
+{{- $awsSize5 := .Values.drive_5.aws.size -}}
+{{- $awsSize6 := .Values.drive_6.aws.size -}}
+{{- $awsSize7 := .Values.drive_7.aws.size -}}
+{{- $awsSize8 := .Values.drive_8.aws.size -}}
+{{- $awsSize9 := .Values.drive_9.aws.size -}}
+{{- $awsSize10 := .Values.drive_10.aws.size -}}
+
+{{- $awsIops1 := .Values.drive_1.aws.iops -}}
+{{- $awsIops2 := .Values.drive_2.aws.iops -}}
+{{- $awsIops3 := .Values.drive_3.aws.iops -}}
+{{- $awsIops4 := .Values.drive_4.aws.iops -}}
+{{- $awsIops5 := .Values.drive_5.aws.iops -}}
+{{- $awsIops6 := .Values.drive_6.aws.iops -}}
+{{- $awsIops7 := .Values.drive_7.aws.iops -}}
+{{- $awsIops8 := .Values.drive_8.aws.iops -}}
+{{- $awsIops9 := .Values.drive_9.aws.iops -}}
+{{- $awsIops10 := .Values.drive_10.aws.iops -}}
+
+{{- $gcType1 := .Values.drive_1.gc.type -}}
+{{- $gcType2 := .Values.drive_2.gc.type -}}
+{{- $gcType3 := .Values.drive_3.gc.type -}}
+{{- $gcType4 := .Values.drive_4.gc.type -}}
+{{- $gcType5 := .Values.drive_5.gc.type -}}
+{{- $gcType6 := .Values.drive_6.gc.type -}}
+{{- $gcType7 := .Values.drive_7.gc.type -}}
+{{- $gcType8 := .Values.drive_8.gc.type -}}
+{{- $gcType9 := .Values.drive_9.gc.type -}}
+{{- $gcType10 := .Values.drive_10.gc.type -}}
+
+{{- $gcSize1 := .Values.drive_1.gc.size -}}
+{{- $gcSize2 := .Values.drive_2.gc.size -}}
+{{- $gcSize3 := .Values.drive_3.gc.size -}}
+{{- $gcSize4 := .Values.drive_4.gc.size -}}
+{{- $gcSize5 := .Values.drive_5.gc.size -}}
+{{- $gcSize6 := .Values.drive_6.gc.size -}}
+{{- $gcSize7 := .Values.drive_7.gc.size -}}
+{{- $gcSize8 := .Values.drive_8.gc.size -}}
+{{- $gcSize9 := .Values.drive_9.gc.size -}}
+{{- $gcSize10 := .Values.drive_10.gc.size -}}
+
+{{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
+{{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
+{{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
+
+{{- if eq "OnPrem" .Values.environment -}}
+    {{- if eq "Manually specify disks" .Values.onpremStorage }}
+            {{- if ne "none" .Values.existingDisk1 }}
+                "-s", "{{- .Values.existingDisk1 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk2 -}}
+                "-s", "{{- .Values.existingDisk2 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk3 -}}
+                "-s", "{{- .Values.existingDisk3 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk4 -}}
+                "-s", "{{- .Values.existingDisk4 }}",
+            {{- end }}
+            {{- if ne "none" .Values.existingDisk5 }}
+                "-s", "{{- .Values.existingDisk5 }}",
+            {{- end }}
+    {{- else if eq "Automatically scan disks" .Values.onpremStorage -}}
+       {{- if or $usedrivesAndPartitions $deployEnvironmentIKS }}
+           "-f",
+       {{- end }}
+       {{- if eq $usedrivesAndPartitions true }}
+           "-A",
+       {{- else }}
+           "-a",
+       {{- end -}}
+    {{- end -}}
+
+{{- else if eq "Cloud" .Values.environment -}}
+    {{- if eq "Consume Unused" .Values.deviceConfig -}}
+       {{- if or $usedrivesAndPartitions $deployEnvironmentIKS }}
+           "-f",
+       {{- end }}
+       {{- if eq $usedrivesAndPartitions true }}
+           "-A",
+       {{- else }}
+           "-a",
+       {{- end -}}
+    {{- end }}
+{{/*------------------- ----------------- Google cloud/GKE -------------- --------------- */}}
+    {{- if eq "Google cloud/GKE" .Values.provider -}}
+        {{- if eq "Use Existing Disks" .Values.deviceConfig -}}
+            {{- if .Values.existingDisk1 -}}
+                "-s", "{{- .Values.existingDisk1 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk2 -}}
+                "-s", "{{- .Values.existingDisk2 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk3 -}}
+                "-s", "{{- .Values.existingDisk3 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk4 -}}
+                "-s", "{{- .Values.existingDisk4 -}}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk5 -}}
+                "-s", "{{- .Values.existingDisk5 -}}",
+            {{- end -}}
+        {{- else if eq "Create Using a Spec" .Values.deviceConfig -}}
+            {{- if $gcType1 }}
+                "-s", "type=pd-{{$gcType1 | lower}},size={{$gcSize1}}",
+            {{- end }}
+            {{/*------------------- DRIVE 2 --------------- */}}
+            {{- if $gcType2 -}}
+                "-s", "type=pd-{{$gcType2 | lower}},size={{$gcSize2}}",
+            {{- end }}
+            {{/*------------------- DRIVE 3 --------------- */}}
+            {{- if $gcType3 -}}
+                "-s", "type=pd-{{$gcType3 | lower}},size={{$gcSize3}}",
+            {{- end }}
+            {{/*------------------- DRIVE 4 --------------- */}}
+            {{- if $gcType4 -}}
+                "-s", "type=pd-{{$gcType4 | lower}},size={{$gcSize4}}",
+            {{- end }}
+            {{/*------------------- DRIVE 5 --------------- */}}
+            {{- if $gcType5 -}}
+                "-s", "type=pd-{{$gcType5 | lower}},size={{$gcSize5}}",
+            {{- end }}
+            {{/*------------------- DRIVE 6 --------------- */}}
+            {{- if $gcType6 -}}
+                "-s", "type=pd-{{$gcType6 | lower}},size={{$gcSize6}}",
+            {{- end }}
+            {{/*------------------- DRIVE 7 --------------- */}}
+            {{- if $gcType7 -}}
+                "-s", "type=pd-{{$gcType7 | lower}},size={{$gcSize7}}",
+            {{- end }}
+            {{/*------------------- DRIVE 8 --------------- */}}
+            {{- if $gcType8 -}}
+                "-s", "type=pd-{{$gcType8 | lower}},size={{$gcSize8}}",
+            {{- end }}
+            {{/*------------------- DRIVE 9 --------------- */}}
+            {{- if $gcType9 -}}
+                "-s", "type=pd-{{$gcType9 | lower}},size={{$gcSize9}}",
+            {{- end }}
+            {{/*------------------- DRIVE 10 --------------- */}}
+            {{- if $gcType10 -}}
+                "-s", "type=pd-{{$gcType1 | lower}},size={{$gcSize10}}",
+            {{- end }}
+        {{- end -}}
+{{/*------------------- ----------------- AWS -------------- --------------- */}}
+    {{- else if eq "AWS" .Values.provider -}}
+        {{- if eq "Use Existing Disks" .Values.deviceConfig -}}
+            {{- if ne "none" .Values.existingDisk1 -}}
+                "-s", "{{ .Values.existingDisk1 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk2 -}}
+                "-s", "{{ .Values.existingDisk2 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk3 -}}
+                "-s", "{{ .Values.existingDisk3 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk4 -}}
+                "-s", "{{ .Values.existingDisk4 }}",
+            {{- end -}}
+            {{- if ne "none" .Values.existingDisk5 -}}
+                "-s", "{{ .Values.existingDisk5 }}",
+            {{- end -}}
+        {{- else if eq "Create Using a Spec" .Values.deviceConfig -}}
+            {{- if ne "none" $awsType1 }}
+                {{- if eq "GP2" $awsType1 -}}
+                    "-s", "type={{$awsType1 | lower}},size={{$awsSize1}}",
+                {{- else if eq "IO1" $awsType1 -}}
+                    "-s", "type={{$awsType1 | lower}},size={{$awsSize1}},iops={{$awsIops1}}",
+                {{- end }}
+            {{- end }}
+            {{/*------------------- DRIVE 2 --------------- */}}
+            {{- if ne "none" $awsType2 -}}
+                {{- if eq "GP2" $awsType2 -}}
+                    "-s", "type={{$awsType2 | lower}},size={{$awsSize2}}",
+                {{- else if eq "IO1" $awsType2 -}}
+                    "-s", "type={{$awsType2 | lower}},size={{$awsSize2}},iops={{$awsIops2}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 3 --------------- */}}
+            {{- if ne "none" $awsType3 }}
+                {{- if eq "GP2" $awsType3 -}}
+                    "-s", "type={{$awsType3 | lower}},size={{$awsSize3}}",
+                {{- else if eq "IO1" $awsType3 -}}
+                    "-s", "type={{$awsType3 | lower}},size={{$awsSize3}},iops={{$awsIops3}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 4 --------------- */}}
+            {{- if ne "none" $awsType4 }}
+                {{- if eq "GP2" $awsType4 -}}
+                    "-s", "type={{$awsType4 | lower}},size={{$awsSize4}}",
+                {{- else if eq "IO1" $awsType4 -}}
+                    "-s", "type={{$awsType4 | lower}},size={{$awsSize4}},iops={{$awsIops4}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 5 --------------- */}}
+            {{- if ne "none" $awsType5 }}
+                {{- if eq "GP2" $awsType5 -}}
+                    "-s", "type={{$awsType5 | lower}},size={{$awsSize5}}",
+                {{- else if eq "IO1" $awsType5 -}}
+                    "-s", "type={{$awsType5 | lower}},size={{$awsSize5}},iops={{$awsIops5}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 6 --------------- */}}
+            {{- if ne "none" $awsType6 }}
+                {{- if eq "GP2" $awsType6 -}}
+                    "-s", "type={{$awsType6 | lower}},size={{$awsSize6}}",
+                {{- else if eq "IO1" $awsType6 -}}
+                    "-s", "type={{$awsType6 | lower}},size={{$awsSize6}},iops={{$awsIops6}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 7 --------------- */}}
+            {{- if ne "none" $awsType7 }}
+                {{- if eq "GP2" $awsType7 -}}
+                    "-s", "type={{$awsType7 | lower}},size={{$awsSize7}}",
+                {{- else if eq "IO1" $awsType7 -}}
+                    "-s", "type={{$awsType7 | lower}},size={{$awsSize7}},iops={{$awsIops7}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 8 --------------- */}}
+            {{- if ne "none" $awsType8 }}
+                {{- if eq "GP2" $awsType8 -}}
+                    "-s", "type={{$awsType8 | lower}},size={{$awsSize8}}",
+                {{- else if eq "IO1" $awsType8 -}}
+                    "-s", "type={{$awsType8 | lower}},size={{$awsSize8}},iops={{$awsIops8}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 9 --------------- */}}
+            {{- if ne "none" $awsType9 }}
+                {{- if eq "GP2" $awsType9 -}}
+                    "-s", "type={{$awsType9 | lower}},size={{$awsSize9}}",
+                {{- else if eq "IO1" $awsType9 -}}
+                    "-s", "type={{$awsType9 | lower}},size={{$awsSize9}},iops={{$awsIops9}}",
+                {{- end -}}
+            {{- end }}
+            {{/*------------------- DRIVE 10 --------------- */}}
+            {{- if ne "none" $awsType10 }}
+                {{- if eq "GP2" $awsType10 -}}
+                    "-s", "type={{$awsType10 | lower}},size={{$awsSize10}}",
+                {{- else if eq "IO1" $awsType10 -}}
+                    "-s", "type={{$awsType10 | lower}},size={{$awsSize10}},iops={{$awsIops10}}",
+                {{- end -}}
+            {{- end }}
+        {{- end -}}
+        {{- end -}}
+    {{- end -}}
+{{- end }}
+

--- a/charts/portworx/v1.0.10/templates/hooks/post-delete/px-postdelete-unlabelnode.yaml
+++ b/charts/portworx/v1.0.10/templates/hooks/post-delete/px-postdelete-unlabelnode.yaml
@@ -1,0 +1,40 @@
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kube-system
+  name: px-hook-postdelete-unlabelnode
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{ if semverCompare ">= 1.8-0" .Capabilities.KubeVersion.GitVersion }}
+  backoffLimit: 0
+{{ else }}
+  activeDeadlineSeconds: 30
+{{ end }}
+  template:
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      restartPolicy: Never
+      serviceAccountName: {{ template "px.hookServiceAccount" . }}
+      containers:
+      - name: post-delete-job
+        {{- if eq $customRegistryURL "none" }}
+        image: "lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- else}}
+        image: "{{ $customRegistryURL }}/lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- end}}
+        args: ['label','nodes','--all','px/enabled-']

--- a/charts/portworx/v1.0.10/templates/hooks/pre-delete/px-predelete-nodelabel.yaml
+++ b/charts/portworx/v1.0.10/templates/hooks/pre-delete/px-predelete-nodelabel.yaml
@@ -1,0 +1,40 @@
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: kube-system
+  name: px-hook-predelete-nodelabel
+  labels:
+    heritage: {{.Release.Service | quote }}
+    release: {{.Release.Name | quote }}
+    chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+{{ if semverCompare ">= 1.8-0" .Capabilities.KubeVersion.GitVersion }}
+  backoffLimit: 0
+{{ else }}
+  activeDeadlineSeconds: 30
+{{ end }}
+  template:
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      serviceAccountName: {{ template "px.hookServiceAccount" . }}
+      restartPolicy: Never
+      containers:
+      - name: pre-delete-job
+        {{- if eq $customRegistryURL "none" }}
+        image: "lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- else}}
+        image: "{{ $customRegistryURL }}/lachlanevenson/k8s-kubectl:{{ template "px.kubernetesVersion" . }}"
+        {{- end}}
+        args: ['label','nodes','--all','px/enabled=remove','--overwrite']

--- a/charts/portworx/v1.0.10/templates/portworx-controller.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-controller.yaml
@@ -1,0 +1,128 @@
+{{- if or ((.Values.openshiftInstall) and (eq .Values.openshiftInstall true)) ((.Values.AKSorEKSInstall) and (eq .Values.AKSorEKSInstall true)) ((.Capabilities.KubeVersion.GitVersion | regexMatch "gke")) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: portworx-pvc-controller-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+   name: portworx-pvc-controller-role
+rules:
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["create","delete","get","list","update","watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "update", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims/status"]
+  verbs: ["update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "delete", "get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "services"]
+  verbs: ["create", "delete", "get", "update"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["watch"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch", "update"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get", "create"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "create", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: portworx-pvc-controller-role-binding
+subjects:
+- kind: ServiceAccount
+  name: portworx-pvc-controller-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: portworx-pvc-controller-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: portworx-pvc-controller
+  namespace: kube-system
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: portworx-pvc-controller
+        tier: control-plane
+    spec:
+      {{- if not (empty .Values.registrySecret) }}
+      imagePullSecrets:
+        - name: {{ .Values.registrySecret }}
+     {{- end }}
+      containers:
+      - command:
+        - kube-controller-manager
+        - --leader-elect=true
+        - --address=0.0.0.0
+        - --controllers=persistentvolume-binder,persistentvolume-expander
+        - --use-service-account-credentials=true
+        - --leader-elect-resource-lock=configmaps
+        image: "{{ template "px.getk8sImages" . }}/kube-controller-manager-amd64:{{ template "px.kubernetesVersion" . }}"
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            host: 127.0.0.1
+            path: /healthz
+            port: 10252
+            scheme: HTTP
+          initialDelaySeconds: 15
+          timeoutSeconds: 15
+        name: portworx-pvc-controller-manager
+        resources:
+          requests:
+            cpu: 200m
+      hostNetwork: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                    - portworx-pvc-controller
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: portworx-pvc-controller-account
+{{- end }}

--- a/charts/portworx/v1.0.10/templates/portworx-csi.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-csi.yaml
@@ -1,0 +1,96 @@
+{{- if (.Values.csi) and (eq .Values.csi true)}}
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: px-csi-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+   name: px-csi-role
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["persistentvolumes"]
+  verbs: ["get", "list", "watch", "create", "delete", "update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["volumeattachments"]
+  verbs: ["get", "list", "watch", "update"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: px-csi-role-binding
+subjects:
+- kind: ServiceAccount
+  name: px-csi-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: px-csi-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: px-csi-service
+  namespace: kube-system
+spec:
+  clusterIP: None
+---
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: px-csi-ext
+  namespace: kube-system
+spec:
+  serviceName: "px-csi-service"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: px-csi-driver
+    spec:
+      serviceAccount: px-csi-account
+      containers:
+        - name: csi-external-provisioner
+          imagePullPolicy: Always
+          image: "{{ template "px.getcsiProvisioner" . }}/csi-provisioner:v0.2.0"
+          args:
+            - "--v=5"
+            - "--provisioner=com.openstorage.pxd"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: csi-attacher
+          imagePullPolicy: Always
+          image: "{{ template "px.getcsiImages" . }}/csi-attacher:v0.2.0"
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+      volumes:
+        - name: socket-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/com.openstorage.pxd
+            type: DirectoryOrCreate
+{{- end }}

--- a/charts/portworx/v1.0.10/templates/portworx-ds.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-ds.yaml
@@ -1,0 +1,436 @@
+{{/* Setting defaults if they are omitted. */}}
+{{- $deployEnvironmentIKS := .Capabilities.KubeVersion.GitVersion | regexMatch "IKS" }}
+{{- $usefileSystemDrive := .Values.usefileSystemDrive | default false }}
+{{- $usedrivesAndPartitions := .Values.usedrivesAndPartitions | default false }}
+{{- $secretType := .Values.secretType | default "k8s" }}
+{{- $journalDevice := .Values.journalDevice | default "none" }}
+{{- $maxStorageNodes := .Values.maxStorageNodes | default "none" }}
+{{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+{{- $registrySecret := .Values.registrySecret | default "none" }}
+
+{{- $dataInterface := .Values.dataInterface | default "none" }}
+{{- $managementInterface := .Values.managementInterface | default "none" }}
+
+{{- $envVars := .Values.envVars | default "none" }}
+{{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
+
+{{- $pksInstall := .Values.pksInstall | default false }}
+{{- $internalKVDB := .Values.etcdType | default "none" }}
+{{- $csi := .Values.csi | default false }}
+
+{{- $etcdCredentials := .Values.etcd.credentials | default "none:none" }}
+{{- $etcdCertPath := .Values.etcd.ca | default "none" }}
+{{- $etcdCA := .Values.etcd.ca | default "none" }}
+{{- $etcdCert := .Values.etcd.cert | default "none" }}
+{{- $etcdKey := .Values.etcd.key | default "none" }}
+{{- $consulToken := .Values.consul.token | default "none" }}
+{{- $misc := .Values.misc | default "" | split " " }}
+{{- $etcdEndPoints := .Values.kvdb }}
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: portworx
+  namespace: kube-system
+  labels:
+    name: portworx
+spec:
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      name: portworx
+      app: portworx
+  template:
+    metadata:
+      labels:
+        app: portworx
+        name: portworx
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: px/enabled
+                operator: NotIn
+                values:
+                - "false"
+              {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+              - key: openshift-infra
+                operator: DoesNotExist
+              {{- else if (not .Values.deployOnMaster) or (eq .Values.deployOnMaster false)}}
+              - key: node-role.kubernetes.io/master
+                operator: DoesNotExist
+              {{- end }}
+      hostNetwork: true
+      hostPID: true
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      containers:
+      # {{ template "px.getImage"}}
+        - name: portworx
+          image: {{ template "px.getImage" . }}:{{ required "A valid Image tag is required in the SemVer format" .Values.imageVersion }}
+          terminationMessagePath: "/tmp/px-termination-log"
+          imagePullPolicy: Always
+          args:
+            [
+              {{ include "px.storage" . | indent 0 }}
+              {{- with .Values -}}
+              {{- if eq "Built-in" $internalKVDB  }}
+              "-b",
+              {{- end -}}
+
+              {{- if ne $journalDevice "none" }}
+              "-j", "{{ $journalDevice }}",
+              {{- end -}}
+
+              {{- if $etcdEndPoints -}}
+              "-k", "{{ regexReplaceAllLiteral "(;)" .kvdb "," }}",
+              {{- else }}
+                {{- if ne "Built-in" $internalKVDB }}
+                  {{- if eq "US region" .region }}
+                     "-k", "etcd:http://px-etcd1.portworx.com:2379,etcd:http://px-etcd2.portworx.com:2379,etcd:http://px-etcd3.portworx.com:2379",
+                  {{- else if eq "EU region" .region }}
+                     "-k", "etcd:http://px-eu-etcd1.portworx.com:2379,etcd:http://px-eu-etcd2.portworx.com:2379,etcd:http://px-eu-etcd3.portworx.com:2379",
+                  {{- else }}
+                    "{{ required "A valid kvdb url is required." .kvdb }}"
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+              "-c", "{{ required "Clustername cannot be empty" .clusterName }}",
+
+              {{- if ne $secretType "none" }}
+              "-secret_type", "{{ $secretType }}",
+              {{- else }}
+                {{- if $deployEnvironmentIKS }}
+              "-secret_type", "ibm-kp",
+                {{- end -}}
+              {{- end -}}
+
+              {{- if and (ne $dataInterface "none") (ne $dataInterface "auto")}}
+              "-d", "{{ $dataInterface }}",
+              {{- end -}}
+
+              {{- if and (ne $managementInterface "none") (ne $managementInterface "auto") }}
+              "-m", "{{ $managementInterface }}",
+              {{- end -}}
+
+              {{- if ne $etcdCredentials "none:none" }}
+              "-userpwd", "{{ $etcdCredentials }}",
+              {{- end -}}
+
+              {{- if ne $etcdCA "none" }}
+              "-ca", "/etc/pwx/etcdcerts/{{ $etcdCA }}",
+              {{- end -}}
+
+              {{- if ne $etcdCert "none" }}
+              "-cert", "/etc/pwx/etcdcerts/{{ $etcdCert }}",
+              {{- end -}}
+
+              {{- if ne $etcdKey "none" }}
+              "-key", "/etc/pwx/etcdcerts/{{ $etcdKey }}",
+              {{- end -}}
+
+              {{- if ne $consulToken "none" }}
+              "-acltoken", "{{ $consulToken }}",
+              {{- end -}}
+
+              {{- if .misc }}
+                {{- range $index, $name := $misc }}
+              "{{ $name }}",
+                {{- end }}
+              {{ end -}}
+
+              "-x", "kubernetes"
+            {{- end -}}
+            ]
+          env:
+            - name: "PX_TEMPLATE_VERSION"
+              value: "v2"
+              {{ if not (eq $envVars "none") }}
+              {{- $vars := $envVars | split ";" }}
+              {{- range $key, $val := $vars }}
+              {{-  $envVariable := $val | split "=" }}
+            - name: {{ $envVariable._0 | trim | quote }}
+              value: {{ $envVariable._1 | trim | quote }}
+              {{ end }}
+              {{- end }}
+
+           {{- if not (eq $registrySecret "none") }}
+            - name: REGISTRY_CONFIG
+              valueFrom:
+                secretKeyRef:
+                {{- if (semverCompare ">=1.9-0" .Capabilities.KubeVersion.GitVersion) or (.Values.openshiftInstall and semverCompare ">=1.8-0" .Capabilities.KubeVersion.GitVersion) }}
+                  key: ".dockerconfigjson"
+                {{- else }}
+                  key: ".dockercfg"
+                {{- end }}
+                  name: "{{ $registrySecret }}"
+            {{- end }}
+
+            {{- if eq $pksInstall true }}
+            - name: "PRE-EXEC"
+              value: "if [ ! -x /bin/systemctl ]; then apt-get update; apt-get install -y systemd; fi"
+            {{- end }}
+
+            {{- if eq $csi true }}
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/kubelet/plugins/com.openstorage.pxd/csi.sock
+            {{- end }}
+
+          livenessProbe:
+            periodSeconds: 30
+            initialDelaySeconds: 840 # allow image pull in slow networks
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+          {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
+              path: /health
+              port: 9015
+          {{- else }}
+              path: /v1/cluster/nodehealth
+              port: 9001
+          {{- end}}
+          securityContext:
+            privileged: true
+          volumeMounts:
+          {{- if not (eq $etcdCertPath "none") }}
+            - mountPath: /etc/pwx/etcdcerts
+              name: etcdcerts
+          {{- end }}
+            - name: dockersock
+              mountPath: /var/run/docker.sock
+            - name: containerdsock
+              mountPath: /run/containerd
+            - name: etcpwx
+              mountPath: /etc/pwx
+            - name: cores
+              mountPath: /var/cores
+          {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
+            - name: optpwx
+              mountPath: /opt/pwx
+            - name: sysdmount
+              mountPath: /etc/systemd/system
+            - name: journalmount1
+              mountPath: /var/run/log
+              readOnly: true
+            - name: journalmount2
+              mountPath: /var/log
+              readOnly: true
+            - name: dbusmount
+              mountPath: /var/run/dbus
+            - name: hostproc
+              mountPath: /host_proc
+          {{- else if eq (.Values.deploymentType | upper | lower) "docker" }}
+            - name: dev
+              mountPath: /dev
+            - name: optpwx
+              mountPath: /export_bin
+            - name: dockerplugins
+              mountPath: /run/docker/plugins
+            - name: hostproc
+              mountPath: /hostproc
+          {{- if semverCompare "< 1.10-0" .Capabilities.KubeVersion.GitVersion }}
+            - name: libosd
+              mountPath: /var/lib/osd:shared
+          {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+            - name: kubelet
+              mountPath: /var/lib/origin/openshift.local.volumes:shared
+          {{- else }}
+            - name: kubelet
+              mountPath: /var/lib/kubelet:shared
+          {{- end }}
+
+          {{- else }}
+            - name: libosd
+              mountPath: /var/lib/osd
+              mountPropagation: "Bidirectional"
+          {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+            - name: kubelet
+              mountPath: /var/lib/origin/openshift.local.volumes
+              mountPropagation: "Bidirectional"
+          {{- else }}
+            - name: kubelet
+              mountPath: /var/lib/kubelet
+              mountPropagation: "Bidirectional"
+          {{- end }}
+
+          {{- end }}
+
+          {{- if eq $isCoreOS true}}
+            - name: src
+              mountPath: /lib/modules
+          {{- else }}
+            - name: src
+              mountPath: /usr/src
+          {{- end }}
+          {{- end }}
+
+          {{- if eq $csi true }}
+        - name: csi-driver-registrar
+          imagePullPolicy: Always
+          {{- if eq $customRegistryURL "none" }}
+          image: "quay.io/k8scsi/driver-registrar:v0.2.0"
+          {{- else }}
+          image: "{{ $customRegistryURL }}/quay.io/k8scsi/driver-registrar:v0.2.0"
+          {{- end}}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - name: csi-driver-path
+              mountPath: /csi
+           {{- end }}
+
+      restartPolicy: Always
+      serviceAccountName: px-account
+      volumes:
+        {{- if ne $etcdCertPath "none" }}
+        - name: etcdcerts
+          secret:
+            secretName: px-etcd-certs
+            items:
+            - key: "{{ $etcdCA }}"
+              path: "{{ $etcdCA }}"
+            - key: "{{ $etcdCert }}"
+              path: "{{ $etcdCert }}"
+            - key: "{{ $etcdKey }}"
+              path: "{{ $etcdKey }}"
+        {{- end}}
+        - name: dockersock
+          hostPath:
+            path: {{if eq $pksInstall true}}/var/vcap/sys/run/docker/docker.sock{{else}}/var/run/docker.sock{{end}}
+        - name: containerdsock
+          hostPath:
+            path: {{if eq $pksInstall true}}/var/vcap/sys/run/containerd{{else}}/run/containerd{{end}}
+          {{- if eq $csi true}}
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/plugins/com.openstorage.pxd
+            type: DirectoryOrCreate
+          {{- end}}
+        - name: etcpwx
+          hostPath:
+            path: /etc/pwx
+        - name: cores
+          hostPath:
+            path: {{if eq $pksInstall true }}/var/vcap/store/cores{{else}}/var/cores{{end}}
+        {{- if eq (.Values.deploymentType | upper | lower) "oci" }}
+        - name: optpwx
+          hostPath:
+            path: {{if eq $pksInstall true }}/var/vcap/store/opt/pwx{{else}}/opt/pwx{{end}}
+        - name: sysdmount
+          hostPath:
+            path: /etc/systemd/system
+        - name: journalmount1
+          hostPath:
+            path: /var/run/log
+        - name: journalmount2
+          hostPath:
+            path: /var/log
+        - name: dbusmount
+          hostPath:
+            path: /var/run/dbus
+        - name: hostproc
+          hostPath:
+            path: /proc
+        {{- else if eq (.Values.deploymentType | upper | lower) "docker" }}
+        - name: libosd
+          hostPath:
+            path: /var/lib/osd
+        - name: optpwx
+          hostPath:
+            path: /opt/pwx/bin
+        - name: dev
+          hostPath:
+            path: /dev
+        {{- if (.Values.openshiftInstall) and (eq .Values.openshiftInstall true)}}
+        - name: kubelet
+          hostPath:
+            path: /var/lib/origin/openshift.local.volumes
+        {{- else }}
+        - name: kubelet
+          hostPath:
+            path: /var/lib/kubelet
+        {{- end }}
+        {{- if eq $isCoreOS true}}
+        - name: src
+          hostPath:
+            path: /lib/modules
+        {{- else }}
+        - name: src
+          hostPath:
+            path: /usr/src
+        {{- end }}
+        - name: dockerplugins
+          hostPath:
+            path: /run/docker/plugins
+        - name: hostproc
+          hostPath:
+            path: /proc
+        {{- end }}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: portworx-api
+  namespace: kube-system
+  labels:
+    name: portworx-api
+spec:
+  selector:
+    matchLabels:
+      name: portworx-api
+  minReadySeconds: 0
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+  template:
+    metadata:
+      labels:
+        name: portworx-api
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: px/enabled
+                    operator: NotIn
+                    values:
+                      - "false"
+                  - key: node-role.kubernetes.io/master
+                    operator: DoesNotExist
+      hostNetwork: true
+      hostPID: false
+      containers:
+        - name: portworx-api
+          image: "{{ template "px.getPauseImage" . }}/pause:3.1"
+          imagePullPolicy: Always
+          readinessProbe:
+            periodSeconds: 10
+            httpGet:
+              host: 127.0.0.1
+              path: /status
+              port: 9001
+      restartPolicy: Always
+      serviceAccountName: px-account

--- a/charts/portworx/v1.0.10/templates/portworx-lighthouse.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-lighthouse.yaml
@@ -1,0 +1,115 @@
+{{- if (.Values.lighthouse) and (eq .Values.lighthouse true) -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: px-lh-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+   name: px-lh-role
+   namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["nodes", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["stork.libopenstorage.org"]
+    resources: ["clusterpairs", "migrations", "groupvolumesnapshots"]
+    verbs: ["get", "list", "create", "update", "delete"]  
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: px-lh-role-binding
+  namespace: kube-system
+subjects:
+- kind: ServiceAccount
+  name: px-lh-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: px-lh-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: px-lighthouse
+  namespace: kube-system
+  labels:
+    tier: px-web-console
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 80
+    - name: https
+      port: 443
+  selector:
+    tier: px-web-console
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: px-lighthouse
+  namespace: kube-system
+  labels:
+    tier: px-web-console
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      tier: px-web-console
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        tier: px-web-console
+    spec:
+      initContainers:
+      - name: config-init
+        image: "{{ template "px.getLighthouseImages" . }}/lh-config-sync:{{.Values.lighthouseSyncVersion}}"
+        imagePullPolicy: Always
+        args:
+        - "init"
+        volumeMounts:
+        - name: config
+          mountPath: /config/lh
+      containers:
+      - name: px-lighthouse
+        image: "{{ template "px.getLighthouseImages" . }}/px-lighthouse:{{ required "A valid lighthouse image version is required" .Values.lighthouseVersion}}"
+        imagePullPolicy: Always
+        args: [ "-kubernetes", "true" ]
+        ports:
+        - containerPort: 80
+        - containerPort: 443
+        volumeMounts:
+        - name: config
+          mountPath: /config/lh
+      - name: config-sync
+        image: "{{ template "px.getLighthouseImages" . }}/lh-config-sync:{{.Values.lighthouseSyncVersion}}"
+        imagePullPolicy: Always
+        args:
+        - "sync"
+        volumeMounts:
+        - name: config
+          mountPath: /config/lh
+      - name: stork-connector
+        image: "{{ template "px.getLighthouseImages" . }}/lh-stork-connector:{{.Values.lighthouseStorkConnectorVersion}}"
+        imagePullPolicy: Always
+      serviceAccountName: px-lh-account
+      volumes:
+      - name: config
+        emptyDir: {}
+{{- end -}}

--- a/charts/portworx/v1.0.10/templates/portworx-rbac-config.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-rbac-config.yaml
@@ -1,0 +1,56 @@
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: px-account
+  namespace: kube-system
+---
+
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+   name: node-get-put-list-role
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["watch", "get", "update", "list"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["delete", "get", "list", "watch", "update"]
+- apiGroups: [""]
+  resources: ["persistentvolumeclaims", "persistentvolumes"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["get", "list", "update", "create"]
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  resourceNames: ["privileged"]
+  verbs: ["use"]
+- apiGroups: ["portworx.io"]
+  resources: ["volumeplacementstrategies"]
+  verbs: ["get", "list"]
+- apiGroups: ["stork.libopenstorage.org"]
+  resources: ["backuplocations"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create"]
+---
+
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: node-role-binding
+subjects:
+- kind: ServiceAccount
+  name: px-account
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: node-get-put-list-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/portworx/v1.0.10/templates/portworx-service.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-service.yaml
@@ -1,0 +1,54 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-service
+  namespace: kube-system
+  labels:
+    name: portworx
+spec:
+  selector:
+    name: portworx
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+    - name: px-kvdb
+      protocol: TCP
+      port: 9019
+      targetPort: 9019
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 9020
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 9021
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: portworx-api
+  namespace: kube-system
+  labels:
+    name: portworx-api
+spec:
+  selector:
+    name: portworx-api
+  type: ClusterIP
+  ports:
+    - name: px-api
+      protocol: TCP
+      port: 9001
+      targetPort: 9001
+    - name: px-sdk
+      protocol: TCP
+      port: 9020
+      targetPort: 9020
+    - name: px-rest-gateway
+      protocol: TCP
+      port: 9021
+      targetPort: 9021
+---

--- a/charts/portworx/v1.0.10/templates/portworx-storageclasses.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-storageclasses.yaml
@@ -1,0 +1,56 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-db-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+  repl: "3"
+  io_profile: "db"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-db2-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "3"
+   block_size: "512b"
+   io_profile: "db"
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-shared-sc
+provisioner: kubernetes.io/portworx-volume
+parameters:
+   repl: "3"
+   shared: "true"
+---
+#
+# NULL StorageClass that documents all possible
+# Portworx StorageClass parameters
+#
+# Please refer to : https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html
+#
+kind: StorageClass
+apiVersion: storage.k8s.io/v1beta1
+metadata:
+  name: portworx-null-sc
+  annotations:
+       params/docs:  'https://docs.portworx.com/scheduler/kubernetes/dynamic-provisioning.html'
+       params/fs:  "Filesystem to be laid out: none|xfs|ext4 "
+       params/block_size: "Block size"
+       params/repl:        "Replication factor for the volume: 1|2|3"
+       params/shared:     "Flag to create a globally shared namespace volume which can be used by multiple pods : true|false"
+       params/priority_io: "IO Priority: low|medium|high"
+       params/io_profile:  "IO Profile can be used to override the I/O algorithm Portworx uses for the volumes. Supported values are [db](/maintain/performance/tuning.html#db), [sequential](/maintain/performance/tuning.html#sequential), [random](/maintain/performance/tuning.html#random), [cms](/maintain/performance/tuning.html#cms)"
+       params/group:       "The group a volume should belong too. Portworx will restrict replication sets of volumes of the same group on different nodes. If the force group option 'fg' is set to true, the volume group rule will be strictly enforced. By default, it's not strictly enforced."
+       params/fg:          "This option enforces volume group policy. If a volume belonging to a group cannot find nodes for it's replication sets which don't have other volumes of same group, the volume creation will fail."
+       params/label:       "List of comma-separated name=value pairs to apply to the Portworx volume"
+       params/nodes:       "Comma-separated Portworx Node ID's to use for replication sets of the volume"
+       params/aggregation_level:     "Specifies the number of replication sets the volume can be aggregated from"
+       params/snap_schedule:     "Snapshot schedule. Following are the accepted formats:  periodic=_mins_,_snaps-to-keep_ daily=_hh:mm_,_snaps-to-keep_ weekly=_weekday@hh:mm_,_snaps-to-keep_  monthly=_day@hh:mm_,_snaps-to-keep_ _snaps-to-keep_ is optional. Periodic, Daily, Weekly and Monthly keep last 5, 7, 5 and 12 snapshots by default respectively"
+       params/sticky:         "Flag to create sticky volumes that cannot be deleted until the flag is disabled"
+       params/journal:         "Flag to indicate if you want to use journal device for the volume's metadata. This will use the journal device that you used when installing Portworx. As of PX version 1.3, it is recommended to use a journal device to absorb PX metadata writes"
+provisioner: kubernetes.io/portworx-volume
+parameters:

--- a/charts/portworx/v1.0.10/templates/portworx-stork.yaml
+++ b/charts/portworx/v1.0.10/templates/portworx-stork.yaml
@@ -1,0 +1,317 @@
+{{- if (.Values.stork) and (eq .Values.stork true)}}
+  {{- $isCoreOS := .Values.isTargetOSCoreOS | default false }}
+  {{- $customRegistryURL := .Values.customRegistryURL | default "none" }}
+  {{- $registrySecret := .Values.registrySecret | default "none" }}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: stork-config
+  namespace: kube-system
+data:
+  policy.cfg: |-
+    {
+      "kind": "Policy",
+      "apiVersion": "v1",
+{{- if semverCompare "< 1.10-0" .Capabilities.KubeVersion.GitVersion }}
+      "predicates": [
+{{- if semverCompare "< 1.9-0" .Capabilities.KubeVersion.GitVersion }}
+        {"name": "NoVolumeNodeConflict"},
+{{- end}}
+        {"name": "MaxAzureDiskVolumeCount"},
+        {"name": "NoVolumeZoneConflict"},
+        {"name": "PodToleratesNodeTaints"},
+        {"name": "CheckNodeMemoryPressure"},
+        {"name": "MaxEBSVolumeCount"},
+        {"name": "MaxGCEPDVolumeCount"},
+        {"name": "MatchInterPodAffinity"},
+        {"name": "NoDiskConflict"},
+        {"name": "GeneralPredicates"},
+        {"name": "CheckNodeDiskPressure"}
+      ],
+      "priorities": [
+        {"name": "NodeAffinityPriority", "weight": 1},
+        {"name": "TaintTolerationPriority", "weight": 1},
+        {"name": "SelectorSpreadPriority", "weight": 1},
+        {"name": "InterPodAffinityPriority", "weight": 1},
+        {"name": "LeastRequestedPriority", "weight": 1},
+        {"name": "BalancedResourceAllocation", "weight": 1},
+        {"name": "NodePreferAvoidPodsPriority", "weight": 1}
+      ],
+{{- end}}
+      "extenders": [
+        {
+          "urlPrefix": "http://stork-service.kube-system:8099",
+          "apiVersion": "v1beta1",
+          "filterVerb": "filter",
+          "prioritizeVerb": "prioritize",
+          "weight": 5,
+          "enableHttps": false,
+          "nodeCacheCapable": false
+        }
+      ]
+    }
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stork-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-role
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: stork-account
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: stork-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: stork-service
+  namespace: kube-system
+spec:
+  selector:
+    name: stork
+  ports:
+    - name: extender
+      protocol: TCP
+      port: 8099
+      targetPort: 8099
+    - name: webhook
+      protocol: TCP
+      port: 443
+      targetPort: 443
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: volumeplacementstrategies.portworx.io
+spec:
+  group: portworx.io
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: false
+      storage: false
+  scope: Cluster
+  names:
+    plural: volumeplacementstrategies
+    singular: volumeplacementstrategy
+    kind: VolumePlacementStrategy
+    shortNames:
+      - vps
+      - vp
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    tier: control-plane
+  name: stork
+  namespace: kube-system
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 3
+  selector:
+    matchLabels:
+      name: stork
+      tier: control-plane
+  template:
+    metadata:
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ""
+      labels:
+        name: stork
+        tier: control-plane
+    spec:
+      {{- if not (eq $registrySecret "none") }}
+      imagePullSecrets:
+        - name: {{ $registrySecret }}
+      {{- end }}
+      containers:
+        - command:
+            - /stork
+            - --driver=pxd
+            - --verbose
+            - --leader-elect=true
+            - --webhook-controller=false
+          imagePullPolicy: Always
+          image: {{ template "px.getStorkImage" . }}:{{ required "A valid Image tag is required in the SemVer format" .Values.storkVersion }}
+          resources:
+            requests:
+              cpu: '0.1'
+          name: stork
+      hostPID: false
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                      - stork
+              topologyKey: "kubernetes.io/hostname"
+      serviceAccountName: stork-account
+---
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: stork-snapshot-sc
+provisioner: stork-snapshot
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: stork-scheduler-account
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-scheduler-role
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["", "events.k8s.io"]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resourceNames: ["kube-scheduler"]
+    resources: ["endpoints"]
+    verbs: ["delete", "get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["delete", "get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["bindings", "pods/binding"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/status"]
+    verbs: ["patch", "update"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers", "services"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps", "extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims", "persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "update", "get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: {{ template "rbac.apiVersion" . }}
+metadata:
+  name: stork-scheduler-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: stork-scheduler-account
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: stork-scheduler-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    component: scheduler
+    tier: control-plane
+  name: stork-scheduler
+  namespace: kube-system
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      component: scheduler
+      tier: control-plane
+  template:
+    metadata:
+      labels:
+        component: scheduler
+        tier: control-plane
+      name: stork-scheduler
+    spec:
+      containers:
+        - command:
+            - /usr/local/bin/kube-scheduler
+            - --address=0.0.0.0
+            - --leader-elect=true
+            - --scheduler-name=stork
+            - --policy-configmap=stork-config
+            - --policy-configmap-namespace=kube-system
+            - --lock-object-name=stork-scheduler
+          image: "{{ template "px.getk8sImages" . }}/kube-scheduler-amd64:{{ template "px.kubernetesVersion" . }}"
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 10251
+            initialDelaySeconds: 15
+          name: stork-scheduler
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 10251
+          resources:
+            requests:
+              cpu: '0.1'
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: "name"
+                    operator: In
+                    values:
+                      - stork-scheduler
+              topologyKey: "kubernetes.io/hostname"
+      hostPID: false
+      serviceAccountName: stork-scheduler-account
+  {{- end }}

--- a/charts/portworx/v1.0.10/templates/serviceaccount-hook.yaml
+++ b/charts/portworx/v1.0.10/templates/serviceaccount-hook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.hook.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -6,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "post-install,pre-delete,post-delete"
   labels:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
@@ -19,7 +18,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "post-install,pre-delete,post-delete"
   name: {{ template "px.hookClusterRole" . }}
 rules:
 - apiGroups: [""]
@@ -31,7 +30,7 @@ apiVersion: {{ template "rbac.apiVersion" . }}
 metadata:
   annotations:
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook": "pre-delete,post-delete"
+    "helm.sh/hook": "post-install,pre-delete,post-delete"
   name: {{ template "px.hookClusterRoleBinding" . }}
 subjects:
 - kind: ServiceAccount
@@ -41,4 +40,3 @@ roleRef:
   kind: ClusterRole
   name: {{ template "px.hookClusterRole" . }}
   apiGroup: rbac.authorization.k8s.io
-{{- end }}

--- a/charts/portworx/v1.0.10/values.yaml
+++ b/charts/portworx/v1.0.10/values.yaml
@@ -1,0 +1,153 @@
+# Please uncomment and specify values for these options as per your requirements.
+kvdb:
+ownEtcdOption: none
+etcdAuth: none
+etcdType: none                        # KVDB type
+
+etcd:
+  credentials: none:none              # Username and password for ETCD authentication in the form user:password
+  ca: none                            # Name of CA file for ETCD authentication. server.ca
+  cert: none                          # Name of certificate for ETCD authentication. Should be server.crt
+  key: none                           # Name of certificate key for ETCD authentication Should be server.key
+consul:
+  token: none                         # ACL token value used for Consul authentication. (example: 398073a8-5091-4d9c-871a-bbbeb030d1f6)
+region: none                          # US or EU regions for Portworx hosted etcds
+
+dataInterface: none                   # Name of the interface <ethX>
+managementInterface: none             # Name of the interface <ethX>
+platformOptions: none                 # AKS, EKS or GKE platforms
+
+customRegistryURL:
+registrySecret:
+
+clusterName: mycluster                # This is the default. please change it to your cluster name.
+secretType: k8s                      # Defaults to None, but can be AWS / KVDB / Vault.
+envVars: none                         # NOTE: This is a ";" seperated list of environment variables. For eg: MYENV1=myvalue1;MYENV2=myvalue2
+stork: true                           # Use Stork https://docs.portworx.com/scheduler/kubernetes/stork.html for hyperconvergence.
+storkVersion: 2.4.2.1
+
+lighthouse: true
+lighthouseVersion: 2.0.7
+lighthouseSyncVersion: 2.0.7
+lighthouseStorkConnectorVersion: 2.0.7
+
+deployOnMaster: false                 # For POC only
+csi: false                            # Enable CSI
+
+serviceAccount:
+  hook:
+    create: true
+    name:
+
+deploymentType: oci                   # accepts "oci" or "docker"
+imageType: none                       #
+imageVersion: 2.5.5                 # Version of the PX Image.
+
+result: none
+environment: none
+onpremStorage: none
+
+maxStorageNodes: none
+journalDevice: none
+
+usefileSystemDrive: false             # true/false Instructs PX to use an unmounted Drive even if it has a filesystem.
+usedrivesAndPartitions: false         # Use unmounted disks even if they have a partition or filesystem on it. PX will never use a drive or partition that is mounted. (useDrivesAndPartitions)
+
+provider: none
+deviceConfig: none
+
+drive_1:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: standard
+    size: 1000
+
+drive_2:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_3:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_4:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_5:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_6:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_7:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_8:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_9:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+drive_10:
+  aws:
+    type: none
+    size: none
+    iops: none
+  gc:
+    type: none
+    size: none
+
+existingDisk1: none
+existingDisk2: none
+existingDisk3: none
+existingDisk4: none
+existingDisk5: none


### PR DESCRIPTION
In this merge request
1. Bumped up Portworx and Portworx Essential Versions to 2.5.5
2. Stork version to 2.4.2.1
3. Enabled webhook for stork and exposed the service port
4. Forces service account creation for pre and post delete hooks.
5. Tested on rancher version 2.4.4 