### PR TITLE
Allow any PushProx client to use secret volumes

### DIFF
--- a/packages/rancher-pushprox/charts/templates/pushprox-clients-rbac.yaml
+++ b/packages/rancher-pushprox/charts/templates/pushprox-clients-rbac.yaml
@@ -62,10 +62,10 @@ spec:
       - min: 0
         max: 65535
   readOnlyRootFilesystem: false
-{{- if and .Values.clients.https.enabled .Values.clients.https.certDir }}
   volumes:
-    - 'emptyDir'
     - 'secret'
+{{- if and .Values.clients.https.enabled .Values.clients.https.certDir }}
+    - 'emptyDir'
     - 'hostPath'
   allowedHostPaths:
   - pathPrefix: {{ required "Need access to volume on host with the SSL cert files to use HTTPs" .Values.clients.https.certDir }}


### PR DESCRIPTION
Preventing PushProx client pods from using secret volumes prevents the clients from being deployed in a hardened cluster since the Pod requires the ability to mount the service account token as a secret to use the PSP in the first place.

Related Issues: https://github.com/rancher/rancher/issues/29059, https://github.com/rancher/rancher/issues/28536, https://github.com/rancher/rancher/issues/18044