### PR TITLE
Add chart for backup-restore-operator

### DIFF
--- a/packages/backup-restore-operator/charts/Chart.yaml
+++ b/packages/backup-restore-operator/charts/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+appVersion: v0.0.1-rc10
+description: Backup-restore-operator can be used to backup kubernetes cluster metadata
+  for certain applications and restore from it
+name: backup-restore-operator
+keywords:
+- applications
+- infrastructure
+version: 0.0.1
+annotations:
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/namespace: cattle-resources-system
+  catalog.cattle.io/release-name: backup-restore-operator
+  catalog.cattle.io/ui-component: backup-restore-operator
+  catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1

--- a/packages/backup-restore-operator/charts/crds/backup.yaml
+++ b/packages/backup-restore-operator/charts/crds/backup.yaml
@@ -1,0 +1,119 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: backups.resources.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.storageLocation
+    name: Location
+    type: string
+  - JSONPath: .status.backupType
+    name: Type
+    type: string
+  - JSONPath: .status.filename
+    name: Latest-Backup
+    type: string
+  - JSONPath: .spec.resourceSetName
+    name: ResourceSet
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+  group: resources.cattle.io
+  names:
+    kind: Backup
+    plural: backups
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            encryptionConfigSecretName:
+              description: Name of the Secret containing the encryption config
+              type: string
+            resourceSetName:
+              description: Name of the ResourceSet CR to use for backup
+              type: string
+            retentionCount:
+              minimum: 1
+              type: integer
+            schedule:
+              description: Cron schedule for recurring backups
+              example:
+                Descriptors: '@midnight'
+                Standard crontab specs: 0 0 * * *
+              type: string
+            storageLocation:
+              nullable: true
+              properties:
+                s3:
+                  nullable: true
+                  properties:
+                    bucketName:
+                      type: string
+                    credentialSecretName:
+                      type: string
+                    credentialSecretNamespace:
+                      type: string
+                    endpoint:
+                      type: string
+                    endpointCA:
+                      type: string
+                    folder:
+                      type: string
+                    insecureTLSSkipVerify:
+                      type: boolean
+                    region:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - resourceSetName
+          type: object
+        status:
+          properties:
+            backupType:
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            filename:
+              type: string
+            lastSnapshotTs:
+              type: string
+            nextSnapshotAt:
+              type: string
+            observedGeneration:
+              type: integer
+            storageLocation:
+              type: string
+            summary:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/backup-restore-operator/charts/crds/resourceset.yaml
+++ b/packages/backup-restore-operator/charts/crds/resourceset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcesets.resources.cattle.io
+spec:
+  group: resources.cattle.io
+  names:
+    kind: ResourceSet
+    plural: resourcesets
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        controllerReferences:
+          items:
+            properties:
+              apiVersion:
+                type: string
+              name:
+                type: string
+              namespace:
+                type: string
+              replicas:
+                type: integer
+              resource:
+                type: string
+            type: object
+          nullable: true
+          type: array
+        resourceSelectors:
+          items:
+            properties:
+              apiVersion:
+                type: string
+              kinds:
+                items:
+                  type: string
+                nullable: true
+                type: array
+              kindsRegexp:
+                type: string
+              labelSelectors:
+                nullable: true
+                properties:
+                  matchExpressions:
+                    items:
+                      properties:
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                      type: object
+                    nullable: true
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    nullable: true
+                    type: object
+                type: object
+              namespaceRegexp:
+                type: string
+              namespaces:
+                items:
+                  type: string
+                nullable: true
+                type: array
+              resourceNameRegexp:
+                type: string
+              resourceNames:
+                items:
+                  type: string
+                nullable: true
+                type: array
+            type: object
+          nullable: true
+          required:
+          - apiVersion
+          type: array
+      required:
+      - resourceSelectors
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/backup-restore-operator/charts/crds/restore.yaml
+++ b/packages/backup-restore-operator/charts/crds/restore.yaml
@@ -1,0 +1,102 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: restores.resources.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.backupSource
+    name: Backup-Source
+    type: string
+  - JSONPath: .spec.backupFilename
+    name: Backup-File
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+  group: resources.cattle.io
+  names:
+    kind: Restore
+    plural: restores
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            backupFilename:
+              type: string
+            deleteTimeoutSeconds:
+              maximum: 10
+              type: integer
+            encryptionConfigName:
+              type: string
+            prune:
+              nullable: true
+              type: boolean
+            storageLocation:
+              nullable: true
+              properties:
+                s3:
+                  nullable: true
+                  properties:
+                    bucketName:
+                      type: string
+                    credentialSecretName:
+                      type: string
+                    credentialSecretNamespace:
+                      type: string
+                    endpoint:
+                      type: string
+                    endpointCA:
+                      type: string
+                    folder:
+                      type: string
+                    insecureTLSSkipVerify:
+                      type: boolean
+                    region:
+                      type: string
+                  type: object
+              type: object
+          required:
+          - backupFilename
+          type: object
+        status:
+          properties:
+            backupSource:
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    type: string
+                  lastUpdateTime:
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            observedGeneration:
+              type: integer
+            restoreCompletionTs:
+              type: string
+            summary:
+              type: string
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/backup-restore-operator/charts/templates/_helpers.tpl
+++ b/packages/backup-restore-operator/charts/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Windows cluster will add default taint for linux nodes, 
+add below linux tolerations to workloads could be scheduled to those linux nodes
+*/}}
+{{- define "linux-node-tolerations" -}}
+- key: "cattle.io/os"
+  value: "linux"
+  effect: "NoSchedule"
+  operator: "Equal"
+{{- end -}}
+
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "backupRestore.fullname" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "backupRestore.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "backupRestore.labels" -}}
+helm.sh/chart: {{ include "backupRestore.chart" . }}
+{{ include "backupRestore.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "backupRestore.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "backupRestore.fullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+resources.cattle.io/operator: backup-restore
+{{- end }}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "backupRestore.serviceAccountName" -}}
+{{ include "backupRestore.fullname" . }}
+{{- end }}
+
+
+{{- define "backupRestore.s3SecretName" -}}
+{{- printf "%s-%s" .Chart.Name "s3" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "backupRestore.pvcName" -}}
+{{ include "backupRestore.fullname" . }}
+{{- end }}
+
+{{- define "backupRestore.nfsPVName" -}}
+{{ include "backupRestore.fullname" . }}
+{{- end }}

