### PR TITLE
Istio Phase 2: Change namespace, add forceInstall flag

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.6.7
+appVersion: 1.6.8
 description: Helm chart for installing istio components with the istioctl
-name: rancher-istio-installer
-version: 1.6.700
+name: rancher-istio
+version: 1.6.800
 icon: https://charts.rancher.io/assets/logos/istio.svg
 annotations:
   catalog.cattle.io/certified: rancher

--- a/packages/rancher-istio/charts/README.md
+++ b/packages/rancher-istio/charts/README.md
@@ -4,16 +4,17 @@ A Rancher created chart that packages the istioctl binary to install via a helm 
 
 # Installation
 
-### pre-requisites
+### Requirements
 
-This chart depends on the rancher-kiali-server-crd chart. 
+This chart depends on the rancher-kiali-server-crd chart.
 
-It also depends on rancher-monitoring being installed with default values for nameOverride, namespaceOverride, and the prometheus.service.port.
+It also depends on the `rancher-monitoring` chart being installed with default values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port`.
 If those values are modified on the rancher-monitoring deployment, please adjust the `kiali.external_services.prometheus` url settings:
 ```
 http://{{ .Values.nameOverride }}-prometheus.{{ .Values.namespaceOverride }}.svc:{{ prometheus.service.port }}
 ```
 
-### installation
-
+### Installation
+```
 helm install rancher-istio ./ --create-namespace -n cattle-istio-system
