### PR TITLE
Add generate CRD for charts that don't have a url in package.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ packages/${CHART_NAME}/
     values.yaml
 ```
 
+For **Rancher original** charts with a crds directory, it should have the following tree structure
+
+```text
+packages/${CHART_NAME}/
+  package.yaml              # metadata manifest to enable or disable crds generation
+  charts/                   # regular helm chart directory
+    templates/
+    crds/
+    Chart.yaml
+    values.yaml
+```
+
 For **Rancher modified** charts, it should have the following tree structure
 
 ```text
@@ -34,11 +46,13 @@ packages/${CHART_NAME}/
 A regular `package.yaml` will have the following content:
 
 ```yaml
-url: https://charts.bitnami.com/bitnami/external-dns-2.20.10.tgz # url to fetch upstream chart
+url: https://charts.bitnami.com/bitnami/external-dns-2.20.10.tgz # url to fetch upstream chart, omit this field for a rancher original chart
 packageVersion: 00 # packageVersion of modified charts, producing a $version-$packageVersion chart. For example, if istio 1.4.7 is modified with changes, rancher produces a 1.4.700 chart version that includes the modification rancher made on top of upstream charts.
+generateCRDChart:
+  enabled: true
 ```
 
-Here is an example of upstream chart based on git repository
+Here is an **example** of upstream chart based on git repository
 
 ```yaml
 url: https://github.com/open-policy-agent/gatekeeper.git  # Url to fetch upstream chart from git
@@ -46,7 +60,16 @@ subdirectory: chart/gatekeeper-operator # Sub directory for helm charts in git r
 type: git # optinal, indicate that upstream chart is from git
 commit: v3.1.0-beta.8 # the revision of git repo
 packageVersion: 00 # package version
-``` 
+generateCRDChart:
+  enabled: true
+```
+
+Here is an **example** of local chart with a crds directory
+
+```yaml
+generateCRDChart:
+  enabled: true
+```
 
 ### Workflow
 

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 
 for f in packages/*; do
-  if [[ -f ${f}/package.yaml ]]; then
-  	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
-  		rm -rf ${f}/charts
-		rm -rf ${f}/charts-crd
-  	fi
-  fi
+	if [[ -f ${f}/package.yaml ]]; then
+		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
+			if [[ $(cat ${f}/package.yaml | yq r - url) ]]; then
+				rm -rf ${f}/charts
+			elif [ -d ${f}/charts-crd/templates ]; then
+				mv ${f}/charts-crd/templates ${f}/charts/crds
+			fi
+			rm -rf ${f}/charts-crd
+		fi
+	fi
 done
 
 for f in packages/*; do

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -37,6 +37,9 @@ for f in packages/*; do
   if [[ -f ${f}/package.yaml ]]; then
   	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
 			url=$(cat ${f}/package.yaml | yq r - url)
+			if [[ -z ${url} ]]; then
+				continue
+			fi
 			subdirectory=$(cat ${f}/package.yaml | yq r - subdirectory)
 			type=$(cat ${f}/package.yaml | yq r - type)
 			commit=$(cat ${f}/package.yaml | yq r - commit)

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -4,8 +4,8 @@ set -e
 # Pull in the upstream charts
 for f in packages/*; do
 	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
-		if [[ -f ${f}/package.yaml ]]; then
-			url=$(cat ${f}/package.yaml | yq r - url)
+		url=$(cat ${f}/package.yaml | yq r - url)
+		if [[ -f ${f}/package.yaml && -n ${url} ]]; then
 			subdirectory=$(cat ${f}/package.yaml | yq r - subdirectory)
 			type=$(cat ${f}/package.yaml | yq r - type)
 			fields=$(echo ${subdirectory} | awk -F'/' '{print NF}')


### PR DESCRIPTION
**Problem**
The ability to generate CRD charts is tied to the `package.yaml` file existing and the` url` key value being set. This does not support CRD generation when the chart has locally defined crds(usually found at the following path `<path>/<chart>/charts/crds`)

_Note: If the `package.yaml` doesn't exist, then no crd generation or patching occurs_ 

**Solution**
When a chart has a `package.yaml`  file and if no ` url` key value is present, the local chart's crds directory will be generated. This occurs by checking that the package.yaml file exists and only runs url specific commands if the url also exits. 

Updated clean command to only run if the charts-crd directory exists for charts that have a `package.yaml` file

Generate patch is also skipped for charts that have a `package.yaml`  file and if no ` url` key value present. This is because there are no upstream changes to apply a patch on; all changes occur locally. 

**Issue**
https://github.com/rancher/rancher/issues/28628