### PR TITLE
Fix remove_timestamp_from_diff in generate-patch

### DIFF
--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -11,7 +11,8 @@ function remove_timestamp_from_diff {
 	time="[[:digit:]]\{2\}:[[:digit:]]\{2\}:[[:digit:]]\{2\}.[[:digit:]]\{9\}"
 	timezone="[-\+][[:digit:]]\{4\}"
 	timestamp_format="${date}[[:space:]]${time}[[:space:]]${timezone}"
-	sed -i '' "s/\(${prefix} ${filename_format}\)[[:space:]]${timestamp_format}/\1/g" ${f}/$(basename -- ${f}).patch
+	sed -i.bak "s/\(${prefix} ${filename_format}\)[[:space:]]${timestamp_format}/\1/g" ${f}/$(basename -- ${f}).patch
+	rm ${f}/$(basename -- ${f}).patch.bak
 }
 
 function revert_crd_changes {
@@ -63,10 +64,10 @@ for f in packages/*; do
 					revert_crd_changes ${f}
 				fi
 				diff -x *.tgz -x *.lock -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
-				remove_timestamp_from_diff
 				if [[ "${split_crds}" == "true" ]]; then
 					./scripts/prepare-crds ${f}
 				fi
+				remove_timestamp_from_diff
 			fi
 			rm -rf ${f}/charts-original
 		fi


### PR DESCRIPTION
This PR resolves two issues that are found when working with charts:
- On a failed sed command for removing the timestamp, the patch also
fails to regenerate the CRD package. Since removing the timestamps on the patch
before or after generating the CRD package makes no difference, we can just
move the `remove_timestamp_from_diff` command to the end of the for loop.
- The sed command would fail depending on what type of sed you were using.
The easiest fix is to provide a backup file extension name like `.bak` and just
delete the file after generating it to have it work with both types of sed.

Related comment for second issue: https://github.com/rancher/dev-charts/pull/38#discussion_r458442691