### PR TITLE
[2.5.1] remove link from readme in crd charts

### DIFF
--- a/scripts/chart-templates/crd-base/README.md
+++ b/scripts/chart-templates/crd-base/README.md
@@ -1,2 +1,2 @@
 # ${name}-crd
-A Rancher chart that installs the CRDs used by [${name}](https://github.com/rancher/dev-charts/tree/master/packages/${name}).
+A Rancher chart that installs the CRDs used by ${name}.


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/29219

We could fix link, but its prone to change again, and going between dev/main is tricky. 