### PR TITLE
Remove canary and set version to 1.6.7 for upgrade testing

### DIFF
--- a/packages/rancher-istio/charts/templates/istio-install-job.yaml
+++ b/packages/rancher-istio/charts/templates/istio-install-job.yaml
@@ -17,10 +17,6 @@ spec:
           env:
           - name: RELEASE_NAME
             value: {{ .Release.Name }}
-          {{- if .Values.revision }}
-          - name: CANARY_REVISION
-            value: {{ .Values.revision }}
-          {{- end }}
           - name: ISTIO_NAMESPACE
             value: {{ template "istio.namespace" . }}
           - name: FORCE_INSTALL

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,7 +1,6 @@
-revision: "" # leave blank for no canary deployment, or set to given revision, eg: "1-7-2"
 overlayFile: ""
-tag: 1.6.8
-installerVersion: 0.1.6
+tag: 1.6.7
+installerVersion: 1.6.7-rancher1
 forceInstall: false
 
 istiocoredns:
@@ -19,7 +18,7 @@ base:
 cni:
     enabled: false
     repository: rancher/istio-install-cni
-    tag: 1.6.8
+    tag: 1.6.7
 
 egressGateways:
     enabled: false
@@ -35,17 +34,17 @@ istiodRemote:
 pilot:
     enabled: true
     repository: rancher/istio-pilot
-    tag: 1.6.8
+    tag: 1.6.7
 
 policy:
     enabled: true
     repository: rancher/istio-mixer
-    tag: 1.6.8
+    tag: 1.6.7
 
 telemetry:
     enabled: true
     repository: rancher/istio-mixer
-    tag: 1.6.8
+    tag: 1.6.7
 
 sidecarInjectorWebhook:
   enableNamespacesByDefault: false
@@ -58,10 +57,10 @@ global:
   systemDefaultRegistry: ""
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.6.8
+    tag: 1.6.7
   proxy_init:
     repository: rancher/istio-proxyv2
-    tag: 1.6.8
+    tag: 1.6.7
 
 # this can be removed in 1.7 as it is default
 meshConfig:


### PR DESCRIPTION
Needed to create a an older version of istio with recent changes (name change, remove canary, manifest changes) for upgrade testing 