### PR TITLE
Updating chart tags for cis-operator and security-scan images and set version to v0.2.0

### DIFF
--- a/packages/rancher-cis-benchmark/charts/Chart.yaml
+++ b/packages/rancher-cis-benchmark/charts/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
-appVersion: v0.0.1
+appVersion: v1.0.0
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 name: rancher-cis-benchmark
-version: 0.0.1
+version: 1.0.000
+icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security
 annotations:

--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v0.0.6
+    tag: v1.0.0
   securityScan:
     repository: rancher/security-scan
-    tag: v0.2.0
+    tag: v0.2.1
   sonobuoy:
     repository: rancher/sonobuoy-sonobuoy
     tag: v0.16.3


### PR DESCRIPTION
Updating chart tags for cis-operator and security-scan images and setting app version to v0.2.0

https://github.com/rancher/cis-operator/issues/37