### PR TITLE
Remove rancher-operator, fleet and rancher-webhook charts from resource-set

### DIFF
--- a/packages/rancher-backup/charts/Chart.yaml
+++ b/packages/rancher-backup/charts/Chart.yaml
@@ -6,6 +6,7 @@ keywords:
 - applications
 - infrastructure
 version: 0.1.0
+icon: https://charts.rancher.io/assets/logos/backup-restore.svg
 annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/namespace: cattle-resources-system

--- a/packages/rancher-backup/charts/templates/rancher-resourceset.yaml
+++ b/packages/rancher-backup/charts/templates/rancher-resourceset.yaml
@@ -5,64 +5,32 @@ metadata:
 resourceSelectors:
   - apiVersion: "v1"
     kindsRegexp: "^namespaces$"
-    resourceNameRegexp: "^cattle-|^p-|^c-|^user-|^u-|^fleet-|^cluster-fleet-"
+    resourceNameRegexp: "^cattle-|^p-|^c-|^user-|^u-"
     resourceNames:
       - "local"
-      - "rancher-operator-system"
   - apiVersion: "v1"
-    kindsRegexp: "^secrets$"
+    kindsRegexp: "^Secret$|^serviceaccounts$"
     namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
-    labelSelectors:
-      matchExpressions:
-        - key: "owner"
-          operator: "NotIn"
-          values: ["helm"]
-  - apiVersion: "v1"
-    kindsRegexp: "^secrets$"
-    labelSelectors:
-      matchExpressions:
-        - key: "owner"
-          operator: "NotIn"
-          values: ["helm"]
-        - key: "fleet.cattle.io/managed"
-          operator: "In"
-          values: ["true"]
-  - apiVersion: "v1"
-    kindsRegexp: "^serviceaccounts$"
-    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-|^fleet-"
-    namespaces:
-      - "rancher-operator-system"
   - apiVersion: "v1"
     kindsRegexp: "^configmaps$"
     namespaces:
       - "cattle-system"
-      - "fleet-system"
   - apiVersion: "rbac.authorization.k8s.io/v1"
     kindsRegexp: "^roles$|^rolebindings$"
     namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
   - apiVersion: "rbac.authorization.k8s.io/v1"
-    kindsRegexp: "^roles$|^rolebindings$"
-    resourceNames:
-      - "fleet-controller"
-    namespaceRegexp: "^fleet-"
-  - apiVersion: "rbac.authorization.k8s.io/v1"
     kindsRegexp: "^clusterrolebindings$"
-    resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-|^fleet-"
+    resourceNameRegexp: "^cattle-|^clusterrolebinding-|^globaladmin-user-|^grb-u-"
     resourceNames:
       - "eks-operator"
-      - "rancher-operator"
-      - "gitjob-binding"
-      - "rancher-webhook"
   - apiVersion: "rbac.authorization.k8s.io/v1"
     kindsRegexp: "^clusterroles$"
-    resourceNameRegexp: "^cattle-|^p-|^c-|^local-|^user-|^u-|^project-|^create-ns$|^fleet-"
+    resourceNameRegexp: "^cattle-|^p-|^c-|^local-|^user-|^u-|^project-|^create-ns$"
     resourceNames:
       - "eks-operator"
-      - "rancher-operator"
-      - "gitjob"
   - apiVersion: "apiextensions.k8s.io/v1beta1"
     kindsRegexp: "."
-    resourceNameRegexp: "management.cattle.io$|project.cattle.io$|catalog.cattle.io$|eks.cattle.io$|resources.cattle.io$|rancher.cattle.io$|fleet.cattle.io$|gitjob.cattle.io$"
+    resourceNameRegexp: "management.cattle.io$|project.cattle.io$|catalog.cattle.io$|eks.cattle.io$|resources.cattle.io$"
   - apiVersion: "management.cattle.io/v3"
     kindsRegexp: "."
   - apiVersion: "project.cattle.io/v3"
@@ -77,48 +45,6 @@ resourceSelectors:
     kindsRegexp: "^deployments$"
     resourceNames:
       - "eks-config-operator"
-    namespaces:
-      - "cattle-system"
-  - apiVersion: "rancher.cattle.io/v1"
-    kindsRegexp: "."
-  - apiVersion: "apps/v1"
-    kindsRegexp: "^deployments$"
-    resourceNames:
-      - "rancher-operator"
-    namespaces:
-      - "rancher-operator-system"
-  - apiVersion: "fleet.cattle.io/v1alpha1"
-    kindsRegexp: "."
-  - apiVersion: "gitjob.cattle.io/v1"
-    kindsRegexp: "."
-  - apiVersion: "apps/v1"
-    kindsRegexp: "^deployments$"
-    resourceNames:
-      - "fleet-controller"
-      - "gitjob"
-    namespaces:
-      - "fleet-system"
-  - apiVersion: "apps/v1"
-    kindsRegexp: "^services$"
-    resourceNames:
-      - "gitjob"
-    namespaces:
-      - "fleet-system"
-  - apiVersion: "admissionregistration.k8s.io/v1"
-    kinds:
-      - "ValidatingWebhookConfiguration"
-    resourceNames:
-      - "rancher.cattle.io"
-  - apiVersion: "apps/v1"
-    kindsRegexp: "^services$"
-    resourceNames:
-      - "rancher-webhook"
-    namespaces:
-      - "cattle-system"
-  - apiVersion: "apps/v1"
-    kindsRegexp: "^deployments$"
-    resourceNames:
-      - "rancher-webhook"
     namespaces:
       - "cattle-system"
 controllerReferences:

--- a/packages/rancher-backup/charts/templates/rancher-resourceset.yaml
+++ b/packages/rancher-backup/charts/templates/rancher-resourceset.yaml
@@ -9,7 +9,15 @@ resourceSelectors:
     resourceNames:
       - "local"
   - apiVersion: "v1"
-    kindsRegexp: "^Secret$|^serviceaccounts$"
+    kindsRegexp: "^secrets$"
+    namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
+    labelSelectors:
+      matchExpressions:
+        - key: "owner"
+          operator: "NotIn"
+          values: ["helm"]
+  - apiVersion: "v1"
+    kindsRegexp: "^serviceaccounts$"
     namespaceRegexp: "^cattle-|^p-|^c-|^local$|^user-|^u-"
   - apiVersion: "v1"
     kindsRegexp: "^configmaps$"


### PR DESCRIPTION
This PR reverts the changes made to rancher's default resource set in [this PR](https://github.com/rancher/charts/pull/678/files), except for the one to exclude helm secrets. 
Also adds in the link to rancher-backup chart icon (the icon file is merged in dev-v2.5 branch)

https://github.com/rancher/backup-restore-operator/issues/44
https://github.com/rancher/backup-restore-operator/issues/42
https://github.com/rancher/backup-restore-operator/issues/30#issuecomment-700982880