### PR TITLE
Update rancher-backup chart version to use v1.0.2 tag

### DIFF
--- a/packages/rancher-backup/charts/Chart.yaml
+++ b/packages/rancher-backup/charts/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-appVersion: v1.0.1
+appVersion: v1.0.2
 description: Provides ability to back up and restore the Rancher application running on any Kubernetes cluster
 name: rancher-backup
 keywords:
 - applications
 - infrastructure
-version: 1.0.100
+version: 1.0.200
 icon: https://charts.rancher.io/assets/logos/backup-restore.svg
 annotations:
   catalog.cattle.io/certified: rancher

--- a/packages/rancher-backup/charts/values.yaml
+++ b/packages/rancher-backup/charts/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/backup-restore-operator
-  tag: v1.0.1
+  tag: v1.0.2
 
 ## Default s3 bucket for storing all backup files created by the backup-restore-operator
 s3:


### PR DESCRIPTION
v1.0.2 includes the fix for https://github.com/rancher/backup-restore-operator/issues/49