### PR TITLE
Update patch for mac compatibility

### DIFF
--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -11,7 +11,7 @@ function remove_timestamp_from_diff {
 	time="[[:digit:]]\{2\}:[[:digit:]]\{2\}:[[:digit:]]\{2\}.[[:digit:]]\{9\}"
 	timezone="[-\+][[:digit:]]\{4\}"
 	timestamp_format="${date}[[:space:]]${time}[[:space:]]${timezone}"
-	sed -i "s/\(${prefix} ${filename_format}\)[[:space:]]${timestamp_format}/\1/g" ${f}/$(basename -- ${f}).patch
+	sed -i '' "s/\(${prefix} ${filename_format}\)[[:space:]]${timestamp_format}/\1/g" ${f}/$(basename -- ${f}).patch
 }
 
 function revert_crd_changes {


### PR DESCRIPTION
Update patch for mac compatibility

Without this change the patch script will not work in macOS.
Throws an error similar to this:
```
sed: 1: "packages/rancher-gateke ...": extra characters at the end of p command                                                                         
make: *** [patch] Error 1 
```