### PR TITLE
CIS v2 charts

### DIFF
--- a/packages/rancher-cis-benchmark/charts/Chart.yaml
+++ b/packages/rancher-cis-benchmark/charts/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: v0.0.1
+description: The cis-operator enables running CIS benchmark security scans on a kubernetes cluster
+name: rancher-cis-benchmark
+version: 0.0.1
+keywords:
+- security
+annotations:
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/namespace: cis-operator-system
+  catalog.cattle.io/release-name: rancher-cis-benchmark
+  catalog.cattle.io/ui-component: rancher-cis-benchmark
+  catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1

--- a/packages/rancher-cis-benchmark/charts/README.md
+++ b/packages/rancher-cis-benchmark/charts/README.md
@@ -1,0 +1,14 @@
+# Rancher CIS Benchmark Chart
+
+The cis-operator enables running CIS benchmark security scans on a kubernetes cluster and generate compliance reports.
+
+# Installation
+
+### Requirements
+
+This chart depends on the rancher-cis-benchmark-crd chart.
+
+### Installation
+```
+helm install rancher-cis-benchmark ./ --create-namespace -n cis-operator-system
+```

--- a/packages/rancher-cis-benchmark/charts/crds/clusterscan.yaml
+++ b/packages/rancher-cis-benchmark/charts/crds/clusterscan.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterscans.cis.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.display.state
+    name: Status
+    type: string
+  - JSONPath: .status.lastRunScanProfileName
+    name: ClusterScanProfile
+    type: string
+  - JSONPath: .status.summary.total
+    name: Total
+    type: string
+  - JSONPath: .status.summary.pass
+    name: Pass
+    type: string
+  - JSONPath: .status.summary.fail
+    name: Fail
+    type: string
+  - JSONPath: .status.summary.skip
+    name: Skip
+    type: string
+  - JSONPath: .status.summary.notApplicable
+    name: Not Applicable
+    type: string
+  - JSONPath: .status.lastRunTimestamp
+    name: LastRunTimestamp
+    type: string
+  group: cis.cattle.io
+  names:
+    kind: ClusterScan
+    plural: clusterscans
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            scanProfileName:
+              nullable: true
+              type: string
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    nullable: true
+                    type: string
+                  lastUpdateTime:
+                    nullable: true
+                    type: string
+                  message:
+                    nullable: true
+                    type: string
+                  reason:
+                    nullable: true
+                    type: string
+                  status:
+                    nullable: true
+                    type: string
+                  type:
+                    nullable: true
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            display:
+              nullable: true
+              properties:
+                error:
+                  type: boolean
+                message:
+                  nullable: true
+                  type: string
+                state:
+                  nullable: true
+                  type: string
+                transitioning:
+                  type: boolean
+              type: object
+            lastRunScanProfileName:
+              nullable: true
+              type: string
+            lastRunTimestamp:
+              nullable: true
+              type: string
+            observedGeneration:
+              type: integer
+            summary:
+              nullable: true
+              properties:
+                fail:
+                  type: integer
+                notApplicable:
+                  type: integer
+                pass:
+                  type: integer
+                skip:
+                  type: integer
+                total:
+                  type: integer
+              type: object
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/rancher-cis-benchmark/charts/crds/clusterscanbenchmark.yaml
+++ b/packages/rancher-cis-benchmark/charts/crds/clusterscanbenchmark.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterscanbenchmarks.cis.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.clusterProvider
+    name: ClusterProvider
+    type: string
+  - JSONPath: .spec.minKubernetesVersion
+    name: MinKubernetesVersion
+    type: string
+  - JSONPath: .spec.maxKubernetesVersion
+    name: MaxKubernetesVersion
+    type: string
+  group: cis.cattle.io
+  names:
+    kind: ClusterScanBenchmark
+    plural: clusterscanbenchmarks
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            clusterProvider:
+              nullable: true
+              type: string
+            customBenchmarkConfigMapName:
+              nullable: true
+              type: string
+            customBenchmarkConfigMapNameSpace:
+              nullable: true
+              type: string
+            maxKubernetesVersion:
+              nullable: true
+              type: string
+            minKubernetesVersion:
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/rancher-cis-benchmark/charts/crds/clusterscanprofile.yaml
+++ b/packages/rancher-cis-benchmark/charts/crds/clusterscanprofile.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterscanprofiles.cis.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.benchmarkVersion
+    name: BenchmarkVersion
+    type: string
+  group: cis.cattle.io
+  names:
+    kind: ClusterScanProfile
+    plural: clusterscanprofiles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            benchmarkVersion:
+              nullable: true
+              type: string
+            skipTests:
+              items:
+                nullable: true
+                type: string
+              nullable: true
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/rancher-cis-benchmark/charts/crds/clusterscanreport.yaml
+++ b/packages/rancher-cis-benchmark/charts/crds/clusterscanreport.yaml
@@ -1,0 +1,40 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterscanreports.cis.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.lastRunTimestamp
+    name: LastRunTimestamp
+    type: string
+  - JSONPath: .spec.benchmarkVersion
+    name: BenchmarkVersion
+    type: string
+  group: cis.cattle.io
+  names:
+    kind: ClusterScanReport
+    plural: clusterscanreports
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            benchmarkVersion:
+              nullable: true
+              type: string
+            lastRunTimestamp:
+              nullable: true
+              type: string
+            reportJSON:
+              nullable: true
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/rancher-cis-benchmark/charts/templates/_helpers.tpl
+++ b/packages/rancher-cis-benchmark/charts/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/* Ensure namespace is set the same everywhere */}}
+{{- define "cis.namespace" -}}
+  {{- .Release.Namespace | default "cis-operator-system" -}}
+{{- end -}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Windows cluster will add default taint for linux nodes,
+add below linux tolerations to workloads could be scheduled to those linux nodes
+*/}}
+{{- define "linux_node_tolerations" -}}
+- key: "cattle.io/os"
+  value: "linux"
+  effect: "NoSchedule"
+  operator: "Equal"
+{{- end -}}

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-cis-1.5.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-cis-1.5.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: cis-1.5
+spec:
+  clusterProvider: ""
+  minKubernetesVersion: "1.15.0"

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-eks-1.0.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-eks-1.0.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: eks-1.0
+spec:
+  clusterProvider: eks
+  minKubernetesVersion: "1.15.0"

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-gke-1.0.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-gke-1.0.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: gke-1.0
+spec:
+  clusterProvider: gke
+  minKubernetesVersion: "1.15.0"

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.5-hardened.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.5-hardened.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: rke-cis-1.5-hardened
+spec:
+  clusterProvider: rke
+  minKubernetesVersion: "1.15.0"

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.5-permissive.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.5-permissive.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: rke-cis-1.5-permissive
+spec:
+  clusterProvider: rke
+  minKubernetesVersion: "1.15.0"

