### PR TITLE
Update gatekeeper chart

### DIFF
--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+All notable changes from the upstream OPA Gatekeeper chart will be added to this file
+
+## [Package Version 00] - 2020-07-27
+### Added
+
+### Modified
+- Updated chart version in `Chart.yaml` to follow the upstream's format `v3.1.0-beta.X`
+
+### Removed
+- Removed the following files as the `gatekeeper-webhook-service` was removed in our previous version of the chart
+    - `gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml`
+    - `gatekeeper-webhook-service-service.yaml`

--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes from the upstream OPA Gatekeeper chart will be added to this
 ### Modified
 - Updated chart version in `Chart.yaml` to follow the upstream's format `v3.1.0-beta.X`
 - Updated namespace to `cattle-gatekeeper-system`
+- Updated `rancher/istio-kubectl` image to `1.5.8`
 
 ### Removed
 - Removed the following files as the `gatekeeper-webhook-service` was removed in our previous version of the chart

--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -17,3 +17,4 @@ All notable changes from the upstream OPA Gatekeeper chart will be added to this
     - `constraintpodstatus-customresourcedefinition.yaml`                             
     - `constrainttemplate-customresourcedefinition.`                              
     - `constrainttemplatepodstatus-customresourcedefinition.yaml`
+- Removed unnecessary `index.yaml` as we package and host our charts

--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable changes from the upstream OPA Gatekeeper chart will be added to this
 - Removed the following files as the `gatekeeper-webhook-service` was removed in our previous version of the chart
     - `gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml`
     - `gatekeeper-webhook-service-service.yaml`
+- Removed `gatekeeper-system-namespace.yaml` as Rancher handles namespaces for chart installation

--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes from the upstream OPA Gatekeeper chart will be added to this
 
 ## [Package Version 00] - 2020-07-27
 ### Added
+- Added `validate_crds_installed.yaml` to validate crds are installed before installing racher-gatekeeper
 
 ### Modified
 - Updated chart version in `Chart.yaml` to follow the upstream's format `v3.1.0-beta.X`

--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -4,9 +4,13 @@ All notable changes from the upstream OPA Gatekeeper chart will be added to this
 ## [Package Version 00] - 2020-07-27
 ### Added
 - Added `validate_crds_installed.yaml` to validate crds are installed before installing racher-gatekeeper
+- Added the following crd annotations for `rancher-gatekeeper-crd` chart dependency:
+    - `catalog.cattle.io/requires-gvr: configs.config.gatekeeper.sh/v1alpha1`
+    - `catalog.cattle.io/auto-install-gvr: configs.config.gatekeeper.sh/v1alpha1`
 
 ### Modified
 - Updated chart version in `Chart.yaml` to follow the upstream's format `v3.1.0-beta.X`
+- Updated namespace to `cattle-gatekeeper-system`
 
 ### Removed
 - Removed the following files as the `gatekeeper-webhook-service` was removed in our previous version of the chart

--- a/packages/rancher-gatekeeper/overlay/CHANGELOG.md
+++ b/packages/rancher-gatekeeper/overlay/CHANGELOG.md
@@ -12,3 +12,8 @@ All notable changes from the upstream OPA Gatekeeper chart will be added to this
     - `gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml`
     - `gatekeeper-webhook-service-service.yaml`
 - Removed `gatekeeper-system-namespace.yaml` as Rancher handles namespaces for chart installation
+- Removed the following crds as they will reside in a separate chart
+    - `config-customresourcedefinition.yaml`                                          
+    - `constraintpodstatus-customresourcedefinition.yaml`                             
+    - `constrainttemplate-customresourcedefinition.`                              
+    - `constrainttemplatepodstatus-customresourcedefinition.yaml`

--- a/packages/rancher-gatekeeper/package.yaml
+++ b/packages/rancher-gatekeeper/package.yaml
@@ -1,4 +1,4 @@
 url: https://github.com/open-policy-agent/gatekeeper.git
-subdirectory: chart/gatekeeper-operator
+subdirectory: charts/gatekeeper
 type: git