+```

--- a/packages/rancher-istio/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio/charts/configs/istio-base.yaml
@@ -67,6 +67,7 @@ spec:
         name: istio-ingressgateway
         type: {{ .Values.ingressGateways.type }}
     global:
+      istioNamespace: {{ template "istio.namespace" . }}
       proxy:
         image: {{ .Values.global.proxy.image }}
       proxy_init:

--- a/packages/rancher-istio/charts/samples/overlay-example.yaml
+++ b/packages/rancher-istio/charts/samples/overlay-example.yaml
@@ -1,0 +1,37 @@
+apiVersion: install.istio.io/v1alpha1
+kind: IstioOperator
+spec:
+  components:
+    ingressGateways:
+    - enabled: true
+      name: ilb-gateway
+      namespace: user-ingressgateway-ns
+      k8s:
+        resources:
+          requests:
+            cpu: 200m
+        service:
+          ports:
+          - name: tcp-citadel-grpc-tls
+            port: 8060
+            targetPort: 8060
+          - name: tcp-dns
+            port: 5353
+        serviceAnnotations:
+          cloud.google.com/load-balancer-type: internal
+    - enabled: true
+      name: other-gateway
+      namespace: cattle-istio-system
+      k8s:
+        resources:
+          requests:
+            cpu: 200m
+        service:
+          ports:
+          - name: tcp-citadel-grpc-tls
+            port: 8060
+            targetPort: 8060
+          - name: tcp-dns
+            port: 5353
+        serviceAnnotations:
+          cloud.google.com/load-balancer-type: internal

--- a/packages/rancher-istio/charts/templates/_helpers.tpl
+++ b/packages/rancher-istio/charts/templates/_helpers.tpl
@@ -1,0 +1,4 @@
+{{/* Ensure namespace is set the same everywhere */}}
+{{- define "istio.namespace" -}}
+  {{- .Release.Namespace | default "istio-system" -}}
+{{- end -}}

--- a/packages/rancher-istio/charts/templates/admin-role.yaml
+++ b/packages/rancher-istio/charts/templates/admin-role.yaml
@@ -4,8 +4,8 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-  namespace: istio-system
   name: istio-admin
+  namespace: {{ template "istio.namespace" . }}
 rules:
   - apiGroups:
       - config.istio.io

--- a/packages/rancher-istio/charts/templates/base-config-map.yaml
+++ b/packages/rancher-istio/charts/templates/base-config-map.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-installer-base
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
 data:
 {{ tpl (.Files.Glob "configs/*").AsConfig . | indent 2 }}

--- a/packages/rancher-istio/charts/templates/clusterrolebinding.yaml
+++ b/packages/rancher-istio/charts/templates/clusterrolebinding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: istio-installer
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
 roleRef:
   kind: ClusterRole
   name: istio-installer

--- a/packages/rancher-istio/charts/templates/edit-role.yaml
+++ b/packages/rancher-istio/charts/templates/edit-role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
   name: istio-edit
 rules:
   - apiGroups:

--- a/packages/rancher-istio/charts/templates/istio-install-job.yaml
+++ b/packages/rancher-istio/charts/templates/istio-install-job.yaml
@@ -2,13 +2,11 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: istioctl-installer
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "-5"
-    # Todo: use following line instead
-    # "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   backoffLimit: 1
   template:
@@ -23,6 +21,10 @@ spec:
           - name: CANARY_REVISION
             value: {{ .Values.revision }}
           {{- end }}
+          - name: ISTIO_NAMESPACE
+            value: {{ template "istio.namespace" . }}
+          - name: FORCE_INSTALL
+            value: {{ .Values.forceInstall | default "false" | quote }}
           command: ["/bin/sh","-c"]
           args: ["/usr/local/app/scripts/run.sh"]
           volumeMounts:

--- a/packages/rancher-istio/charts/templates/istio-uninstall-job.yaml
+++ b/packages/rancher-istio/charts/templates/istio-uninstall-job.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: istioctl-uninstaller
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "-5"
@@ -16,6 +16,8 @@ spec:
           env:
           - name: RELEASE_NAME
             value: {{ .Release.Name }}
+          - name: ISTIO_NAMESPACE
+            value: {{ template "istio.namespace" . }}
           command: ["/bin/sh","-c"]
           args: ["/usr/local/app/scripts/uninstall_istio_system.sh"]
           volumeMounts:

--- a/packages/rancher-istio/charts/templates/overlay-config-map.yaml
+++ b/packages/rancher-istio/charts/templates/overlay-config-map.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: istio-installer-overlay
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
 data:
   overlay-config.yaml: {{ toYaml .Values.overlayFile | indent 2 }}
 {{- end }}

--- a/packages/rancher-istio/charts/templates/service-monitors.yaml
+++ b/packages/rancher-istio/charts/templates/service-monitors.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: envoy-stats-monitor
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
   labels:
     monitoring: istio-proxies
 spec:
@@ -34,7 +34,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: istio-component-monitor
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
   labels:
     monitoring: istio-components
 spec:

--- a/packages/rancher-istio/charts/templates/serviceaccount.yaml
+++ b/packages/rancher-istio/charts/templates/serviceaccount.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     name: istio-installer
-    namespace: istio-system
+    namespace: {{ template "istio.namespace" . }}

--- a/packages/rancher-istio/charts/templates/view-role.yaml
+++ b/packages/rancher-istio/charts/templates/view-role.yaml
@@ -4,7 +4,7 @@ kind: ClusterRole
 metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-  namespace: istio-system
+  namespace: {{ template "istio.namespace" . }}
   name: istio-view
 rules:
   - apiGroups:

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,7 +1,8 @@
 revision: "" # leave blank for no canary deployment, or set to given revision, eg: "1-7-2"
 overlayFile: ""
-tag: 1.6.7
-installerVersion: 0.1.5
+tag: 1.6.8
+installerVersion: 0.1.6
+forceInstall: false
 
 istiocoredns:
     enabled: false


### PR DESCRIPTION
Change namespace from istio-system to cattle-istio system
 -- Left option to default to istio-system if being installed on own an not through rancher

Change istioctl-installer job to delete on success (to ensure namespace is clear after uninstall)

Add value to set for forceInstall to bypass version checks and analyze checks in installer script

Added back in addon components since those are still available until 1.7.x (and we are currently at 1.6.7)