### PR TITLE
Image updates for Istio 1.7.1 and Kiali 1.23.0

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.6.8
-description: Helm chart for installing istio components with the istioctl
+appVersion: 1.7.1
+description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.6.800
+version: 1.7.100
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking
@@ -13,4 +13,5 @@ annotations:
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
+  catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
   catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.22.001

--- a/packages/rancher-istio/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio/charts/configs/istio-base.yaml
@@ -4,14 +4,6 @@ spec:
   addonComponents:
     istiocoredns:
       enabled: {{ .Values.istiocoredns.enabled }}
-    prometheus:
-      enabled: false
-    grafana:
-      enabled: false
-    kiali:
-      enabled: false
-    tracing:
-      enabled: false
   components:
     base:
       enabled: {{ .Values.base.enabled }}

--- a/packages/rancher-istio/charts/requirements.yaml
+++ b/packages/rancher-istio/charts/requirements.yaml
@@ -3,5 +3,5 @@ dependencies:
   - name: rancher-kiali-server
     alias: kiali
     condition: kiali.enabled
-    version: 1.22.0
+    version: 1.23.0
     repository: file://../../rancher-kiali-server/charts

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,13 +1,13 @@
 overlayFile: ""
 tag: 1.7.1
-installerVersion: 1.6.8-rancher1
+installerVersion: 1.7.1-rancher1
 forceInstall: false
 
 istiocoredns:
     enabled: false
     image:
       repository: rancher/coredns-coredns
-      tag: 1.7.1
+      tag: 1.6.2
     pluginImage:
       repository: rancher/istio-coredns-plugin
       tag: 0.2-istio-1.1

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,5 +1,5 @@
 overlayFile: ""
-tag: 1.6.8
+tag: 1.7.1
 installerVersion: 1.6.8-rancher1
 forceInstall: false
 
@@ -7,7 +7,7 @@ istiocoredns:
     enabled: false
     image:
       repository: rancher/coredns-coredns
-      tag: 1.6.2
+      tag: 1.7.1
     pluginImage:
       repository: rancher/istio-coredns-plugin
       tag: 0.2-istio-1.1
@@ -18,7 +18,7 @@ base:
 cni:
     enabled: false
     repository: rancher/istio-install-cni
-    tag: 1.6.8
+    tag: 1.7.1
 
 egressGateways:
     enabled: false
@@ -34,17 +34,17 @@ istiodRemote:
 pilot:
     enabled: true
     repository: rancher/istio-pilot
-    tag: 1.6.8
+    tag: 1.7.1
 
 policy:
     enabled: true
     repository: rancher/istio-mixer
-    tag: 1.6.8
+    tag: 1.7.1
 
 telemetry:
     enabled: true
     repository: rancher/istio-mixer
-    tag: 1.6.8
+    tag: 1.7.1
 
 sidecarInjectorWebhook:
   enableNamespacesByDefault: false
@@ -58,10 +58,10 @@ global:
     systemDefaultRegistry: ""
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.6.8
+    tag: 1.7.1
   proxy_init:
     repository: rancher/istio-proxyv2
-    tag: 1.6.8
+    tag: 1.7.1
   defaultPodDisruptionBudget:
     enabled: true
 
@@ -77,7 +77,7 @@ kiali:
   deployment:
     ingress_enabled: false
     repository: rancher/kiali-kiali
-    tag: v1.22.1
+    tag: v1.23.0
   external_services:
     prometheus:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"

--- a/packages/rancher-kiali-server/package.yaml
+++ b/packages/rancher-kiali-server/package.yaml
@@ -1,4 +1,4 @@
-url: https://kiali.org/helm-charts/kiali-server-1.22.0.tgz
+url: https://kiali.org/helm-charts/kiali-server-1.23.0.tgz
 packageVersion: 01
 generateCRDChart:
   enabled: true

--- a/packages/rancher-kiali-server/rancher-kiali-server.patch
+++ b/packages/rancher-kiali-server/rancher-kiali-server.patch
@@ -1,12 +1,12 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/Chart.yaml packages/rancher-kiali-server/charts/Chart.yaml
 --- packages/rancher-kiali-server/charts-original/Chart.yaml
 +++ packages/rancher-kiali-server/charts/Chart.yaml
