### PR TITLE
Update Istio and Kiali Versions

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.7.1
+appVersion: 1.7.3
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.7.101
+version: 1.7.300
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking
@@ -12,6 +12,5 @@ annotations:
   catalog.cattle.io/namespace: istio-system
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
-  catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.23.002
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.001

--- a/packages/rancher-istio/charts/app-readme.md
+++ b/packages/rancher-istio/charts/app-readme.md
@@ -1,13 +1,3 @@
-# Rancher Istio Installers
-
-A Rancher created chart that packages the istioctl binary to install via a helm chart.
-
-# Installation Requirements 
-
-## Chart Dependencies
-- rancher-kiali-server-crd chart
-
-
 ## Kiali
 
 ###  Dependencies
@@ -27,8 +17,3 @@ To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreN
 
 1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
 1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
-
-# Installation
-```
-helm install rancher-istio . --create-namespace -n istio-system
-```

--- a/packages/rancher-istio/charts/requirements.yaml
+++ b/packages/rancher-istio/charts/requirements.yaml
@@ -3,5 +3,5 @@ dependencies:
   - name: rancher-kiali-server
     alias: kiali
     condition: kiali.enabled
-    version: 1.23.0
+    version: 1.24.0
     repository: file://../../rancher-kiali-server/charts

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,10 +1,11 @@
 overlayFile: ""
-tag: 1.7.1
+tag: 1.7.3
+##Setting forceInstall: true will remove the check for istio version < 1.6.x and will not analyze your install cluster prior to install
 forceInstall: false
 
 installer:
   repository: rancher/istio-installer
-  tag: 1.7.1-rancher1
+  tag: 1.7.3-rancher1
 
 istiocoredns:
   enabled: false
@@ -21,7 +22,7 @@ base:
 cni:
   enabled: false
   repository: rancher/istio-install-cni
-  tag: 1.7.1
+  tag: 1.7.3
 
 egressGateways:
   enabled: false
@@ -37,13 +38,13 @@ istiodRemote:
 pilot:
   enabled: true
   repository: rancher/istio-pilot
-  tag: 1.7.1
+  tag: 1.7.3
 
 #Mixer Policy is deprecated in 1.7.x, will not be supported in 1.8.x 
 policy:
   enabled: false
   repository: rancher/istio-mixer
-  tag: 1.7.1
+  tag: 1.7.3
 
 telemetry:
   enabled: true
@@ -51,7 +52,7 @@ telemetry:
   v1:
     enabled: false
     repository: rancher/istio-mixer
-    tag: 1.7.1
+    tag: 1.7.3
   v2:
     enabled: true
 
@@ -67,10 +68,10 @@ global:
     systemDefaultRegistry: ""
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.7.1
+    tag: 1.7.3
   proxy_init:
     repository: rancher/istio-proxyv2
-    tag: 1.7.1
+    tag: 1.7.3
   defaultPodDisruptionBudget:
     enabled: true
 
@@ -86,7 +87,7 @@ kiali:
   deployment:
     ingress_enabled: false
     repository: rancher/kiali-kiali
-    tag: v1.23.0
+    tag: v1.24.0
   external_services:
     prometheus:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"

--- a/packages/rancher-istio/scripts/version_update.go
+++ b/packages/rancher-istio/scripts/version_update.go
@@ -53,4 +53,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	err = updateFiles(fmt.Sprintf("%s/packages/rancher-istio/charts/requirements.yaml", wd), *currentIstio, *newIstio, *currentKiali, *newKiali)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/packages/rancher-istio/scripts/version_update.go
+++ b/packages/rancher-istio/scripts/version_update.go
@@ -1,0 +1,56 @@
+package main
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"flag"
+)
+
+func updateFiles(path string, currentIstio string, newIstio string, currentKiali string, newKiali string) error {
+	read, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(path)
+	if currentIstio != "" && newIstio != "" {
+		err := replaceAndWrite(read, path, currentIstio, newIstio)
+		if err != nil{
+			return err
+		}
+	}
+
+	if currentKiali != "" && newKiali != "" {
+		err := replaceAndWrite(read, path, currentKiali, newKiali)
+		if err != nil{
+			return err
+		}
+	}
+	return nil
+}
+
+func replaceAndWrite(read []byte, path string, old string, new string ) error {
+	newContents := strings.Replace(string(read), old, new, -1)
+	fmt.Println(newContents)
+	return ioutil.WriteFile(path, []byte(newContents), 0)
+}
+
+func main() {
+	currentIstio := flag.String("ci", "", "The current version of istio")
+	newIstio := flag.String("ni", "", "The new version of istio")
+	currentKiali := flag.String("ck", "", "The current version of kiali")
+	newKiali := flag.String("nk", "", "The new version of kiali")
+	flag.Parse()
+	wd, err := os.Getwd()
+	if err != nil {
+		panic (err)
+	}
+	err = updateFiles(fmt.Sprintf("%s/packages/rancher-istio/charts/values.yaml", wd), *currentIstio, *newIstio, *currentKiali, *newKiali)
+	if err != nil {
+		panic(err)
+	}
+	err = updateFiles(fmt.Sprintf("%s/packages/rancher-istio/charts/Chart.yaml", wd), *currentIstio, *newIstio, *currentKiali, *newKiali)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/packages/rancher-kiali-server/package.yaml
+++ b/packages/rancher-kiali-server/package.yaml
@@ -1,5 +1,5 @@
-url: https://kiali.org/helm-charts/kiali-server-1.23.0.tgz
-packageVersion: 02
+url: https://kiali.org/helm-charts/kiali-server-1.24.0.tgz
+packageVersion: 01
 generateCRDChart:
   enabled: true
 

--- a/packages/rancher-kiali-server/rancher-kiali-server.patch
+++ b/packages/rancher-kiali-server/rancher-kiali-server.patch
@@ -3,7 +3,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/C
 +++ packages/rancher-kiali-server/charts/Chart.yaml
 @@ -1,20 +1,27 @@
  apiVersion: v2
- appVersion: v1.23.0
+ appVersion: v1.24.0
 -description: Kiali is an open source project for service mesh observability, refer
 -  to https://www.kiali.io for details.
 +description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details. This is installed as sub-chart with customized values in Rancher's Istio.
@@ -34,7 +34,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/C
 +  - https://github.com/kiali/kiali-ui
 +  - https://github.com/kiali/kiali-operator
 +  - https://github.com/kiali/helm-charts
- version: 1.23.0
+ version: 1.24.0
 +annotations:
 +  catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
 +  catalog.rancher.io/namespace: cattle-istio-system
@@ -145,8 +145,8 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/v
 +  repository: rancher/kiali-kiali
    image_pull_policy: "Always"
    image_pull_secrets: []
--  image_version: v1.23.0
-+  tag: v1.23.0
+-  image_version: v1.24.0
++  tag: v1.24.0
    ingress_enabled: true
    node_selector: {}
    override_ingress_yaml:


### PR DESCRIPTION
**Problem**
Kiali released version 1.24.0
Istio released version 1.7.3 (this is a security release)
Older versions of installer use verify-install which does not work as expected in all scenarios

**Solution**
Update versions for kiali and istio to match the latest releases 
With the istio version update, the new installer without verify-install is used

Also added script to make updating the versions a lot easier. On occasion I would miss a value, the script ensures all values are getting updated as expected. 

**Issues**
rancher/rancher#29383
rancher/rancher#29249
rancher/rancher#29408

**Dependencies**
https://github.com/rancher/istio-installer/pull/12