### PR TITLE
Correct Kiali Version, Enable Telemetry V2

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -14,4 +14,4 @@ annotations:
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.22.001
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.23.001

--- a/packages/rancher-istio/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio/charts/configs/istio-base.yaml
@@ -43,7 +43,7 @@ spec:
     policy:
       enabled: {{ .Values.policy.enabled }}
     telemetry:
-      enabled: {{ .Values.telemetry.enabled }}
+      enabled: {{ .Values.telemetry.v1.enabled }}
   hub: {{ .Values.systemDefaultRegistry | default "docker.io" }}
   profile: default
   tag: {{ .Values.tag }}
@@ -63,7 +63,7 @@ spec:
       proxy:
         image: {{ template "system_default_registry" . }}{{ .Values.global.proxy.repository }}:{{ .Values.global.proxy.tag }}
       proxy_init:
-        image: {{ template "system_default_registry" . }}{{ .Values.global.proxy_init.repository}}:{{ .Values.global.proxy_init.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.global.proxy_init.repository }}:{{ .Values.global.proxy_init.tag }}
       {{- if .Values.global.defaultPodDisruptionBudget.enabled }}
       defaultPodDisruptionBudget:
         enabled: {{ .Values.global.defaultPodDisruptionBudget.enabled }}
@@ -72,19 +72,27 @@ spec:
       coreDNSImage: {{ template "system_default_registry" . }}{{ .Values.istiocoredns.image.repository }}
       coreDNSPluginImage: {{ template "system_default_registry" . }}{{ .Values.istiocoredns.pluginImage.repository }}:{{ .Values.istiocoredns.pluginImage.tag }}
       coreDNSTag: {{ .Values.istiocoredns.image.tag }}
+    {{- if or .Values.policy.enabled .Values.telemetry.v1.enabled }}
     mixer:
       {{- if .Values.policy.enabled }}
       policy:
-        image: {{ template "system_default_registry" . }}{{ .Values.policy.repository}}:{{ .Values.policy.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.policy.repository }}:{{ .Values.policy.tag }}
       {{- end }}
-      {{- if .Values.telemetry.enabled }}
+      {{- if .Values.telemetry.v1.enabled }}
       telemetry:
-        image: {{ template "system_default_registry" . }}{{ .Values.telemetry.repository}}:{{ .Values.telemetry.tag }}
+        image: {{ template "system_default_registry" . }}{{ .Values.telemetry.v1.repository }}:{{ .Values.telemetry.v1.tag }}
       {{- end }}
+    {{- end }}
     {{- if .Values.pilot.enabled }}
     pilot:
-      image: {{ template "system_default_registry" . }}{{ .Values.pilot.repository}}:{{ .Values.pilot.tag }}
+      image: {{ template "system_default_registry" . }}{{ .Values.pilot.repository }}:{{ .Values.pilot.tag }}
     {{- end }}
+    telemetry:
+      enabled: {{ .Values.telemetry.enabled }}
+      v1:
+        enabled: {{ .Values.telemetry.v1.enabled }}
+      v2:
+        enabled: {{ .Values.telemetry.v2.enabled }}
     {{- if .Values.cni.enabled }}
     cni:
       image: {{ template "system_default_registry" . }}{{ .Values.cni.repository }}:{{ .Values.cni.tag }}

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -7,47 +7,53 @@ installer:
   tag: 1.7.1-rancher1
 
 istiocoredns:
-    enabled: false
-    image:
-      repository: rancher/coredns-coredns
-      tag: 1.6.2
-    pluginImage:
-      repository: rancher/istio-coredns-plugin
-      tag: 0.2-istio-1.1
+  enabled: false
+  image:
+    repository: rancher/coredns-coredns
+    tag: 1.6.2
+  pluginImage:
+    repository: rancher/istio-coredns-plugin
+    tag: 0.2-istio-1.1
 
 base:
-    enabled: true
+  enabled: true
 
 cni:
-    enabled: false
-    repository: rancher/istio-install-cni
-    tag: 1.7.1
+  enabled: false
+  repository: rancher/istio-install-cni
+  tag: 1.7.1
 
 egressGateways:
-    enabled: false
-    type: NodePort
+  enabled: false
+  type: NodePort
 
 ingressGateways:
-    enabled: true
-    type: NodePort
+  enabled: true
+  type: NodePort
 
 istiodRemote:
-    enabled: false
+  enabled: false
 
 pilot:
-    enabled: true
-    repository: rancher/istio-pilot
-    tag: 1.7.1
+  enabled: true
+  repository: rancher/istio-pilot
+  tag: 1.7.1
 
+#Mixer Policy is deprecated in 1.7.x, will not be supported in 1.8.x 
 policy:
-    enabled: true
-    repository: rancher/istio-mixer
-    tag: 1.7.1
+  enabled: false
+  repository: rancher/istio-mixer
+  tag: 1.7.1
 
 telemetry:
-    enabled: true
+  enabled: true
+  #Telemetry v1 is deprecated in 1.7.x, will not be supported in 1.8.x 
+  v1:
+    enabled: false
     repository: rancher/istio-mixer
     tag: 1.7.1
+  v2:
+    enabled: true
 
 sidecarInjectorWebhook:
   enableNamespacesByDefault: false


### PR DESCRIPTION
**Problem:**
Telemetry V2 was is not getting enabled. Current chart is still using Telemetry v1. 
Kiail version for the chart.yaml auto-install annotation is 1.22.x, not 1.23.x

**Solution:**
Change auto-install annotation to correct kiali version
Disable mixer telemetry and policy. Add configuration for tTelemetry v2. 

**Issue:** 
https://github.com/rancher/rancher/issues/29169
https://github.com/rancher/rancher/issues/28738