### PR TITLE
Update readme to show dependencies better

### DIFF
--- a/packages/rancher-istio/charts/README.md
+++ b/packages/rancher-istio/charts/README.md
@@ -2,19 +2,28 @@
 
 A Rancher created chart that packages the istioctl binary to install via a helm chart.
 
-# Installation
+# Installation Requirements 
 
-### Requirements
+## Chart Dependencies
+- rancher-kiali-server-crd chart
+- rancher-monitoring chart or other monitoring installation
 
-This chart depends on the rancher-kiali-server-crd chart.
-
-It also depends on the `rancher-monitoring` chart being installed with default values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port`.
-If those values are modified on the rancher-monitoring deployment, please adjust the `kiali.external_services.prometheus` url settings:
+### Kiali
+The `kiali.external_services.prometheus` url is set in the values.yaml:
 ```
 http://{{ .Values.nameOverride }}-prometheus.{{ .Values.namespaceOverride }}.svc:{{ prometheus.service.port }}
 ```
+The url depends on the default values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port` being set in your rancher-monitoring or other monitoring instance.
 
-### Installation
+The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=true` which means only the `istio-system` namespace will be scraped by prometheus by default. To ensure you can view traffic, metrics and graphs for resources deployed in other namespaces you will need to add additional configuration.
+
+There are three different ways to enable prometheus to detect resources in other namespaces:
+
+1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
+1. Set `prometheus.prometheusSpec.ignoreNamespaceSelectors=false` on your rancher-monitoring instance.
+1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
+
+# Installation
 ```
-helm install rancher-istio ./ --create-namespace -n istio-system
+helm install rancher-istio . --create-namespace -n istio-system
 ```


### PR DESCRIPTION
**Problem**
rancher-istio chart uses `catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1` to trigger the ui to request for rancher-monitoring installation. Since we cannot guarantee what installed `monitoring.coreos.com.prometheus/v1` we need an additional way to let the user know how to configure the chart

**Solution**
Update the readme to make the chart dependencies more obvious

**Issue**
https://github.com/rancher/rancher/issues/29295