### PR TITLE
Add ability to create new PVC on upgrade

### DIFF
--- a/packages/rancher-backup/charts/templates/_helpers.tpl
+++ b/packages/rancher-backup/charts/templates/_helpers.tpl
@@ -67,10 +67,10 @@ Create the name of the service account to use
 {{- printf "%s-%s" .Chart.Name "s3" | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Create PVC name using release and revision number.
+*/}}
 {{- define "backupRestore.pvcName" -}}
-{{ include "backupRestore.fullname" . }}
+{{- printf "%s-%d" .Release.Name .Release.Revision }}
 {{- end }}
 
-{{- define "backupRestore.nfsPVName" -}}
-{{ include "backupRestore.fullname" . }}
-{{- end }}

--- a/packages/rancher-backup/charts/templates/deployment.yaml
+++ b/packages/rancher-backup/charts/templates/deployment.yaml
@@ -17,7 +17,8 @@ spec:
       labels:
         {{- include "backupRestore.selectorLabels" . | nindent 8 }}
       annotations:
-        checksum/secret: {{ include (print $.Template.BasePath "/s3-secret.yaml") . | sha256sum }}
+        checksum/s3: {{ include (print $.Template.BasePath "/s3-secret.yaml") . | sha256sum }}
+        checksum/pvc: {{ include (print $.Template.BasePath "/pvc.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "backupRestore.serviceAccountName" . }}
       containers:


### PR DESCRIPTION
This commit modifies the helper for creating PVC name to address this bug
https://github.com/rancher/backup-restore-operator/issues/39

The chart name was used as PVC name till now, because of which if you upgrade the chart to use a different Persistent Volume, it would use the same PVC since the chart name stays constant. Now PVC is named with a combination of release name and revision number so it changes each time on upgrade. The PVC will be recreated and the annotation in the deployment will launch a new pod to use the new PV

Also removed the nfs pv helper which is no longer used