### PR TITLE
Add chart for backup-restore-operator

### DIFF
--- a/packages/backup-restore-operator/charts/Chart.yaml
+++ b/packages/backup-restore-operator/charts/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+appVersion: v0.0.1-rc4
+description: Helm chart for installing the rancher backup-restore-operator
+name: backup-restore-operator
+version: 0.0.1
+annotations:
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/namespace: cattle-resources-system
+  catalog.cattle.io/release-name: backup-restore-operator
+  catalog.cattle.io/ui-component: backup-restore-operator

--- a/packages/backup-restore-operator/charts/examples/s3values.yaml
+++ b/packages/backup-restore-operator/charts/examples/s3values.yaml
@@ -1,0 +1,14 @@
+image: 
+  repository: rancher/backup-restore-operator
+  tag: v0.0.1-rc4
+debug: false            # Enable debug logging in controller
+# Set as empty object {} if no s3 bucket needs to be configured for the operator
+s3: 
+  credentialSecretName: creds
+  region: us-west-2
+  bucketName: rajashree-backup-test
+  folder: ecm1
+  endpoint: s3.us-west-2.amazonaws.com
+
+global:
+  systemDefaultRegistry: ""

--- a/packages/backup-restore-operator/charts/templates/_helpers.tpl
+++ b/packages/backup-restore-operator/charts/templates/_helpers.tpl
@@ -1,0 +1,9 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/packages/backup-restore-operator/charts/templates/backup.yaml
+++ b/packages/backup-restore-operator/charts/templates/backup.yaml
@@ -1,0 +1,92 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.resources.cattle.io
+spec:
+  group: resources.cattle.io
+  names:
+    kind: Backup
+    plural: backups
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            encryptionConfigName:
+              description: 'Name of secret containing the encryption config, must
+                be in the namespace of the chart: cattle-resources-system'
+              type: string
+            resourceSetName:
+              description: Name of resourceSet CR to use for backup, must be in the
+                same namespace
+              type: string
+            retentionCount:
+              type: integer
+            schedule:
+              description: Cron schedule for recurring backups
+              type: string
+            storageLocation:
+              nullable: true
+              properties:
+                s3:
+                  nullable: true
+                  properties:
+                    bucketName:
+                      type: string
+                    credentialSecretName:
+                      type: string
+                    endpoint:
+                      type: string
+                    endpointCA:
+                      type: string
+                    folder:
+                      type: string
+                    insecureTLSSkipVerify:
+                      type: boolean
+                    region:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - resourceSetName
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            lastSnapshotTs:
+              type: string
+            nextSnapshotAt:
+              type: string
+            numSnapshots:
+              type: integer
+            observedGeneration:
+              type: integer
+            summary:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/backup-restore-operator/charts/templates/clusterrolebinding.yaml
+++ b/packages/backup-restore-operator/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: backup-restore-operator-installer
+subjects:
+- kind: ServiceAccount
+  name: backup-restore-operator-serviceaccount
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/packages/backup-restore-operator/charts/templates/deployment.yaml
+++ b/packages/backup-restore-operator/charts/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  name: backup-restore-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    resources.cattle.io/operator: backup-restore
+spec:
+  selector:
+    matchLabels:
+      resources.cattle.io/operator: backup-restore
+  template:
+    metadata:
+      labels:
+        resources.cattle.io/operator: backup-restore
+    spec:
+      serviceAccountName: backup-restore-operator-serviceaccount
+      containers:
+      - name: backup-restore-operator
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: CHART_NAMESPACE
+          value: {{ .Release.Namespace }}
+          {{- if .Values.pvc }}
+        - name: DEFAULT_PVC_BACKUP_STORAGE_LOCATION
+          value: {{ .Release.Name }}-pvc
+          {{- end }}
+          {{- if .Values.s3 }}
+        - name: DEFAULT_S3_BACKUP_STORAGE_LOCATION
+          value: {{ .Release.Name }}-s3
+          {{- end }}
+        {{- if .Values.pvc }}
+        volumeMounts:
+        - mountPath: "/var/lib/backups"
+          name: pv-storage
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.pvcName }}
+          {{- end}}
+    {{- with .Values.nodeSelector }}
+    nodeSelector:
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+    affinity:
+    {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations:
+    {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/packages/backup-restore-operator/charts/templates/resourceset.yaml
+++ b/packages/backup-restore-operator/charts/templates/resourceset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcesets.resources.cattle.io
+spec:
+  group: resources.cattle.io
+  names:
+    kind: ResourceSet
+    plural: resourcesets
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        controllerReferences:
+          items:
+            properties:
+              apiVersion:
+                type: string
+              name:
+                type: string
+              namespace:
+                type: string
+              replicas:
+                type: integer
+              resource:
+                type: string
+            type: object
+          nullable: true
+          type: array
+        resourceSelectors:
+          items:
+            properties:
+              apiVersion:
+                type: string
+              kinds:
+                items:
+                  type: string
+                nullable: true
+                type: array
+              kindsRegexp:
+                type: string
+              labelSelectors:
+                nullable: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    nullable: true
+                    type: object
+                type: object
+              namespaceRegexp:
+                type: string
+              namespaces:
+                items:
+                  type: string
+                nullable: true
+                type: array
+              resourceNameRegexp:
+                type: string
+              resourceNames:
+                items:
+                  type: string
+                nullable: true
+                type: array
+            type: object
+          nullable: true
+          required:
+          - apiVersion
+          type: array
+      required:
+      - resourceSelectors
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/backup-restore-operator/charts/templates/restore.yaml
+++ b/packages/backup-restore-operator/charts/templates/restore.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.resources.cattle.io
+spec:
+  group: resources.cattle.io
+  names:
+    kind: Restore
+    plural: restores
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            backupFilename:
+              type: string
+            deleteTimeout:
+              maximum: 5
+              type: integer
+            encryptionConfigName:
+              type: string
+            prune:
+              nullable: true
+              type: boolean
+            storageLocation:
+              nullable: true
+              properties:
+                s3:
+                  nullable: true
+                  properties:
+                    bucketName:
+                      type: string
+                    credentialSecretName:
+                      type: string
+                    endpoint:
+                      type: string
+                    endpointCA:
+                      type: string
+                    folder:
+                      type: string
+                    insecureTLSSkipVerify:
+                      type: boolean
+                    region:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - backupFilename
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            numRetries:
+              type: integer
+            observedGeneration:
+              type: integer
+            restoreCompletionTs:
+              type: string
+            summary:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/backup-restore-operator/charts/templates/s3secret.yaml
+++ b/packages/backup-restore-operator/charts/templates/s3secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.s3 -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-s3
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+stringData:
+  {{- with .Values.s3}}
+  {{if .credentialSecretName }}credentialSecretName: {{ .credentialSecretName }} {{- end }}
+  region: {{ .region }}
+  bucketName: {{ .bucketName }}
+  {{if .folder }}folder: {{ .folder }} {{- end}}
+  endpoint: {{ .endpoint }}
+  {{ if .endpointCA -}}endpointCA: {{ .endpointCA }} {{- end }}
+  {{ if .insecureTLSSkipVerify }}insecureTLSSkipVerify: {{ .insecureTLSSkipVerify }} {{- end}}
+  {{- end}}
+{{ end }}

--- a/packages/backup-restore-operator/charts/templates/serviceaccount.yaml
+++ b/packages/backup-restore-operator/charts/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: backup-restore-operator-serviceaccount
+  namespace: {{ .Release.Namespace }}

--- a/packages/backup-restore-operator/charts/values.yaml
+++ b/packages/backup-restore-operator/charts/values.yaml
@@ -1,0 +1,25 @@
+image: 
+  repository: rancher/backup-restore-operator
+  tag: v0.0.1-rc4
+debug: false            # Enable debug logging in controller
+# Set as empty object {} if no s3 bucket needs to be configured for the operator
+s3: {}
+  # credentialSecretName: creds
+  # region: us-west-2
+  # bucketName: rajashree-backup-test
+  # folder: ecm1
+  # endpoint: s3.us-west-2.amazonaws.com
+# Set as empty object {} if no pvc needs to be configured for the operator
+pvc: {}
+  # storageClassName:
+  # size:
+
+
+global:
+  systemDefaultRegistry: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This chart contains manifests for:
* Creating a ServiceAccount for the backup-restore-operator
* ClusterRoleBinding to grant cluster-admin role to the serviceAccount. This operator
needs cluster-admin role because it should have CRUD permissions on all resources.
* Deployment for launching a pod for the operator. The above serviceAccount is assigned to
the deployment. We also set env vars for default s3 store and default pvc details if they are set
* If s3 details are specified in values.yaml, the s3secret.yaml will be used for creating that secret

**NOTE**
1. The PVC input fields are still not final, QA wants this chart to be merged and they are aware that they can't use the default PVC configuration with this version of the chart. So please ignore those fields as they will change in the next version (in a day or two)
2. The CRD manifests are all autogenerated from wrangler's CRD & openapi schema generator. So changes related to field descriptions can be done, but the rest are all autogenerated
3. Also I'll add in additionalPrinterColumns in the next version