### PR TITLE
Remove quotes around pvc storageClassName

### DIFF
--- a/packages/backup-restore-operator/charts/Chart.yaml
+++ b/packages/backup-restore-operator/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: v0.0.1-rc10
+appVersion: v0.0.1-rc11
 description: Backup-restore-operator can be used to backup kubernetes cluster metadata
   for certain applications and restore from it
 name: backup-restore-operator

--- a/packages/backup-restore-operator/charts/templates/pvc.yaml
+++ b/packages/backup-restore-operator/charts/templates/pvc.yaml
@@ -17,7 +17,7 @@ spec:
 {{- if (eq "-" .storageClass) }}
   storageClassName: ""
 {{- else }}
-  storageClassName: "{{ .storageClass | quote }}"
+  storageClassName: {{ .storageClass | quote }}
 {{- end }}
 {{- end }}
 {{- if .volumeName }}

--- a/packages/backup-restore-operator/charts/values.yaml
+++ b/packages/backup-restore-operator/charts/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/backup-restore-operator
-  tag: v0.0.1-rc10
+  tag: v0.0.1-rc11
 
 ## Default s3 bucket for storing all backup files created by the backup-restore-operator
 s3:


### PR DESCRIPTION
The field storageClassName uses "quote" template function. So the quotes around it lead to errors. This commit removes the quotes
https://github.com/rancher/backup-restore-operator/issues/27