-commit: 478aa0e193909a301cc7461f0f8c078d652e70fb
+commit: 9a8051ac8fa3dc407056ed0293a0d97210386115

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -19,6 +19,28 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Cha
 +  catalog.cattle.io/experimental: true
 +  catalog.cattle.io/namespace: gatekeeper-system
 +  catalog.cattle.io/release-name: rancher-gatekeeper
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/index.yaml packages/rancher-gatekeeper/charts/index.yaml
+--- packages/rancher-gatekeeper/charts-original/index.yaml
++++ packages/rancher-gatekeeper/charts/index.yaml
+@@ -1,18 +0,0 @@
+-apiVersion: v1
+-entries:
+-  gatekeeper:
+-  - apiVersion: v1
+-    appVersion: v3.1.0-beta.11
+-    created: "2020-07-24T16:56:23.670543818-07:00"
+-    description: A Helm chart for Gatekeeper
+-    digest: 937aeddadbeac8fa1b71169c4fcde5229fa8445b0caec6339dc7cae2ac10d43f
+-    home: https://github.com/open-policy-agent/gatekeeper
+-    keywords:
+-    - open policy agent
+-    name: gatekeeper
+-    sources:
+-    - https://github.com/open-policy-agent/gatekeeper.git
+-    urls:
+-    - https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.1.0-beta.11/charts/gatekeeper/gatekeeper-v3.1.0-beta.11.tgz
+-    version: v3.1.0-beta.11
+-generated: "2020-07-24T16:56:23.669766565-07:00"
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/_helpers.tpl packages/rancher-gatekeeper/charts/templates/_helpers.tpl
 --- packages/rancher-gatekeeper/charts-original/templates/_helpers.tpl
 +++ packages/rancher-gatekeeper/charts/templates/_helpers.tpl

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -1,103 +1,39 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Chart.yaml packages/rancher-gatekeeper/charts/Chart.yaml
 --- packages/rancher-gatekeeper/charts-original/Chart.yaml
 +++ packages/rancher-gatekeeper/charts/Chart.yaml
-@@ -1,10 +1,16 @@
+@@ -1,6 +1,6 @@
  apiVersion: v1
  description: A Helm chart for Gatekeeper
--name: gatekeeper-operator
+-name: gatekeeper
 +name: rancher-gatekeeper
  keywords:
    - open policy agent
--version: v3.1.0-beta.7
-+version: 0.1.0
- home: https://github.com/open-policy-agent/gatekeeper
+ version: v3.1.0-beta.11
+@@ -8,3 +8,9 @@
  sources:
    - https://github.com/open-policy-agent/gatekeeper.git
- appVersion: v3.1.0-beta.7
+ appVersion: v3.1.0-beta.11
 +icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
 +annotations:
 +  catalog.cattle.io/certified: rancher
 +  catalog.cattle.io/experimental: true
 +  catalog.cattle.io/namespace: gatekeeper-system
 +  catalog.cattle.io/release-name: rancher-gatekeeper
-diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/helm-modifications/helm-modifications.yaml packages/rancher-gatekeeper/charts/helm-modifications/helm-modifications.yaml
---- packages/rancher-gatekeeper/charts-original/helm-modifications/helm-modifications.yaml
-+++ packages/rancher-gatekeeper/charts/helm-modifications/helm-modifications.yaml
-@@ -1,61 +0,0 @@
--apiVersion: v1
--kind: Service
--metadata:
--  name: gatekeeper-webhook-service
--  namespace: gatekeeper-system
--spec:
--  selector:
--    app: GATEKEEPER_APP_LABEL
-----
--apiVersion: apiextensions.k8s.io/v1beta1
--kind: CustomResourceDefinition
--metadata:
--  name: configs.config.gatekeeper.sh
--  annotations:
--    helm.sh/hook: crd-install
--    helm.sh/hook-delete-policy: before-hook-creation
--status: null
--spec:
--  names:
--    shortNames:
--      - config # add shortName to CRD until https://github.com/kubernetes-sigs/kubebuilder/issues/404 is solved
-----
--apiVersion: apiextensions.k8s.io/v1beta1
--kind: CustomResourceDefinition
--metadata:
--  name: constrainttemplates.templates.gatekeeper.sh
--  annotations:
--    helm.sh/hook: crd-install
--    helm.sh/hook-delete-policy: before-hook-creation
--status: null
--spec:
--  names:
--    shortNames:
--      - constraints # add shortName to CRD until https://github.com/kubernetes-sigs/kubebuilder/issues/404 is solved
-----
--apiVersion: apps/v1
--kind: Deployment
--metadata:
--  name: gatekeeper-controller-manager
--  namespace: gatekeeper-system
--spec:
--  replicas: HELMSUBST_DEPLOYMENT_REPLICAS
--  selector:
--    matchLabels:
--      app: gatekeeper-operator
--      release: RELEASE_NAME
--  template:
--    spec:
--      containers:
--        - name: manager
--          args:
--            - --audit-interval={{ .Values.auditInterval }}
--            - --port=8443
--            - --logtostderr
--            - --constraint-violations-limit={{ .Values.constraintViolationsLimit }}
--            - --audit-from-cache={{ .Values.auditFromCache }}
--            - --exempt-namespace=gatekeeper-system
--          imagePullPolicy: "{{ .Values.image.pullPolicy }}"
--          image: "{{ .Values.image.repository }}:{{ .Values.image.release }}"
--          resources: HELMSUBST_DEPLOYMENT_CONTAINER_RESOURCES
--      nodeSelector: HELMSUBST_DEPLOYMENT_POD_SCHEDULING
-diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/helm-modifications/kustomization.yaml packages/rancher-gatekeeper/charts/helm-modifications/kustomization.yaml
---- packages/rancher-gatekeeper/charts-original/helm-modifications/kustomization.yaml
-+++ packages/rancher-gatekeeper/charts/helm-modifications/kustomization.yaml
-@@ -1,9 +0,0 @@
--commonLabels:
--  app: '{{ template "gatekeeper-operator.name" . }}'
--  chart: '{{ template "gatekeeper-operator.name" . }}'
--  release: '{{ .Release.Name }}'
--  heritage: '{{ .Release.Service }}'
--resources:
--  - _temp.yaml
--patchesStrategicMerge:
--  - helm-modifications.yaml
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/_helpers.tpl packages/rancher-gatekeeper/charts/templates/_helpers.tpl
+--- packages/rancher-gatekeeper/charts-original/templates/_helpers.tpl
++++ packages/rancher-gatekeeper/charts/templates/_helpers.tpl
+@@ -42,3 +42,11 @@
+ {{- end }}
+ app.kubernetes.io/managed-by: {{ .Release.Service }}
+ {{- end -}}
++
++{{- define "system_default_registry" -}}
++{{- if .Values.global.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/allowedrepos.yaml packages/rancher-gatekeeper/charts/templates/allowedrepos.yaml
 --- packages/rancher-gatekeeper/charts-original/templates/allowedrepos.yaml
 +++ packages/rancher-gatekeeper/charts/templates/allowedrepos.yaml
@@ -137,11 +73,10 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
 +          not any(satisfied)
 +          msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
 +        }
-\ No newline at end of file
-diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper.yaml
---- packages/rancher-gatekeeper/charts-original/templates/gatekeeper.yaml
-+++ packages/rancher-gatekeeper/charts/templates/gatekeeper.yaml
-@@ -485,7 +485,7 @@
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-audit-deployment.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-audit-deployment.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-audit-deployment.yaml
++++ packages/rancher-gatekeeper/charts/templates/gatekeeper-audit-deployment.yaml
+@@ -58,7 +58,7 @@
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
@@ -150,30 +85,109 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
          imagePullPolicy: '{{ .Values.image.pullPolicy }}'
          livenessProbe:
            httpGet:
-@@ -517,7 +517,7 @@
-         - mountPath: /certs
-           name: cert
-           readOnly: true
--      nodeSelector: 
-+      nodeSelector:
- {{ toYaml .Values.nodeSelector | indent 8 }}
-       affinity:
- {{ toYaml .Values.affinity | indent 8 }}
-diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/_helpers.tpl packages/rancher-gatekeeper/charts/templates/_helpers.tpl
---- packages/rancher-gatekeeper/charts-original/templates/_helpers.tpl
-+++ packages/rancher-gatekeeper/charts/templates/_helpers.tpl
-@@ -42,3 +42,11 @@
- {{- end }}
- app.kubernetes.io/managed-by: {{ .Release.Service }}
- {{- end -}}
-+
-+{{- define "system_default_registry" -}}
-+{{- if .Values.global.systemDefaultRegistry -}}
-+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
-+{{- else -}}
-+{{- "" -}}
-+{{- end -}}
-+{{- end -}}
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-controller-manager-deployment.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-controller-manager-deployment.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-controller-manager-deployment.yaml
++++ packages/rancher-gatekeeper/charts/templates/gatekeeper-controller-manager-deployment.yaml
+@@ -67,7 +67,7 @@
+           valueFrom:
+             fieldRef:
+               fieldPath: metadata.name
+-        image: '{{ .Values.image.repository }}:{{ .Values.image.release }}'
++        image: '{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}'
+         imagePullPolicy: '{{ .Values.image.pullPolicy }}'
+         livenessProbe:
+           httpGet:
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
++++ packages/rancher-gatekeeper/charts/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
+@@ -1,60 +0,0 @@
+-{{- if not .Values.disableValidatingWebhook }}
+-apiVersion: admissionregistration.k8s.io/v1beta1
+-kind: ValidatingWebhookConfiguration
+-metadata:
+-  creationTimestamp: null
+-  labels:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: gatekeeper-validating-webhook-configuration
+-webhooks:
+-- clientConfig:
+-    caBundle: Cg==
+-    service:
+-      name: gatekeeper-webhook-service
+-      namespace: gatekeeper-system
+-      path: /v1/admit
+-  failurePolicy: Ignore
+-  name: validation.gatekeeper.sh
+-  namespaceSelector:
+-    matchExpressions:
+-    - key: control-plane
+-      operator: DoesNotExist
+-    - key: admission.gatekeeper.sh/ignore
+-      operator: DoesNotExist
+-  rules:
+-  - apiGroups:
+-    - '*'
+-    apiVersions:
+-    - '*'
+-    operations:
+-    - CREATE
+-    - UPDATE
+-    resources:
+-    - '*'
+-  sideEffects: None
+-  timeoutSeconds: 5
+-- clientConfig:
+-    caBundle: Cg==
+-    service:
+-      name: gatekeeper-webhook-service
+-      namespace: gatekeeper-system
+-      path: /v1/admitlabel
+-  failurePolicy: Fail
+-  name: check-ignore-label.gatekeeper.sh
+-  rules:
+-  - apiGroups:
+-    - ""
+-    apiVersions:
+-    - '*'
+-    operations:
+-    - CREATE
+-    - UPDATE
+-    resources:
+-    - namespaces
+-  sideEffects: None
+-  timeoutSeconds: 5
+-{{- end }}
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-webhook-service-service.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-webhook-service-service.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-webhook-service-service.yaml
++++ packages/rancher-gatekeeper/charts/templates/gatekeeper-webhook-service-service.yaml
+@@ -1,23 +0,0 @@
+-apiVersion: v1
+-kind: Service
+-metadata:
+-  labels:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: gatekeeper-webhook-service
+-  namespace: gatekeeper-system
+-spec:
+-  ports:
+-  - port: 443
+-    targetPort: 8443
+-  selector:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    control-plane: controller-manager
+-    gatekeeper.sh/operation: webhook
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/job-constraints-crd.yaml packages/rancher-gatekeeper/charts/templates/job-constraints-crd.yaml
 --- packages/rancher-gatekeeper/charts-original/templates/job-constraints-crd.yaml
 +++ packages/rancher-gatekeeper/charts/templates/job-constraints-crd.yaml
@@ -197,7 +211,6 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
 +        command: ["kubectl",  "delete", "constrainttemplates", "--all"]
 +      restartPolicy: Never
 +  backoffLimit: 1
-\ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/requiredlabels.yaml packages/rancher-gatekeeper/charts/templates/requiredlabels.yaml
 --- packages/rancher-gatekeeper/charts-original/templates/requiredlabels.yaml
 +++ packages/rancher-gatekeeper/charts/templates/requiredlabels.yaml
@@ -259,28 +272,28 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
 +          def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
 +          msg := get_message(input.parameters, def_msg)
 +        }
