### PR TITLE
[proposal] Replace yq in place commands with awk replaces

### DIFF
--- a/scripts/awk/delete_annotation.awk
+++ b/scripts/awk/delete_annotation.awk
@@ -1,0 +1,26 @@
+BEGIN {
+    # By default, we are not within the annotations section yet
+    within_annotations=0;
+}
+
+{
+    if (within_annotations==1 && ($0~/^ /) == 0) {
+        # Since the first line here is not a space (i.e. indented)
+        # we are no longer in the annotation section
+        within_annotations=0
+    }
+}
+
+{
+    if (within_annotations==1 && $0~field) {
+        # If we are within the annotation section and we see our
+        # annotation, just skip printing that line
+        next
+    }
+}
+
+# Check to see if we have entered the annotations part of the YAML file
+/^annotations:/{within_annotations=1}
+
+# print any values that haven't been skipped
+{print}

--- a/scripts/awk/write_annotation.awk
+++ b/scripts/awk/write_annotation.awk
@@ -1,0 +1,67 @@
+BEGIN {
+    # Set the field separator to anything except a space or a tab
+    # and set all other values to 0
+    FS="[^ \t]";
+    seen_annotations=0
+    within_annotations=0
+    field_seen=0
+}
+
+{
+    if (within_annotations==1 && ($0~/^ /) == 0) {
+        # Since the first line here is not a space (i.e. indented)
+        # we are no longer in the annotation section
+        within_annotations=0
+    }
+}
+
+{
+    if (within_annotations==1 && $0~field) {
+        # If we are within the annotation section and we see our
+        # annotation, replace its contents with our new_val
+        gsub(/: .*/, ": %s")
+        gsub("%s", new_val)
+        field_seen=1;
+    }
+}
+
+{
+    if (within_annotations==0 && seen_annotations==1 && field_seen==0) {
+        # If we just crossed the end of the annotations field and we
+        # haven't seen our annotation yet but are moving on to another section
+        # of the Chart.yaml, add our annotation here with its new_val
+        for(i=1;i<=curr_indent;i++) printf " "
+        printf "%s: %s", field, new_val;
+        print ""
+        field_seen=1;
+    }
+}
+
+/^annotations:/{
+    # We have seen annotations and are currently
+    # within the annotation section of the Chart.yaml
+    within_annotations=1;
+    seen_annotations=1
+}
+
+{curr_indent=length($1)}
+
+{print}
+
+END {
+    # Handle edge cases
+    if (seen_annotations==0) {
+        # We never saw an annotation section, so we add an annotation
+        # section and insert the value there
+        print "annotations:"
+        printf "  %s: %s", field, new_val;
+        print ""
+    } else if (field_seen==0) {
+        # If we crossed the end of our annotations field and
+        # we haven't seen our annotation yet but we have reached
+        # the end of the file, add our annotation here with its new_val
+        for(i=1;i<=curr_indent;i++) printf " "
+        printf "%s: %s", field, new_val;
+        print ""
+    }
+}

--- a/scripts/clean-crds
+++ b/scripts/clean-crds
@@ -1,6 +1,24 @@
 #!/usr/bin/env bash
 set -e
 
+delete_annotation() {
+    # Functionally is the same as yq d -i $1 'annotations[$2]'
+    if [[ -z ${1} ]]; then
+        echo "No Chart.yaml path provided"
+        exit 1
+    fi
+    chart_yaml="${1}"
+    if [[ -z ${2} ]]; then
+        echo "Did not provide field to delete in annotations listed in ${f}/charts/Chart.yaml"
+        exit 1
+    fi
+    # escaping for awk
+    field="${2/\//\\/}"
+    tmpfile=$(mktemp)
+    awk -f ./scripts/awk/delete_annotation.awk -v field=$field ${f}/charts/Chart.yaml > $tmpfile
+    mv $tmpfile $chart_yaml
+}
+
 # Reverts changes done to a chart from the prepare-crd script to go back to using one chart
 if [[ -z $1 ]]; then
     echo "No directory provided to revert charts-crd changes within"
@@ -33,5 +51,5 @@ name=$(cat ${f}/charts/Chart.yaml | yq r - 'name')
 rm ${f}/charts/templates/validate-install-crd.yaml
 # Remove additional annotations added to original chart if added
 if [[ "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/auto-install]')" == "${name}-crd=match" ]]; then
-    yq d -i ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/auto-install]'
+    delete_annotation ${f}/charts/Chart.yaml "catalog.cattle.io/auto-install"
 fi

--- a/scripts/prepare-crds
+++ b/scripts/prepare-crds
@@ -11,6 +11,30 @@ set -e
 # - Move any CRDs from the upstream chart into the appropriate directory for CRDs based on flags
 # - Apply any additional necessary annotation logic on the Chart.yaml of both the upstream and CRD charts
 
+write_annotation() {
+    # Functionally is the same as yq w -i $1 'annotations[$2]' $3
+	if [[ -z ${1} ]]; then
+        echo "No Chart.yaml path provided"
+        exit 1
+    fi
+	chart_yaml="${1}"
+    if [[ -z ${2} ]]; then
+        echo "Did not provide field to delete in annotations listed in ${f}/charts/Chart.yaml"
+        exit 1
+    fi
+	# escaping for awk
+    field="${2/\//\\/}"
+	if [[ -z ${3} ]]; then
+        echo "Did not provide new value for field ${1} in ${f}/charts/Chart.yaml"
+        exit 1
+    fi
+	# escaping for awk
+    new_val="${3/\//\\/}"
+	tmpfile=$(mktemp)
+	awk -f ./scripts/awk/write_annotation.awk -v field=$field -v new_val=$new_val $chart_yaml > $tmpfile
+	mv $tmpfile $chart_yaml
+}
+
 if [[ -z $1 ]]; then
 	echo "No directory provided to initialize charts-crd within"
 	exit 1
@@ -94,7 +118,7 @@ rm -rf ${f}/charts/crds
 
 # Make the primary chart auto-install the CRD chart
 if [[ -z "$(yq r ${f}/charts/Chart.yaml 'annotations[catalog.cattle.io/auto-install]')" ]]; then
-	yq w -i ${f}/charts/Chart.yaml "annotations[catalog.cattle.io/auto-install]" "${name}-crd=match"
+	write_annotation ${f}/charts/Chart.yaml "catalog.cattle.io/auto-install" "${name}-crd=match"
 fi
 
 # Add annotations to ${f}/charts-crd/Chart.yaml
@@ -105,6 +129,6 @@ for a in ${copyAnnotations[@]}; do
 		if [[ ${a} == "catalog.cattle.io/release-name" ]]; then
 			v="${v}-crd"
 		fi
-		yq w -i ${f}/charts-crd/Chart.yaml "annotations[${a}]" "${v}"
+		write_annotation ${f}/charts-crd/Chart.yaml "${a}" "${v}"
 	fi
 done


### PR DESCRIPTION
Until yq has a resolution that allows us to cleanly deal with in-place insertion, we need to provide a solution in the scripts that makes it possible for developers to be able to run the scripts without encountering random changes associated with `Chart.yaml` changes. This commit replaces all our inplace modifications using yq with awk-based (or should I say awk-ward?) functions that effectively do the same YAML manipulation.

Tested it out on several test cases (missing annotations, random indentations, etc.) and it seems to be working as expected.