--- a/packages/rancher-cis-benchmark/charts/templates/cis-roles.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/cis-roles.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: cis-admin
+  namespace: {{ template "cis.namespace" . }}
+rules:
+  - apiGroups:
+      - cis.cattle.io
+    resources:
+      - clusterscanbenchmarks
+      - clusterscanprofiles
+      - clusterscans
+      - clusterscanreports
+    verbs: ["create", "update", "delete", "patch","get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  namespace: {{ template "cis.namespace" . }}
+  name: cis-edit
+rules:
+  - apiGroups:
+      - cis.cattle.io
+    resources:
+      - clusterscanbenchmarks
+      - clusterscanprofiles
+      - clusterscans
+      - clusterscanreports
+    verbs: ["create", "update", "delete", "patch","get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  namespace: {{ template "cis.namespace" . }}
+  name: cis-view
+rules:
+  - apiGroups:
+      - cis.cattle.io
+    resources:
+      - clusterscanbenchmarks
+      - clusterscanprofiles
+      - clusterscans
+      - clusterscanreports
+    verbs: ["get", "watch", "list"]

--- a/packages/rancher-cis-benchmark/charts/templates/configmap.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/configmap.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: default-clusterscanprofiles
+  namespace: {{ template "cis.namespace" . }}
+data:
+  # Default ClusterScanProfiles per cluster provider type
+  rke: "rke-profile-permissive"
+  eks: "eks-profile"
+  gke: "gke-profile"
+  default: "cis-1.5-profile"

--- a/packages/rancher-cis-benchmark/charts/templates/deployment.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cis-operator
+  namespace: {{ template "cis.namespace" . }}
+  labels:
+    cis.cattle.io/operator: cis-operator
+spec:
+  selector:
+    matchLabels:
+      cis.cattle.io/operator: cis-operator
+  template:
+    metadata:
+      labels:
+        cis.cattle.io/operator: cis-operator
+    spec:
+      serviceAccountName: cis-operator-serviceaccount
+      containers:
+      - name: cis-operator
+        image: '{{ template "system_default_registry" . }}{{ .Values.image.cisoperator.repository }}:{{ .Values.image.cisoperator.tag }}'
+        imagePullPolicy: Always
+        env:
+        - name: SECURITY_SCAN_IMAGE
+          value: {{ .Values.image.securityScan.repository }}
+        - name: SECURITY_SCAN_IMAGE_TAG
+          value: {{ .Values.image.securityScan.tag }}
+        - name: SONOBUOY_IMAGE
+          value: {{ .Values.image.sonobuoy.repository }}
+        - name: SONOBUOY_IMAGE_TAG
+          value: {{ .Values.image.sonobuoy.tag }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+      nodeSelector:
+        kubernetes.io/os: linux
+      {{- with .Values.nodeSelector }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- include "linux_node_tolerations" . | nindent 8}}
+      {{- with .Values.tolerations }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/rancher-cis-benchmark/charts/templates/rbac.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/rbac.yaml
@@ -1,0 +1,43 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: rancher-cis-benchmark
+    app.kubernetes.io/instance: release-name
+  name: cis-operator-role
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: rancher-cis-benchmark
+    app.kubernetes.io/instance: release-name
+  name: cis-operator-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cis-operator-role
+subjects:
+- kind: ServiceAccount
+  name: cis-serviceaccount
+  namespace: {{ template "cis.namespace" . }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cis-operator-installer
+subjects:
+- kind: ServiceAccount
+  name: cis-operator-serviceaccount
+  namespace: {{ template "cis.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofile-cis-1.5.yml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofile-cis-1.5.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: cis-1.5-profile
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: cis-1.5

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-hardened.yml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-hardened.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: rke-profile-hardened
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: rke-cis-1.5-hardened

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-permissive.yml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-permissive.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: rke-profile-permissive
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: rke-cis-1.5-permissive

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofileeks.yml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofileeks.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: eks-profile
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: eks-1.0

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofilegke.yml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofilegke.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: gke-profile
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: gke-1.0

--- a/packages/rancher-cis-benchmark/charts/templates/serviceaccount.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/serviceaccount.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ template "cis.namespace" . }}
+  name: cis-operator-serviceaccount
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: {{ template "cis.namespace" . }}
+  labels:
+    app.kubernetes.io/name: rancher-cis-benchmark
+    app.kubernetes.io/instance: release-name
+  name: cis-serviceaccount

--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -1,0 +1,36 @@
+# Default values for rancher-cis-benchmark.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  cisoperator:
+    repository: rancher/cis-operator
+    tag: v0.0.4
+  securityScan:
+    repository: rancher/security-scan
+    tag: v0.2.0
+  sonobuoy:
+    repository: rancher/sonobuoy-sonobuoy
+    tag: v0.16.3
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+global:
+  cattle:
+    systemDefaultRegistry: ""

--- a/packages/rancher-cis-benchmark/package.yaml
+++ b/packages/rancher-cis-benchmark/package.yaml
@@ -1,0 +1,2 @@
+generateCRDChart:
+  enabled: true


### PR DESCRIPTION
Updated:
--------------
- NO separate CRD chart. Combine CRDs into rancher-cis-benchmark/crds chart itself.
- Add a package.yaml under rancher-cis-benchmark chart
- Added the linux nodeSelector and tolerations


---------------
Adding two charts for CIS v2 feature:

- rancher-cis-benchmark-crds - CRD chart
- rancher-cis-benchmark - chart deploying rancher/cis-operator

Commands to install the charts:
helm install clusterscan-operator ./rancher-cis-benchmark/charts/ --create-namespace=true -n cis-operator-system --
kubeconfig <kubeconfig>

Commands to uninstall the charts:
helm uninstall clusterscan-operator -n cis-operator-system --kubeconfig <kubeconfig>
 