-\ No newline at end of file
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/values.yaml packages/rancher-gatekeeper/charts/values.yaml
 --- packages/rancher-gatekeeper/charts-original/values.yaml
 +++ packages/rancher-gatekeeper/charts/values.yaml
-@@ -1,12 +1,12 @@
- replicas: 1
+@@ -1,5 +1,5 @@
+ replicas: 3
 -auditInterval: 60
 +auditInterval: 300
  constraintViolationsLimit: 20
  auditFromCache: false
+ disableValidatingWebhook: false
+@@ -8,8 +8,8 @@
+ emitAdmissionEvents: false
+ emitAuditEvents: false
  image:
--  repository: quay.io/open-policy-agent/gatekeeper
--  release: v3.1.0-beta.7
+-  repository: openpolicyagent/gatekeeper
+-  release: v3.1.0-beta.11
 +  repository: rancher/opa-gatekeeper
-+  tag: v3.1.0-beta.7
++  tag: v3.1.0-beta.11
    pullPolicy: IfNotPresent
--nodeSelector: {}
-+nodeSelector: {"beta.kubernetes.io/os": "linux"}
- tolerations: []
- resources:
-   limits:
-@@ -15,3 +15,8 @@
+ nodeSelector: { kubernetes.io/os: linux }
+ affinity: {}
+@@ -23,3 +23,8 @@
    requests:
      cpu: 100m
      memory: 256Mi
