### PR TITLE
Allow patches on remote deps with fixed versions

### DIFF
--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -58,16 +58,41 @@ for f in packages/*; do
 				mkdir -p ${f}/charts-original
 				curl -sLf ${url} | tar xvzf - -C ${f}/charts-original --strip ${fields} ${subdirectory} > /dev/null 2>&1
 			fi
+			if [[ -f ${f}/charts/requirements.yaml ]]; then
+				i=0
+				while ! [[ -z $(yq r ${f}/charts/requirements.yaml "dependencies[${i}]") ]]; do
+					subchart=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].name" | head -n 1)
+					version=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].version" | head -n 1)
+					helm_repo=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].repository" | head -n 1)
+					if [[ ${helm_repo} == file://* ]] || [[ ${version} == *'*'* ]]; then
+						# Subchart is tracked locally; patches will not be tracked
+						rm -rf ${f}/charts-original/charts/${subchart}
+						((i=i+1))
+						continue
+					fi
+					# Subchart is tracked in remote Helm repo with a fixed version number; we grab the download URL and get the local chart archive
+					echo "Comparing current changes to ${subchart}-${version} against upstream found at ${helm_repo}"
+					download_url=$(curl -sLf ${helm_repo}index.yaml | cat | yq r - "entries.${subchart}.(version == ${version}).urls[0]")
+					curl -sLf ${download_url} | tar xvzf - -C ${f}/charts-original/charts > /dev/null 2>&1
+					((i=i+1))
+				done
+			fi
 			if [[ -d ${f}/charts ]]; then
 				split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
 				if [[ "${split_crds}" == "true" ]]; then
 					revert_crd_changes ${f}
 				fi
 				diff -x *.tgz -x *.lock -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
+				if ! [[ -s ${f}/$(basename -- ${f}).patch ]]; then
+					# If no changes exist in patch then remove it
+					rm ${f}/$(basename -- ${f}).patch
+				fi
+				if [[ -f ${f}/$(basename -- ${f}).patch ]]; then
+					remove_timestamp_from_diff
+				fi
 				if [[ "${split_crds}" == "true" ]]; then
 					./scripts/prepare-crds ${f}
 				fi
-				remove_timestamp_from_diff
 			fi
 			rm -rf ${f}/charts-original
 		fi

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-# rebase the patch with upsteam charts defined in package.yaml. Make sure patches still apply
-# for the latest upsteam charts. If there is conflits commiter should solve it.
-
+# Pull in the upstream charts
 for f in packages/*; do
-	if [[ -f ${f}/package.yaml ]]; then
-		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
+	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
+		if [[ -f ${f}/package.yaml ]]; then
 			url=$(cat ${f}/package.yaml | yq r - url)
 			subdirectory=$(cat ${f}/package.yaml | yq r - subdirectory)
 			type=$(cat ${f}/package.yaml | yq r - type)
@@ -31,25 +29,17 @@ for f in packages/*; do
 			else
 				curl -sLf ${url} | tar xvzf - -C ${f}/charts --strip ${fields} ${subdirectory} > /dev/null 2>&1
 			fi
+		fi
+		# Loop through packages again and copy dependencies over
+		# If sub-charts existed as package.yaml they will now be vendored into parent
+		./scripts/prepare-subcharts ${f}
+
+		# Apply the patch and split the CRD package
+		if [[ -f ${f}/package.yaml ]]; then
 			for file in $(find ./${f} -type f -name "*.patch"); do
 				basename=$(basename -- ${file})
 				patch -E -p3 -d ${f}/charts < ${f}/$basename
 			done
-		fi
-	fi
-done
-
-# Loop through packages again and copy dependencies over
-# If sub-charts existed as package.yaml they will now be vendored into parent
-for f in packages/*; do
-	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
-		./scripts/prepare-subcharts ${f}
-	fi
-done
-
-for f in packages/*; do
-	if [[ -f ${f}/package.yaml ]]; then
-		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
 			split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
 			if [[ "${split_crds}" == "true" ]]; then
 				./scripts/prepare-crds ${f}

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -35,10 +35,6 @@ for f in packages/*; do
 				basename=$(basename -- ${file})
 				patch -E -p3 -d ${f}/charts < ${f}/$basename
 			done
-			split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
-			if [[ "${split_crds}" == "true" ]]; then
-				./scripts/prepare-crds ${f}
-			fi
 		fi
 	fi
 done
@@ -47,26 +43,17 @@ done
 # If sub-charts existed as package.yaml they will now be vendored into parent
 for f in packages/*; do
 	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
-		copied_dependencies=()
-		if [[ -f ${f}/charts/requirements.yaml ]]; then
-			repos=$(cat ${f}/charts/requirements.yaml | yq r - "dependencies.*.repository")
-			while IFS= read -r repo; do
-				if [[ ${repo} == file://* ]]; then
-					charts_path=${repo/file:\/\//${f}/charts/}
-					overlay_path=${repo/file:\/\//${f}/overlay/}
-					if [[ ! -d $charts_path ]] && [[ -d $overlay_path ]]; then
-						cp -R $overlay_path $charts_path
-						copied_dependencies+=("${charts_path}")
-					fi
-				fi
-			done < <(echo "${repos}")
+		./scripts/prepare-subcharts ${f}
+	fi
+done
+
+for f in packages/*; do
+	if [[ -f ${f}/package.yaml ]]; then
+		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
+			split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
+			if [[ "${split_crds}" == "true" ]]; then
+				./scripts/prepare-crds ${f}
+			fi
 		fi
-		pwd=$(pwd)
-		cd ${f}/charts
-		helm dependency update
-		cd $pwd
-		for dep in "${copied_dependencies[@]}"; do
-			rm -rf $dep
-		done
 	fi
 done

--- a/scripts/prepare-subcharts
+++ b/scripts/prepare-subcharts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+if [[ -z $1 ]]; then
+	echo "No directory provided to pull in subcharts"
+	exit 1
+fi
+
+f=$1
+
+copied_dependencies=()
+if [[ -f ${f}/charts/requirements.yaml ]]; then
+	repos=$(cat ${f}/charts/requirements.yaml | yq r - "dependencies.*.repository")
+	while IFS= read -r repo; do
+		if [[ ${repo} == file://* ]]; then
+			charts_path=${repo/file:\/\//${f}/charts/}
+			overlay_path=${repo/file:\/\//${f}/overlay/}
+			if [[ ! -d $charts_path ]] && [[ -d $overlay_path ]]; then
+				cp -R $overlay_path $charts_path
+				copied_dependencies+=("${charts_path}")
+			fi
+		fi
+	done < <(echo "${repos}")
+fi
+
+pwd=$(pwd)
+cd ${f}/charts
+helm dependency update
+cd $pwd
+
+for dep in "${copied_dependencies[@]}"; do
+	rm -rf $dep
+done

--- a/scripts/prepare-subcharts
+++ b/scripts/prepare-subcharts
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -e
 
+# Pull in the subcharts required by a chart
+#
+# At the end of this process, all the required subcharts will exist in the charts/charts directory.
+# Charts will either exist as chart archives (i.e. a .tgz file) if they are not eligible for patches or
+# as a local chart archive (i.e. a directory) if they are eligible for patches (i.e. remote subchart with fixed version number)
+#
+# In order to prepare sub-charts so that we can patch them:
+# - We apply any patches on the requirements.yaml to track any new subcharts added via patch or updates to version numbers of the subcharts
+# - We pull in any subchart that is a feature chart by running prepare on it
+# - We copy in any local subcharts that are located in the overlay/ directory
+# - We call `helm dependency update` to generate chart archives (.tgz files) for local and remote charts
+# - We clean up any copied charts from the overlay/ directory
+# - We clean up any feature charts that were recursively prepared
+# - We unarchive the chart archive if and only if its a remote subchart with a fixed version number (which means it can be patched)
+# - We revert the initial patch we applied on the requirements.yaml
+
 if [[ -z $1 ]]; then
 	echo "No directory provided to pull in subcharts"
 	exit 1
@@ -8,26 +24,118 @@ fi
 
 f=$1
 
-copied_dependencies=()
-if [[ -f ${f}/charts/requirements.yaml ]]; then
-	repos=$(cat ${f}/charts/requirements.yaml | yq r - "dependencies.*.repository")
-	while IFS= read -r repo; do
-		if [[ ${repo} == file://* ]]; then
-			charts_path=${repo/file:\/\//${f}/charts/}
-			overlay_path=${repo/file:\/\//${f}/overlay/}
-			if [[ ! -d $charts_path ]] && [[ -d $overlay_path ]]; then
-				cp -R $overlay_path $charts_path
-				copied_dependencies+=("${charts_path}")
-			fi
-		fi
-	done < <(echo "${repos}")
+if ! [[ -f ${f}/charts/requirements.yaml ]]; then
+	echo "Chart ${CHART} has no dependencies; skipping step to pull in dependencies"
+	exit 0
 fi
 
+# Apply the patch on the requirements.yaml
+for file in $(find ./${f} -type f -name "*.patch"); do
+	# This awk statement extracts the contents between the first line that matches the regex `diff.*requirements.yaml`
+    # and the first line that matches the regex `diff` after it. This corresponds to the contents of any patches on the requirements.yaml file.
+	awk '/diff.*requirements.yaml/{flag=1;next}/diff/{flag=0}flag' $file >> ${f}/requirements.patch
+done
+if [[ -f ${f}/requirements.patch ]] && [[ -s ${f}/requirements.patch ]]; then
+	patch -E -p3 -d ${f}/charts < ${f}/requirements.patch
+fi
+
+# Pull in any dependencies that are stored as package.yamls or in the overlay/ folder
+overlaid_dependencies=()
+mirrored_dependencies=()
+i=0
+while ! [[ -z $(yq r ${f}/charts/requirements.yaml "dependencies[${i}]") ]]; do
+	repo=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].repository")
+	if [[ ${repo} == file://* ]]; then
+		charts_path=${repo/file:\/\//${f}/charts/}
+		if [[ -d ${charts_path} ]]; then
+			# Chart already exists
+			((i=i+1))
+			continue
+		fi
+		if [[ -f ${charts_path%/*}/package.yaml ]]; then
+			# Prepare the subchart and pull it in
+			subchart=$(basename -- ${charts_path%/*})
+			mirrored_dependencies+=("${subchart}")
+			prepare_subchart () {
+				local CURRENT_CHART=${CHART}
+				local CURRENT_INDEX=${i}
+				CHART=${subchart} ./scripts/prepare
+				CHART=${CURRENT_CHART}
+				i=${CURRENT_INDEX}
+			}
+			prepare_subchart
+		fi
+		overlay_path=${repo/file:\/\//${f}/overlay/}
+		if [[ -d $overlay_path ]]; then
+			# Pull in the subchart from the overlay/ directory
+			cp -R $overlay_path $charts_path
+			overlaid_dependencies+=("${charts_path}")
+		fi
+	fi
+	((i=i+1))
+done
+
+# Update the current requirements.lock and requirements.yaml to keep track of the overlay/ dependencies
 pwd=$(pwd)
 cd ${f}/charts
 helm dependency update
 cd $pwd
 
-for dep in "${copied_dependencies[@]}"; do
+# Remove any dependencies that came from the overlay/ directory, we don't track patches for overlay files
+for dep in "${overlaid_dependencies[@]}"; do
 	rm -rf $dep
 done
+
+# Cleanup any dependencies that came from another local chart, any changes should be made there.
+for subchart in "${mirrored_dependencies[@]}"; do
+	cleanup_subchart () {
+		local CURRENT_CHART=${CHART}
+		CHART=${subchart} ./scripts/clean
+		CHART=${CURRENT_CHART}
+	}
+	cleanup_subchart
+done
+
+if ! [[ -d ${f}/charts/charts ]]; then
+	exit 0
+fi
+
+# If it is possible to patch a subchart, create a local chart archive for it
+# Otherwise, it should only be stored as a tgz file to prevent users from accidentally patching it
+i=0
+while ! [[ -z $(yq r ${f}/charts/requirements.yaml "dependencies[${i}]") ]]; do
+	name=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].name")
+	version=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].version")
+	charts_path=${f}/charts/charts/${name}
+	subchart_tgz=${name}-${version}.tgz
+	repo=$(yq r ${f}/charts/requirements.yaml "dependencies[${i}].repository")
+	if [[ ${repo} == file://* ]]; then
+		# Subcharts that are tracked locally should be directly edited, not via a patch
+		if [[ -f ${subchart_tgz} ]]; then
+			rm -rf charts_path
+		fi
+		((i=i+1))
+		continue
+	fi
+	subchart_path=$(ls ${f}/charts/charts/${subchart_tgz})
+	if [[ ${version} == *'*'* ]]; then
+		# Subcharts that are tracked remotely must have a fixed version number
+		if [[ -f ${subchart_path} ]]; then
+			rm -rf ${charts_path}
+		fi
+		((i=i+1))
+		continue
+	fi
+	# Subchart could be patched
+	if [[ -f ${subchart_path} ]]; then
+		tar xvzf ${f}/charts/charts/${subchart_tgz} -C ${f}/charts/charts > /dev/null 2>&1
+		rm ${f}/charts/charts/${subchart_tgz}
+	fi
+	((i=i+1))
+done
+
+# Undo the patch on the requirements.yaml
+if [[ -f ${f}/requirements.patch ]] && [[ -s ${f}/requirements.patch ]]; then
+	patch -R -E -p3 -d ${f}/charts < ${f}/requirements.patch
+	rm ${f}/requirements.patch
+fi


### PR DESCRIPTION
This commit adds the ability to add patches on subcharts in `rancher/charts` that meet the following constraints:
- Must be a remote chart (i.e. the repo url cannot point to a `file://<path>`)
- Must have a fixed version number (since we need a consistent base to apply the patch on)

The following changes have been made to the scripts to faciliate this feature:

**prepare**

Only run the patch after preparing the subchart

**prepare-subcharts:**

Inital checks:
1. We only prepare the subcharts if the chart has a `requirements.yaml`.
2. Extract the patches that would be applied to the requirements.yaml and only apply that

Note: in the future, we need to add support for dependencies outlined in the Chart.yaml directory, which is currently the recommended approach for Helm 3 charts that use `apiVersion: v2`, but since none of our charts currently use that it is assumed that they will encode their dependencies in a `requirements.yaml` at the moment.

Generate special dependencies (overlay, package.yaml):
1. For dependencies that are mirrored (i.e. rancher-kiali-server, where the dependency itself is stored as a `package.yaml`) that have not generated a `charts/` directory yet, we recursively run the `prepare` script for them in order to generate the directories so that `helm dependency update` can pull them in. The assumption here is that there will be no circular dependencies, although there is no explicit check for this.
2. For dependencies that are overlaid, we perform the overlay so that `helm dependency update` operates as expected.

Pull in latest subcharts and update files:
1. Perform `helm dependency update` to update the `requirements.yaml` and `requirements.lock` with the latest subchart versions

Cleanup (overlay, package.yaml, patched requirements)
1. Remove overlaid dependencies since they won't be tracked in the patch
2. Run the `clean` script on the mirrored dependencies
3. Revert the patch on the requirements.yaml

Apply logic to enable / disable patching:
1. If a subchart is a local chart, leave it as a tgz so it will be ignored on patch
2. If a subchart does not have a fixed version number, leave it as a tgz so it will be ignored on patch
3. If neither of these are true, unarchive the tgz for the subchart and delete the tgz so it will be tracked by the patch

NOTE: since the dependency still exists as either a tgz or a directory, `generate-charts` will not break from this change.

**generate-patch:**

Loop through the local `charts/requirements.yaml` to update the `charts-original/charts` directory:
1. If a subchart is not a local chart, remove it as we don't need to check for patches against it
2. If a subchart does not have a fixed version number,  remove it as we don't need to check for patches against it
3. If neither of these are true, pull in the version number specified from the remote helm repo to track patches against it.

**Why does the version number need to be fixed?**:

In general, Helm chart owners can use wildcards within a `requirements.yaml` to specify the version of a subchart when a specific patch version does not necessarily need to be fixed. This is usually a great feature since that means that parent charts do not need to be updated in order for a `helm dependency update` to automatically pull in the latest versions of a dependency that do not break the parent chart; however, this causes an issue with patching subcharts since the base that the patch is applied on is not fixed.

Therefore, this commit only allows users to apply patches on subcharts that have a fixed subchart version specified in their `requirements.yaml`.

**Why can't we track local charts?**

If the chart is local to this repo, the assumption is tha