### PR TITLE
Deprecate providesGVR flag and update validate script

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -3,7 +3,8 @@
 for f in packages/*; do
 	if [[ -f ${f}/package.yaml ]]; then
 		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
-			if [[ -d ${f}/charts-crd ]]; then
+			split_crds=$(yq r ${f}/package.yaml generateCRDChart.enabled)
+			if [[ "${split_crds}" == "true" && -d ${f}/charts-crd ]]; then
 				./scripts/clean-crds ${f}
 			fi
 			if [[ $(cat ${f}/package.yaml | yq r - url) ]]; then

--- a/scripts/clean
+++ b/scripts/clean
@@ -3,12 +3,12 @@
 for f in packages/*; do
 	if [[ -f ${f}/package.yaml ]]; then
 		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
+			if [[ -d ${f}/charts-crd ]]; then
+				./scripts/clean-crds ${f}
+			fi
 			if [[ $(cat ${f}/package.yaml | yq r - url) ]]; then
 				rm -rf ${f}/charts
-			elif [ -d ${f}/charts-crd/templates ]; then
-				mv ${f}/charts-crd/templates ${f}/charts/crds
 			fi
-			rm -rf ${f}/charts-crd
 		fi
 	fi
 done

--- a/scripts/clean
+++ b/scripts/clean
@@ -7,7 +7,8 @@ for f in packages/*; do
 			if [[ "${split_crds}" == "true" && -d ${f}/charts-crd ]]; then
 				./scripts/clean-crds ${f}
 			fi
-			if [[ $(cat ${f}/package.yaml | yq r - url) ]]; then
+			url=$(yq r ${f}/package.yaml url)
+ 			if [[ -n $url ]]; then
 				rm -rf ${f}/charts
 			fi
 		fi

--- a/scripts/clean-crds
+++ b/scripts/clean-crds
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+# Reverts changes done to a chart from the prepare-crd script to go back to using one chart
+if [[ -z $1 ]]; then
+    echo "No directory provided to revert charts-crd changes within"
+	exit 1
+fi
+
+f=$1
+
+if ! [[ -d ${f}/charts-crd ]]; then
+    echo "Chart does not have a charts-crd/ directory to revert changes from"
+    exit 1
+fi
+
+# Move CRDs back into ${f}/charts/crd/ and remove ${f}/charts-crd
+mkdir -p ${f}/charts/crds/
+mv ${f}/charts-crd/templates/* ${f}/charts/crds/
+rm -rf ${f}/charts-crd
+
+if ! [[ -d ${f}/charts ]]; then
+    # Main chart has already been deleted; no need to modify contents
+    exit 0
+fi
+
+# Remove the validate-install-${name}-crd.yaml
+name=$(cat ${f}/charts/Chart.yaml | yq r - 'name')
+rm ${f}/charts/templates/validate-install-${name}-crd.yaml
+# Remove additional annotations added to original chart if added
+if [[ "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/auto-install]')" == "${name}-crd=match" ]]; then
+    yq d -i ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/auto-install]'
+fi

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -67,12 +67,6 @@ for f in packages/*; do
 				if [[ "${split_crds}" == "true" ]]; then
 					./scripts/clean-crds ${f}
 				fi
-				providesGVR="$(cat ${f}/package.yaml | yq r - providesGVR)"
-				if ! [[ -z ${providesGVR} ]]; then
-					if [[ "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/provides-gvr]')" == "${providesGVR}" ]]; then
-						yq d -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/provides-gvr]"
-					fi
-				fi
 				diff -x *.tgz -x *.lock -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
 				if ! [[ -s ${f}/$(basename -- ${f}).patch ]]; then
 					# If no changes exist in patch then remove it

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -16,8 +16,8 @@ function remove_timestamp_from_diff {
 }
 
 for f in packages/*; do
-  if [[ -f ${f}/package.yaml ]]; then
-  	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
+	if [[ -f ${f}/package.yaml ]]; then
+		if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
 			url=$(cat ${f}/package.yaml | yq r - url)
 			if [[ -z ${url} ]]; then
 				continue

--- a/scripts/generate-patch
+++ b/scripts/generate-patch
@@ -15,24 +15,6 @@ function remove_timestamp_from_diff {
 	rm ${f}/$(basename -- ${f}).patch.bak
 }
 
-function revert_crd_changes {
-	if [[ -z $1 ]]; then
-		echo "No directory provided to revert charts-crd changes within"
-		exit 1
-	fi
-	# Move charts-crd/templates back into charts/crd/
-	mkdir -p ${f}/charts/crds/
-	mv ${f}/charts-crd/templates/* ${f}/charts/crds/
-	# Remove the validate-install-${name}-crd.yaml
-	name=$(cat ${f}/charts/Chart.yaml | yq r - 'name')
-	rm ${f}/charts/templates/validate-install-${name}-crd.yaml
-	# Remove additional annotations added to original chart
-	yq d -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/auto-install-gvr]"
-	# Remove charts-crd
-	rm -rf ${f}/charts-crd
-}
-
-
 for f in packages/*; do
   if [[ -f ${f}/package.yaml ]]; then
   	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
@@ -83,7 +65,13 @@ for f in packages/*; do
 			if [[ -d ${f}/charts ]]; then
 				split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
 				if [[ "${split_crds}" == "true" ]]; then
-					revert_crd_changes ${f}
+					./scripts/clean-crds ${f}
+				fi
+				providesGVR="$(cat ${f}/package.yaml | yq r - providesGVR)"
+				if ! [[ -z ${providesGVR} ]]; then
+					if [[ "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/provides-gvr]')" == "${providesGVR}" ]]; then
+						yq d -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/provides-gvr]"
+					fi
 				fi
 				diff -x *.tgz -x *.lock -uNr ${f}/charts-original ${f}/charts > ${f}/$(basename -- ${f}).patch || true
 				if ! [[ -s ${f}/$(basename -- ${f}).patch ]]; then

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -4,8 +4,11 @@ set -e
 # Pull in the upstream charts
 for f in packages/*; do
 	if [[ -z $CHART || $CHART == $(basename -- ${f}) ]]; then
-		url=$(cat ${f}/package.yaml | yq r - url)
-		if [[ -f ${f}/package.yaml && -n ${url} ]]; then
+		unset url
+		if [[ -f ${f}/package.yaml ]]; then
+			url=$(cat ${f}/package.yaml | yq r - url)
+		fi
+		if [[ -n ${url} ]]; then
 			subdirectory=$(cat ${f}/package.yaml | yq r - subdirectory)
 			type=$(cat ${f}/package.yaml | yq r - type)
 			fields=$(echo ${subdirectory} | awk -F'/' '{print NF}')

--- a/scripts/prepare
+++ b/scripts/prepare
@@ -44,13 +44,6 @@ for f in packages/*; do
 			if [[ "${split_crds}" == "true" ]]; then
 				./scripts/prepare-crds ${f}
 			fi
-			# Add provides GVR annotation, this lets other charts require it
-			providesGVR="$(cat ${f}/package.yaml | yq r - providesGVR)"
-			if ! [[ -z ${providesGVR} ]]; then
-				if [[ -z "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/provides-gvr]')" ]]; then
-					yq w -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/provides-gvr]" "${providesGVR}"
-				fi
-			fi
 		fi
 	fi
 done

--- a/scripts/validate
+++ b/scripts/validate
@@ -5,7 +5,27 @@ cd $(dirname $0)/..
 
 ./scripts/prepare
 
+# Remove special changes from optional flags before checking if Git is dirty
+for f in packages/*; do
+    if [[ -f ${f}/package.yaml ]]; then
+        split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
+		if [[ "${split_crds}" == "true" && -d ${f}/charts-crd ]]; then
+			./scripts/clean-crds ${f}
+		fi
+    fi
+done
+
 source ./scripts/version
+
+# Add back in special changes from optional flags
+for f in packages/*; do
+    if [[ -f ${f}/package.yaml ]]; then
+        split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
+		if [[ "${split_crds}" == "true" ]]; then
+			./scripts/prepare-crds ${f}
+		fi
+    fi
+done
 
 if [ -n "$DIRTY" ]; then
     echo Git is dirty


### PR DESCRIPTION
This PR deprecates the provideGVR flag and updates the validate script to unblock CI issues for local charts that use the generateCRDChart flag.

Related to build failures in https://github.com/rancher/charts/pull/594