--- a/packages/backup-restore-operator/charts/templates/clusterrolebinding.yaml
+++ b/packages/backup-restore-operator/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "backupRestore.fullname" . }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "backupRestore.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/packages/backup-restore-operator/charts/templates/deployment.yaml
+++ b/packages/backup-restore-operator/charts/templates/deployment.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.s3.enabled .Values.persistence.enabled }}
+{{- fail "\n\nCannot configure both s3 and PV for storing backups" }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "backupRestore.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "backupRestore.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "backupRestore.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/s3-secret.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "backupRestore.serviceAccountName" . }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: Always
+        env:
+        - name: CHART_NAMESPACE
+          value: {{ .Release.Namespace }}
+          {{- if .Values.s3.enabled }}
+        - name: DEFAULT_S3_BACKUP_STORAGE_LOCATION
+          value: {{ include "backupRestore.s3SecretName" . }}
+          {{- end }}
+          {{- if .Values.persistence.enabled }}
+        - name: DEFAULT_PERSISTENCE_ENABLED
+          value: "persistence-enabled"
+        volumeMounts:
+        - mountPath: "/var/lib/backups"
+          name: pv-storage
+      volumes:
+        - name: pv-storage
+          persistentVolumeClaim:
+            claimName: {{ include "backupRestore.pvcName" . }}
+          {{- end }} 
+      nodeSelector:
+        kubernetes.io/os: linux
+      {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      tolerations:
+      {{- include "linux-node-tolerations" . | nindent 8}}
+      {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/packages/backup-restore-operator/charts/templates/pvc.yaml
+++ b/packages/backup-restore-operator/charts/templates/pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.persistence.enabled -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "backupRestore.pvcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+     {{- with .Values.persistence }}
+    requests:
+      storage: {{ .size | quote }}
+{{- if .storageClass }}
+{{- if (eq "-" .storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .storageClass | quote }}"
+{{- end }}
+{{- end }}
+{{- if .volumeName }}
+  volumeName: {{ .volumeName | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/packages/backup-restore-operator/charts/templates/rancher-resourceset.yaml
+++ b/packages/backup-restore-operator/charts/templates/rancher-resourceset.yaml
@@ -1,0 +1,34 @@
+apiVersion: resources.cattle.io/v1
+kind: ResourceSet
+metadata:
+  name: rancher-resource-set
+resourceSelectors:
+  - apiVersion: "v1"
+    kindsRegexp: "^namespaces$"
+    resourceNameRegexp: "^cattle-|^p-|^c-|^user-|^u-"
+    resourceNames:
+      - "local"
+  - apiVersion: "v1"
+    kindsRegexp: "^Secret$|^serviceaccounts$"
+    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+  - apiVersion: "rbac.authorization.k8s.io/v1"
+    kindsRegexp: "^roles$|^rolebindings$"
+    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+  - apiVersion: "rbac.authorization.k8s.io/v1"
+    kindsRegexp: "^clusterrolebindings$"
+    resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-"
+  - apiVersion: "rbac.authorization.k8s.io/v1"
+    kindsRegexp: "^clusterroles$"
+    resourceNameRegexp: "^cattle-|^p-|^c-|^local-|^user-|^u-|^project-|^create-ns$"
+  - apiVersion: "apiextensions.k8s.io/v1beta1"
+    kindsRegexp: "."
+    resourceNameRegexp: "management.cattle.io$|project.cattle.io$"
+  - apiVersion: "management.cattle.io/v3"
+    kindsRegexp: "."
+  - apiVersion: "project.cattle.io/v3"
+    kindsRegexp: "."
+controllerReferences:
+  - apiVersion: "apps/v1"
+    resource: "deployments"
+    name: "rancher"
+    namespace: "cattle-system"

--- a/packages/backup-restore-operator/charts/templates/s3-secret.yaml
+++ b/packages/backup-restore-operator/charts/templates/s3-secret.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.s3.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "backupRestore.s3SecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- with .Values.s3 }}
+  {{- if .credentialSecretName }}
+  credentialSecretName: {{ .credentialSecretName }} 
+  {{- end }}
+  {{- if .credentialSecretNamespace }}
+  credentialSecretNamespace: {{ .credentialSecretNamespace }} 
+  {{- end }}
+  {{- if .region }}
+  region: {{ .region }}
+  {{- end }}
+  bucketName: {{ .bucketName }}
+  {{- if .folder }}
+  folder: {{ .folder }} 
+  {{- end }}
+  endpoint: {{ .endpoint }}
+  {{- if .endpointCA }} 
+  endpointCA: {{ .endpointCA }} 
+  {{- end }}
+  {{- if .insecureTLSSkipVerify }}
+  insecureTLSSkipVerify: {{ .insecureTLSSkipVerify }} 
+  {{- end }}
+  {{- end }}
+{{ end }}

--- a/packages/backup-restore-operator/charts/templates/serviceaccount.yaml
+++ b/packages/backup-restore-operator/charts/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "backupRestore.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "backupRestore.labels" . | nindent 4 }}

--- a/packages/backup-restore-operator/charts/values.yaml
+++ b/packages/backup-restore-operator/charts/values.yaml
@@ -1,0 +1,49 @@
+image:
+  repository: rancher/backup-restore-operator
+  tag: v0.0.1-rc10
+
+## Default s3 bucket for storing all backup files created by the backup-restore-operator
+s3:
+  enabled: false
+  ## credentialSecretName if set, should be the name of the Secret containing AWS credentials.
+  ## To use IAM Role, don't set this field
+  credentialSecretName: creds 
+  credentialSecretNamespace: ""
+  region: us-west-2
+  bucketName: rancherbackups
+  folder: base folder
+  endpoint: s3.us-west-2.amazonaws.com
+  endpointCA: base64 encoded CA cert
+  # insecureTLSSkipVerify: optional
+
+## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
+## If persistence is enabled, operator will create a PVC with mountPath /var/lib/backups
+persistence: 
+  enabled: false
+
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack). 
+  ## Refer https://kubernetes.io/docs/concepts/storage/persistent-volumes/#class-1
+  ##
+  storageClass: "-"
+
+  ## If you want to disable dynamic provisioning by setting storageClass to "-" above, 
+  ## and want to target a particular PV, provide name of the target volume 
+  volumeName: ""
+
+  ## Only certain StorageClasses allow resizing PVs; Refer https://kubernetes.io/blog/2018/07/12/resizing-persistent-volumes-using-kubernetes/
+  size: 2Gi
+
+
+global:
+  cattle:
+    systemDefaultRegistry: ""
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/packages/backup-restore-operator/package.yaml
+++ b/packages/backup-restore-operator/package.yaml
@@ -1,0 +1,2 @@
+generateCRDChart:
+  enabled: true


### PR DESCRIPTION
This chart needs to create a CR when its installed. So as per offline discussion of making original charts similar in structure to upstream chart, this chart has all its CRDs in the /crds folder. And the CR it should create is in the templates folder.
Carrying over all relevant comments from https://github.com/rancher/charts/pull/589

This chart creates:
1. ServiceAccount bound to the cluster-admin role, which is used for launching the operator deployment. This operator needs CRUD permissions on all resources in the cluster. Hence only cluster-admin should be able to operate it. That's why it was decided in design meetings to assign it the cluster-admin role and have no other roles for it.
2. The CRDs in crds folder are generated using wrangler's CRD definition and openapi schema package. [This](https://rancher.atlassian.net/wiki/spaces/EN/pages/494469147/Backup+Restore+Rancher+MCM+app) design doc covers the explanation behind each field
3. User can either configure a s3 bucket OR a PVC to store backups in. The operator will error if both are specified. This helm chart also uses the `fail` template function to prevent chart installation if both are enabled.
4. If s3.enabled is set to true, the chart creates a secret in the chart's namespace that contains all details required for uploading/retrieving backups to/from s3 compatible stores.
5. If persistence.enabled is set to true, the operator creates a PVC in the chart's namespace and mounts it at /var/lib/backups. We want the PVC's access mode to be RWO, hence that is not accepted from the user. The user can specify storageClass, volumeName and size. The fields accepted for this PVC and the comments surrounding them in the values.yaml file follow the pattern that most of the upstream Helm charts follow. 
6. The `checksum/secret` annotation for s3-secret in the deployment spec will re-configure the pod to use the updated s3 secret if the user changes their s3 configuration, fixing https://github.com/rancher/rancher/issues/28607

https://github.com/rancher/rancher/issues/28640

NOTE: The "url" field in package.yaml is empty since its an original chart, will change it based on the new logic for generating CRDs.

https://github.com/rancher/rancher/issues/28368