### PR TITLE
Update chart version and opertor tag for rancher-backup

### DIFF
--- a/packages/rancher-backup/charts/Chart.yaml
+++ b/packages/rancher-backup/charts/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-appVersion: v0.1.0-rc1
+appVersion: v1.0.0
 description: Provides ability to back up and restore the Rancher application running on any Kubernetes cluster
 name: rancher-backup
 keywords:
 - applications
 - infrastructure
-version: 0.1.0
+version: 1.0.000
 icon: https://charts.rancher.io/assets/logos/backup-restore.svg
 annotations:
   catalog.cattle.io/certified: rancher

--- a/packages/rancher-backup/charts/values.yaml
+++ b/packages/rancher-backup/charts/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/backup-restore-operator
-  tag: v0.1.0-rc1
+  tag: v1.0.0
 
 ## Default s3 bucket for storing all backup files created by the backup-restore-operator
 s3:


### PR DESCRIPTION
This commit adds the new tag v1.0.0 for rancher-backup operator, and changes chart version to 1.0.000