### PR TITLE
fixed airgap images

### DIFF
--- a/packages/rancher-logging/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/eks/logging.yaml
@@ -24,4 +24,8 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
 {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -27,4 +27,8 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
 {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -27,4 +27,8 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
 {{- end }}

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -20,6 +20,18 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/Chart.
 +  catalog.cattle.io/release-name: rancher-logging
 +  catalog.cattle.io/ui-component: logging
 +  catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/templates/deployment.yaml packages/rancher-logging/charts/templates/deployment.yaml
+--- packages/rancher-logging/charts-original/templates/deployment.yaml
++++ packages/rancher-logging/charts/templates/deployment.yaml
+@@ -30,7 +30,7 @@
+     {{- end }}
+       containers:
+         - name: {{ .Chart.Name }}
+-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
++          image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}:{{ .Values.image.tag }}"
+           imagePullPolicy: {{ .Values.image.pullPolicy }}
+           resources:
+             {{- toYaml .Values.resources | nindent 12 }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/templates/_helpers.tpl packages/rancher-logging/charts/templates/_helpers.tpl
 --- packages/rancher-logging/charts-original/templates/_helpers.tpl
 +++ packages/rancher-logging/charts/templates/_helpers.tpl

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -28,7 +28,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/templa
        containers:
          - name: {{ .Chart.Name }}
 -          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-+          image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}:{{ .Values.image.tag }}"
++          image: "{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
            imagePullPolicy: {{ .Values.image.pullPolicy }}
            resources:
              {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
PROBLEMS:
- airgap install fails
- k3s installs require a pvc

SOLUTION:
- added registry prefix to operator image
- override the config reloading images
- ensured the pvc toggle is passed to all loggings