-@@ -1,20 +1,28 @@
+@@ -1,20 +1,27 @@
  apiVersion: v2
- appVersion: v1.22.0
+ appVersion: v1.23.0
 -description: Kiali is an open source project for service mesh observability, refer
 -  to https://www.kiali.io for details.
-+description: Rancher chart based on Kiali Server, containing standard defaults. Installed as sub-chart with customized values in Rancher's Istio.
++description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details. This is installed as sub-chart with customized values in Rancher's Istio.
  home: https://github.com/kiali/kiali
  icon: https://raw.githubusercontent.com/kiali/kiali.io/master/themes/kiali/static/img/kiali_logo_masthead.png
  keywords:
@@ -34,13 +34,12 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/C
 +  - https://github.com/kiali/kiali-ui
 +  - https://github.com/kiali/kiali-operator
 +  - https://github.com/kiali/helm-charts
- version: 1.22.0
+ version: 1.23.0
 +annotations:
 +  catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
 +  catalog.rancher.io/namespace: cattle-istio-system
 +  catalog.rancher.io/release-name: rancher-kiali-server
 +  catalog.cattle.io/hidden: true
-+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=match
 +  catalog.cattle.io/provides-gvr: monitoringdashboards.monitoring.kiali.io/v1alpha1
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/templates/_helpers.tpl packages/rancher-kiali-server/charts/templates/_helpers.tpl
 --- packages/rancher-kiali-server/charts-original/templates/_helpers.tpl
@@ -64,8 +63,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/t
  {{- end }}
 +
 +{{- define "system_default_registry" -}}
-+{{- if .Values.global.systemDefaultRegistry -}}
-+{{- printf "%s/" .Values.global.systemDefaultRegistry -}}
++{{- if .Values.global.cattle.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 +{{- else -}}
 +{{- "" -}}
 +{{- end -}}
@@ -123,7 +122,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/t
 +    {{- include "kiali-server.labels" . | nindent 4 }}
 +data:
 +  env.js: |
-+    window.WEB_ROOT='/k8s/clusters/{{ .Values.global.rancher.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:rancher-istio-kiali:20001/proxy';
++    window.WEB_ROOT='/k8s/clusters/{{ .Values.global.cattle.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:rancher-istio-kiali:20001/proxy';
 +{{- end }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/values.yaml packages/rancher-kiali-server/charts/values.yaml
 --- packages/rancher-kiali-server/charts-original/values.yaml
@@ -136,9 +135,9 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/v
 +web_root_override: true
 +
  #
- # Settings that mimic the Kiali CR which are placed in the ConfigMap
- #
-@@ -57,10 +60,10 @@
+ # Settings that mimic the Kiali CR which are placed in the ConfigMap.
+ # Note that only those values used by the Helm Chart will be here.
+@@ -34,10 +37,10 @@
    custom_dashboards:
      excludes: ['']
      includes: ['*']
@@ -146,22 +145,20 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/v
 +  repository: rancher/kiali-kiali
    image_pull_policy: "Always"
    image_pull_secrets: []
--  image_version: v1.22.0
-+  tag: v1.22.0
+-  image_version: v1.23.0
++  tag: v1.23.0
    ingress_enabled: true
    node_selector: {}
    override_ingress_yaml:
-@@ -182,3 +185,13 @@
-   web_fqdn: ""
+@@ -66,3 +69,11 @@
+   metrics_enabled: true
+   metrics_port: 9090
    web_root: ""
-   web_schema: ""
 +
 +# Common settings used among istio subcharts.
 +global:
-+
 +  # Specify rancher clusterId of external tracing config
 +  # https://github.com/istio/istio.io/issues/4146#issuecomment-493543032
-+  rancher:
++  cattle:
++    systemDefaultRegistry: ""
 +    clusterId:
-+
-+  systemDefaultRegistry: ""


### PR DESCRIPTION
**Dependency**
https://github.com/rancher/image-mirror/pull/36

**Problem**
Istio 1.7.1 and Kiali 1.23.0 were released
Kiali was not hard coded to specific name

**Solution** 
Update images and chart patches / values for new version
New version of Kiali hard codes name to Kiali 

**Issue**
https://github.com/rancher/rancher/issues/28901