### PR TITLE
Provides must exist on both parent and CRD chart

### DIFF
--- a/scripts/prepare-crds
+++ b/scripts/prepare-crds
@@ -72,6 +72,7 @@ if ! [[ -z ${providesGVR} ]]; then
 		yq w -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/auto-install-gvr]" "${providesGVR}"
 	fi
 	if [[ -z "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/provides-gvr]')" ]]; then
+		yq w -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/provides-gvr]" "${providesGVR}"
 		yq w -i ${f}/charts-crd/Chart.yaml "annotations[catalog.cattle.io/provides-gvr]" "${providesGVR}"
 	fi
 	if [[ -z "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/hidden]')" ]]; then


### PR DESCRIPTION
If chart X requires chart Y, but chart Y is split into crd/main chart,
then provides must exist on both so that X auto-installs the main
chart which auto-installs the CRD chart. Without this you would get
Y CRDs but no operator.