### PR TITLE
fixed logging roles

### DIFF
--- a/packages/rancher-logging/overlay/templates/userroles.yaml
+++ b/packages/rancher-logging/overlay/templates/userroles.yaml
@@ -16,8 +16,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: "logging-edit"
+  name: "logging-view"
   labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
 rules:
   - apiGroups:
@@ -25,21 +27,8 @@ rules:
     resources:
       - flows
       - outputs
-    verbs:
-      - "*"
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: "logging-view"
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-rules:
-  - apiGroups:
-      - "logging.banzaicloud.io"
-    resources:
-      - flows
-      - outputs
+      - clusterflows
+      - clusteroutputs
     verbs:
       - get
       - list


### PR DESCRIPTION
Removed edit from cluster members and allowed all users to view cluster level crds.