### PR TITLE
Fix validate errors

### DIFF
--- a/scripts/validate
+++ b/scripts/validate
@@ -3,34 +3,8 @@ set -e
 
 cd $(dirname $0)/..
 
-./scripts/prepare
+CHART=$CHART ./scripts/prepare
 
-# Remove special changes from optional flags before checking if Git is dirty
-for f in packages/*; do
-    if [[ -f ${f}/package.yaml ]]; then
-        split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
-		if [[ "${split_crds}" == "true" && -d ${f}/charts-crd ]]; then
-			./scripts/clean-crds ${f}
-		fi
-    fi
-done
+CHART=$CHART ./scripts/generate-charts
 
-source ./scripts/version
-
-# Add back in special changes from optional flags
-for f in packages/*; do
-    if [[ -f ${f}/package.yaml ]]; then
-        split_crds=$(cat ${f}/package.yaml | yq r - generateCRDChart.enabled)
-		if [[ "${split_crds}" == "true" ]]; then
-			./scripts/prepare-crds ${f}
-		fi
-    fi
-done
-
-if [ -n "$DIRTY" ]; then
-    echo Git is dirty
-    git status
-    exit 1
-fi
-
-./scripts/generate-charts
+CHART=$CHART ./scripts/clean


### PR DESCRIPTION
This PR cleans up the validate script in order to resolve CI errors.

#### Why are you deleting everything?
The core reason why the script became so complicated was that we would check whether Git was dirty when running validate. This was originally intended for either:
- Remote charts (with url in `package.yaml`): check if their `overlay/` or `package.yaml` or `*.patch` files were committed
- Local charts: check if all of their files were committed; since `prepare` performed a noop for these charts, there were no other issues.

However, with the recent changes that allowed local charts to also be `prepare`ed (via the `generateCRDChart` flag), the `prepare-crd` script would modify the local state of the chart to update the Chart.yaml and the contents of the `crd/` directory. While these were initially resolved by just running `clean-crds` after running prepare, the action of modifying the Chart.yaml and unmodifying it still left the Git state dirty since `yq w -i` and `yq d -i` mutate the original state of the Chart.yaml even if `clean-crd` is called after `prepare-crd` since they don't keep the formatting consistent. This led to weird CI build failures.

The resolution for this is to cut out the check for whether Git was dirty in the first place from the original script, which is reasonable since we run the `make validate` script as CI before merging commits anyways, so we'll always be running the script on initially clean git repos at least once before merging any PR.

Thanks @brendarearden @cbron and @mrajashree for hopping on the call to hash this out!