### PR TITLE
Added a 'required' option for user to specify PostgreSQL password. 

### DIFF
--- a/charts/artifactory-ha/v2.5.3/questions.yml
+++ b/charts/artifactory-ha/v2.5.3/questions.yml
@@ -261,7 +261,7 @@ questions:
   - variable: postgresql.postgresqlPassword
     default: ""
     description: "PostgreSQL password"
-    type: string
+    type: password
     required: true
     label: PostgreSQL Password
     group: "Database Settings"
@@ -346,7 +346,7 @@ questions:
 - variable: database.password
   default: ""
   description: "External database password"
-  type: string
+  type: password
   label: External Database Password
   group: "Database Settings"
   show_if: "postgresql.enabled=false"

--- a/charts/artifactory-ha/v2.5.3/questions.yml
+++ b/charts/artifactory-ha/v2.5.3/questions.yml
@@ -258,6 +258,14 @@ questions:
   group: "Database Settings"
   show_subquestion_if: "true"
   subquestions:
+  - variable: postgresql.postgresqlPassword
+    default: ""
+    description: "PostgreSQL password"
+    type: string
+    required: true
+    label: PostgreSQL Password
+    group: "Database Settings"
+    show_if: "postgresql.enabled=true"
   - variable: postgresql.persistence.size
     default: 20Gi
     description: "PostgreSQL persistent volume size"

--- a/charts/artifactory-jcr/v2.3.0/questions.yml
+++ b/charts/artifactory-jcr/v2.3.0/questions.yml
@@ -105,7 +105,15 @@ questions:
   group: "Database Settings"
   show_subquestion_if: "true"
   subquestions:
-  - variable: artifactory.artifactory.postgresql.persistence.size
+  - variable: artifactory.postgresql.postgresqlPassword
+    default: ""
+    description: "PostgreSQL password"
+    type: string
+    required: true
+    label: PostgreSQL Password
+    group: "Database Settings"
+    show_if: "artifactory.postgresql.enabled=true"
+  - variable: artifactory.postgresql.persistence.size
     default: 20Gi
     description: "PostgreSQL persistent volume size"
     type: string

--- a/charts/artifactory-jcr/v2.3.0/questions.yml
+++ b/charts/artifactory-jcr/v2.3.0/questions.yml
@@ -108,7 +108,7 @@ questions:
   - variable: artifactory.postgresql.postgresqlPassword
     default: ""
     description: "PostgreSQL password"
-    type: string
+    type: password
     required: true
     label: PostgreSQL Password
     group: "Database Settings"
@@ -193,7 +193,7 @@ questions:
 - variable: artifactory.database.password
   default: ""
   description: "External database password"
-  type: string
+  type: password
   label: External Database Password
   group: "Database Settings"
   show_if: "artifactory.postgresql.enabled=false"


### PR DESCRIPTION
Without specifying a password, the charts were auto generating a password. This made upgrades and reinstalls fail as that generated a new password and the data saved on persistent volume was not readable.
Now we are giving the user to specify a password. So on upgrades and reinstalls they can specify the same password and upgrades and reinstalls will suceed.
Note: To reinstall without reusing the data, user needs to delete install, delete PVs, then reinstall. In this case, the data will be removed and the user can also specify a different password if desired.