@@ -289,4 +302,3 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/val
 +  kubectl:
 +    repository: rancher/istio-kubectl
 +    tag: 1.4.6
-\ No newline at end of file

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -9,7 +9,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Cha
  keywords:
    - open policy agent
  version: v3.1.0-beta.11
-@@ -8,3 +8,9 @@
+@@ -8,3 +8,10 @@
  sources:
    - https://github.com/open-policy-agent/gatekeeper.git
  appVersion: v3.1.0-beta.11
@@ -17,8 +17,9 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Cha
 +annotations:
 +  catalog.cattle.io/certified: rancher
 +  catalog.cattle.io/experimental: true
-+  catalog.cattle.io/namespace: gatekeeper-system
++  catalog.cattle.io/namespace: cattle-gatekeeper-system
 +  catalog.cattle.io/release-name: rancher-gatekeeper
++  catalog.cattle.io/auto-install-gvr: configs.config.gatekeeper.sh/v1alpha1
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/index.yaml packages/rancher-gatekeeper/charts/index.yaml
 --- packages/rancher-gatekeeper/charts-original/index.yaml
 +++ packages/rancher-gatekeeper/charts/index.yaml

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -730,6 +730,25 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
 +          def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
 +          msg := get_message(input.parameters, def_msg)
 +        }
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/validate_crds_installed.yaml packages/rancher-gatekeeper/charts/validate_crds_installed.yaml
+--- packages/rancher-gatekeeper/charts-original/validate_crds_installed.yaml
++++ packages/rancher-gatekeeper/charts/validate_crds_installed.yaml
+@@ -0,0 +1,15 @@
++# {{- $found := dict -}}
++# {{- set $found "config.gatekeeper.sh/v1alpha1/Config" false -}}
++# {{- set $found "status.gatekeeper.sh/v1beta1/ConstraintTemplatePodStatus" false -}}
++# {{- set $found "status.gatekeeper.sh/v1beta1/ConstraintPodStatus" false -}}
++# {{- set $found "templates.gatekeeper.sh/v1beta1/ConstraintTemplate" false -}}
++# {{- range .Capabilities.APIVersions -}}
++#   {{- if hasKey $found (toString .) -}}
++#     {{- set $found (toString .) true -}}
++#   {{- end -}}
++# {{- end -}}
++# {{- range $_, $exists := $found -}}
++#   {{- if (eq $exists false) -}}
++#     {{- required "Required CRDs are missing. Please install the rancher-gatekeeper-crd chart before installing this chart." "" -}}
++#   {{- end -}}
++# {{- end -}}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/values.yaml packages/rancher-gatekeeper/charts/values.yaml
 --- packages/rancher-gatekeeper/charts-original/values.yaml
 +++ packages/rancher-gatekeeper/charts/values.yaml

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -97,6 +97,22 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
          imagePullPolicy: '{{ .Values.image.pullPolicy }}'
          livenessProbe:
            httpGet:
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-system-namespace.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-system-namespace.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-system-namespace.yaml
++++ packages/rancher-gatekeeper/charts/templates/gatekeeper-system-namespace.yaml
+@@ -1,12 +0,0 @@
+-apiVersion: v1
+-kind: Namespace
+-metadata:
+-  labels:
+-    admission.gatekeeper.sh/ignore: no-self-managing
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    control-plane: controller-manager
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: gatekeeper-system
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
 --- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml
 +++ packages/rancher-gatekeeper/charts/templates/gatekeeper-validating-webhook-configuration-validatingwebhookconfiguration.yaml

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -779,4 +779,4 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/val
 +  systemDefaultRegistry: ""
 +  kubectl:
 +    repository: rancher/istio-kubectl
