### PR TITLE
Allow new charts to generate sums

### DIFF
--- a/scripts/produce-sha256
+++ b/scripts/produce-sha256
@@ -16,6 +16,7 @@ for f in packages/*; do
     find ${f} -type f | xargs sha256sum > ./sha256sum-new/$(basename -- ${f})/$(basename -- ${f}).sum
 done
 
+# If there were no sha256sums in the first place, output the name of every chart
 if [ ! -d sha256sum ]; then
     cp -R sha256sum-new sha256sum
     for f in packages/*; do
@@ -23,8 +24,9 @@ if [ ! -d sha256sum ]; then
     done
 fi
 
-for f in sha256sum/*; do 
-    if ! cmp -s ./sha256sum-new/$(basename -- ${f})/$(basename -- ${f}).sum ${f}/$(basename -- ${f}).sum; then
+# For all the new sha256sums that were generated, compare them and see if the existing assets need to be rebuilt
+for f in sha256sum-new/*; do
+    if ! cmp -s ./sha256sum/$(basename -- ${f})/$(basename -- ${f}).sum ${f}/$(basename -- ${f}).sum; then
         echo $(basename -- ${f})
     fi
 done


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/29173

Dependent on merge:
- [ ] Regenerates charts that merged with bug in generator (https://github.com/rancher/charts/pull/702#pullrequestreview-496872722)