### PR TITLE
Enable login form by default

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring.patch
+++ b/packages/rancher-monitoring/rancher-monitoring.patch
@@ -2285,7 +2285,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
 +    users:
 +      auto_assign_org_role: Viewer
 +    auth:
-+      disable_login_form: true
++      disable_login_form: false
 +    auth.anonymous:
 +      enabled: true
 +      org_role: Viewer


### PR DESCRIPTION
To allow users to have non-readonly access (since the default role is `Viewer` based on https://github.com/rancher/rancher/issues/29165#issuecomment-700255212), we need to enable the login page.