### PR TITLE
Left align all columns in Readme table

### DIFF
--- a/packages/rancher-backup/charts/README.md
+++ b/packages/rancher-backup/charts/README.md
@@ -26,7 +26,7 @@ helm install rancher-backup rancher-chart/rancher-backup -n cattle-resources-sys
 The following table lists the configurable parameters of the rancher-backup chart and their default values:
 
 | Parameter   |      Description      |  Default |
-|----------|:-------------:|------:|
+|----------|---------------|-------|
 | image.repository |  Container image repository | rancher/backup-restore-operator |
 | image.tag |    Container image tag  |   v0.1.0-rc1 |
 | s3.enabled | Configure S3 compatible default storage location. Current version supports S3 and MinIO |    false |


### PR DESCRIPTION
The README contains a table explaining configurable parameters. The alignment of all columns in this table was different. This commit left-aligns all columns
This is what it looks like in UI currently:
<img width="1458" alt="Screen Shot 2020-09-25 at 3 40 25 PM" src="https://user-images.githubusercontent.com/10672776/94321885-c3bd2280-ff45-11ea-9389-b9ea8076f261.png">


This is what it looks like with this commit:
<img width="952" alt="Screen Shot 2020-09-25 at 3 59 52 PM" src="https://user-images.githubusercontent.com/10672776/94322762-35966b80-ff48-11ea-9ee4-237c479a6c01.png">
