### PR TITLE
Removing additional monitoring config info

### DIFF
--- a/packages/rancher-istio/charts/README.md
+++ b/packages/rancher-istio/charts/README.md
@@ -15,12 +15,11 @@ http://{{ .Values.nameOverride }}-prometheus.{{ .Values.namespaceOverride }}.svc
 ```
 The url depends on the default values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port` being set in your rancher-monitoring or other monitoring instance.
 
-The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=true` which means only the `istio-system` namespace will be scraped by prometheus by default. To ensure you can view traffic, metrics and graphs for resources deployed in other namespaces you will need to add additional configuration.
+The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=false` which means all namespaces will be scraped by prometheus by default. This ensures you can view traffic, metrics and graphs for resources deployed in other namespaces.
 
-There are three different ways to enable prometheus to detect resources in other namespaces:
+To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreNamespaceSelectors=true` and add one of the following configurations to ensure you can continue to view traffic, metrics and graphs for your deployed resources. 
 
 1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
-1. Set `prometheus.prometheusSpec.ignoreNamespaceSelectors=false` on your rancher-monitoring instance.
 1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
 
 # Installation


### PR DESCRIPTION
With the changes here https://github.com/rancher/charts/pull/752, having the additional monitoring config options in the readme is no longer needed. 