-+    tag: 1.4.6
++    tag: 1.5.8

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -73,6 +73,426 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/tem
 +          not any(satisfied)
 +          msg := sprintf("container <%v> has an invalid image repo <%v>, allowed repos are %v", [container.name, container.image, input.parameters.repos])
 +        }
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/config-customresourcedefinition.yaml packages/rancher-gatekeeper/charts/templates/config-customresourcedefinition.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/config-customresourcedefinition.yaml
++++ packages/rancher-gatekeeper/charts/templates/config-customresourcedefinition.yaml
+@@ -1,119 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1beta1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.3.0
+-    helm.sh/hook: crd-install
+-    helm.sh/hook-delete-policy: before-hook-creation
+-  creationTimestamp: null
+-  labels:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: configs.config.gatekeeper.sh
+-spec:
+-  group: config.gatekeeper.sh
+-  names:
+-    kind: Config
+-    listKind: ConfigList
+-    plural: configs
+-    shortNames:
+-    - config
+-    singular: config
+-  scope: Namespaced
+-  validation:
+-    openAPIV3Schema:
+-      description: Config is the Schema for the configs API
+-      properties:
+-        apiVersion:
+-          description: 'APIVersion defines the versioned schema of this representation
+-            of an object. Servers should convert recognized schemas to the latest
+-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+-          type: string
+-        kind:
+-          description: 'Kind is a string value representing the REST resource this
+-            object represents. Servers may infer this from the endpoint the client
+-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+-          type: string
+-        metadata:
+-          type: object
+-        spec:
+-          description: ConfigSpec defines the desired state of Config
+-          properties:
+-            match:
+-              description: Configuration for namespace exclusion
+-              items:
+-                properties:
+-                  excludedNamespaces:
+-                    items:
+-                      type: string
+-                    type: array
+-                  processes:
+-                    items:
+-                      type: string
+-                    type: array
+-                type: object
+-              type: array
+-            readiness:
+-              description: Configuration for readiness tracker
+-              properties:
+-                statsEnabled:
+-                  type: boolean
+-              type: object
+-            sync:
+-              description: Configuration for syncing k8s objects
+-              properties:
+-                syncOnly:
+-                  description: If non-empty, only entries on this list will be replicated
+-                    into OPA
+-                  items:
+-                    properties:
+-                      group:
+-                        type: string
+-                      kind:
+-                        type: string
+-                      version:
+-                        type: string
+-                    type: object
+-                  type: array
+-              type: object
+-            validation:
+-              description: Configuration for validation
+-              properties:
+-                traces:
+-                  description: List of requests to trace. Both "user" and "kinds"
+-                    must be specified
+-                  items:
+-                    properties:
+-                      dump:
+-                        description: Also dump the state of OPA with the trace. Set
+-                          to `All` to dump everything.
+-                        type: string
+-                      kind:
+-                        description: Only trace requests of the following GroupVersionKind
+-                        properties:
+-                          group:
+-                            type: string
+-                          kind:
+-                            type: string
+-                          version:
+-                            type: string
+-                        type: object
+-                      user:
+-                        description: Only trace requests from the specified user
+-                        type: string
+-                    type: object
+-                  type: array
+-              type: object
+-          type: object
+-        status:
+-          description: ConfigStatus defines the observed state of Config
+-          type: object
+-      type: object
+-  version: v1alpha1
+-  versions:
+-  - name: v1alpha1
+-    served: true
+-    storage: true
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/constraintpodstatus-customresourcedefinition.yaml packages/rancher-gatekeeper/charts/templates/constraintpodstatus-customresourcedefinition.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/constraintpodstatus-customresourcedefinition.yaml
++++ packages/rancher-gatekeeper/charts/templates/constraintpodstatus-customresourcedefinition.yaml
+@@ -1,86 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1beta1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.3.0
+-  creationTimestamp: null
+-  labels:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: constraintpodstatuses.status.gatekeeper.sh
+-spec:
+-  group: status.gatekeeper.sh
+-  names:
+-    kind: ConstraintPodStatus
+-    listKind: ConstraintPodStatusList
+-    plural: constraintpodstatuses
+-    singular: constraintpodstatus
+-  scope: Namespaced
+-  validation:
+-    openAPIV3Schema:
+-      description: ConstraintPodStatus is the Schema for the constraintpodstatuses
+-        API
+-      properties:
+-        apiVersion:
+-          description: 'APIVersion defines the versioned schema of this representation
+-            of an object. Servers should convert recognized schemas to the latest
+-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+-          type: string
+-        kind:
+-          description: 'Kind is a string value representing the REST resource this
+-            object represents. Servers may infer this from the endpoint the client
+-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+-          type: string
+-        metadata:
+-          type: object
+-        status:
+-          description: ConstraintPodStatusStatus defines the observed state of ConstraintPodStatus
+-          properties:
+-            constraintUID:
+-              description: Storing the constraint UID allows us to detect drift, such
+-                as when a constraint has been recreated after its CRD was deleted
+-                out from under it, interrupting the watch
+-              type: string
+-            enforced:
+-              type: boolean
+-            errors:
+-              items:
+-                description: Error represents a single error caught while adding a
+-                  constraint to OPA
+-                properties:
+-                  code:
+-                    type: string
+-                  location:
+-                    type: string
+-                  message:
+-                    type: string
+-                required:
+-                - code
+-                - message
+-                type: object
+-              type: array
+-            id:
+-              type: string
+-            observedGeneration:
+-              format: int64
+-              type: integer
+-            operations:
+-              items:
+-                type: string
+-              type: array
+-          type: object
+-      type: object
+-  version: v1beta1
+-  versions:
+-  - name: v1beta1
+-    served: true
+-    storage: true
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: []
+-  storedVersions: []
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/constrainttemplate-customresourcedefinition.yaml packages/rancher-gatekeeper/charts/templates/constrainttemplate-customresourcedefinition.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/constrainttemplate-customresourcedefinition.yaml
++++ packages/rancher-gatekeeper/charts/templates/constrainttemplate-customresourcedefinition.yaml
+@@ -1,111 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1beta1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    helm.sh/hook: crd-install
+-    helm.sh/hook-delete-policy: before-hook-creation
+-  creationTimestamp: null
+-  labels:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    controller-tools.k8s.io: "1.0"
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: constrainttemplates.templates.gatekeeper.sh
+-spec:
+-  group: templates.gatekeeper.sh
+-  names:
+-    kind: ConstraintTemplate
+-    plural: constrainttemplates
+-    shortNames:
+-    - constraints
+-  scope: Cluster
+-  subresources:
+-    status: {}
+-  validation:
+-    openAPIV3Schema:
+-      properties:
+-        apiVersion:
+-          description: 'APIVersion defines the versioned schema of this representation
+-            of an object. Servers should convert recognized schemas to the latest
+-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+-          type: string
+-        kind:
+-          description: 'Kind is a string value representing the REST resource this
+-            object represents. Servers may infer this from the endpoint the client
+-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+-          type: string
+-        metadata:
+-          type: object
+-        spec:
+-          properties:
+-            crd:
+-              properties:
+-                spec:
+-                  properties:
+-                    names:
+-                      properties:
+-                        kind:
+-                          type: string
+-                        shortNames:
+-                          items:
+-                            type: string
+-                          type: array
+-                      type: object
+-                    validation:
+-                      type: object
+-                  type: object
+-              type: object
+-            targets:
+-              items:
+-                properties:
+-                  libs:
+-                    items:
+-                      type: string
+-                    type: array
+-                  rego:
+-                    type: string
+-                  target:
+-                    type: string
+-                type: object
+-              type: array
+-          type: object
+-        status:
+-          properties:
+-            byPod:
+-              items:
+-                properties:
+-                  errors:
+-                    items:
+-                      properties:
+-                        code:
+-                          type: string
+-                        location:
+-                          type: string
+-                        message:
+-                          type: string
+-                      required:
+-                      - code
+-                      - message
+-                      type: object
+-                    type: array
+-                  id:
+-                    description: a unique identifier for the pod that wrote the status
+-                    type: string
+-                  observedGeneration:
+-                    format: int64
+-                    type: integer
+-                type: object
+-              type: array
+-            created:
+-              type: boolean
+-          type: object
+-  version: v1beta1
+-  versions:
+-  - name: v1beta1
+-    served: true
+-    storage: true
+-  - name: v1alpha1
+-    served: true
+-    storage: false
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/constrainttemplatepodstatus-customresourcedefinition.yaml packages/rancher-gatekeeper/charts/templates/constrainttemplatepodstatus-customresourcedefinition.yaml
+--- packages/rancher-gatekeeper/charts-original/templates/constrainttemplatepodstatus-customresourcedefinition.yaml
++++ packages/rancher-gatekeeper/charts/templates/constrainttemplatepodstatus-customresourcedefinition.yaml
+@@ -1,88 +0,0 @@
+-apiVersion: apiextensions.k8s.io/v1beta1
+-kind: CustomResourceDefinition
+-metadata:
+-  annotations:
+-    controller-gen.kubebuilder.io/version: v0.3.0
+-  creationTimestamp: null
+-  labels:
+-    app: '{{ template "gatekeeper.name" . }}'
+-    chart: '{{ template "gatekeeper.name" . }}'
+-    gatekeeper.sh/system: "yes"
+-    heritage: '{{ .Release.Service }}'
+-    release: '{{ .Release.Name }}'
+-  name: constrainttemplatepodstatuses.status.gatekeeper.sh
+-spec:
+-  group: status.gatekeeper.sh
+-  names:
+-    kind: ConstraintTemplatePodStatus
+-    listKind: ConstraintTemplatePodStatusList
+-    plural: constrainttemplatepodstatuses
+-    singular: constrainttemplatepodstatus
+-  scope: Namespaced
+-  validation:
+-    openAPIV3Schema:
+-      description: ConstraintTemplatePodStatus is the Schema for the constrainttemplatepodstatuses
+-        API
+-      properties:
+-        apiVersion:
+-          description: 'APIVersion defines the versioned schema of this representation
+-            of an object. Servers should convert recognized schemas to the latest
+-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+-          type: string
+-        kind:
+-          description: 'Kind is a string value representing the REST resource this
+-            object represents. Servers may infer this from the endpoint the client
+-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+-          type: string
+-        metadata:
+-          type: object
+-        status:
+-          description: ConstraintTemplatePodStatusStatus defines the observed state
+-            of ConstraintTemplatePodStatus
+-          properties:
+-            errors:
+-              items:
+-                description: CreateCRDError represents a single error caught during
+-                  parsing, compiling, etc.
+-                properties:
+-                  code:
+-                    type: string
+-                  location:
+-                    type: string
+-                  message:
+-                    type: string
+-                required:
+-                - code
+-                - message
+-                type: object
+-              type: array
+-            id:
+-              description: 'Important: Run "make" to regenerate code after modifying
+-                this file'
+-              type: string
+-            observedGeneration:
+-              format: int64
+-              type: integer
+-            operations:
+-              items:
+-                type: string
+-              type: array
+-            templateUID:
+-              description: UID is a type that holds unique ID values, including UUIDs.  Because
+-                we don't ONLY use UUIDs, this is an alias to string.  Being a type
+-                captures intent and helps make sure that UIDs and names do not get
+-                conflated.
+-              type: string
+-          type: object
+-      type: object
+-  version: v1beta1
+-  versions:
+-  - name: v1beta1
+-    served: true
+-    storage: true
+-status:
+-  acceptedNames:
+-    kind: ""
+-    plural: ""
+-  conditions: []
+-  storedVersions: []
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/templates/gatekeeper-audit-deployment.yaml packages/rancher-gatekeeper/charts/templates/gatekeeper-audit-deployment.yaml
 --- packages/rancher-gatekeeper/charts-original/templates/gatekeeper-audit-deployment.yaml
 +++ packages/rancher-gatekeeper/charts/templates/gatekeeper-audit-deployment.yaml


### PR DESCRIPTION
**Problem:** Update the opa gatekeeper chart to latest and add helm 3 compatibility.

**Solution:** Updated the opa gatekeeper chart to version v3.1.0-beta.11 and moved crds into a separate chart.

**Related PRs:**
Separate crds chart: https://github.com/rancher/charts/pull/516
image-mirror opa gatekeeper bump: rancher/image-mirror#15