### PR TITLE
Updating cis-operator tag and updating cis ClusterRoles to drop label and ns

### DIFF
--- a/packages/rancher-cis-benchmark/charts/Chart.yaml
+++ b/packages/rancher-cis-benchmark/charts/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: v1.0.1
+appVersion: v1.0.2
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes
   cluster
 name: rancher-cis-benchmark
-version: 1.0.101
+version: 1.0.200
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
 - security

--- a/packages/rancher-cis-benchmark/charts/crds/scheduledscan.yaml
+++ b/packages/rancher-cis-benchmark/charts/crds/scheduledscan.yaml
@@ -1,0 +1,80 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: scheduledscans.cis.cattle.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.lastRunTimestamp
+    name: LastRunTimestamp
+    type: string
+  - JSONPath: .status.lastClusterScanName
+    name: LastClusterScanName
+    type: string
+  - JSONPath: .spec.cronSchedule
+    name: CronSchedule
+    type: string
+  group: cis.cattle.io
+  names:
+    kind: ScheduledScan
+    plural: scheduledscans
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            cronSchedule:
+              nullable: true
+              type: string
+            retentionCount:
+              type: integer
+            scanProfileName:
+              nullable: true
+              type: string
+          type: object
+        status:
+          properties:
+            NextScanAt:
+              nullable: true
+              type: string
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    nullable: true
+                    type: string
+                  lastUpdateTime:
+                    nullable: true
+                    type: string
+                  message:
+                    nullable: true
+                    type: string
+                  reason:
+                    nullable: true
+                    type: string
+                  status:
+                    nullable: true
+                    type: string
+                  type:
+                    nullable: true
+                    type: string
+                type: object
+              nullable: true
+              type: array
+            lastClusterScanName:
+              nullable: true
+              type: string
+            lastRunTimestamp:
+              nullable: true
+              type: string
+            observedGeneration:
+              type: integer
+          type: object
+      type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/packages/rancher-cis-benchmark/charts/templates/cis-roles.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/cis-roles.yaml
@@ -2,10 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: cis-admin
-  namespace: {{ template "cis.namespace" . }}
 rules:
   - apiGroups:
       - cis.cattle.io
@@ -19,26 +16,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-edit: "true"
-  namespace: {{ template "cis.namespace" . }}
-  name: cis-edit
-rules:
-  - apiGroups:
-      - cis.cattle.io
-    resources:
-      - clusterscanbenchmarks
-      - clusterscanprofiles
-      - clusterscans
-      - clusterscanreports
-    verbs: ["create", "update", "delete", "patch","get", "watch", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
-  namespace: {{ template "cis.namespace" . }}
   name: cis-view
 rules:
   - apiGroups:

--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -5,7 +5,7 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.0.1
+    tag: v1.0.2
   securityScan:
     repository: rancher/security-scan
     tag: v0.2.1


### PR DESCRIPTION
1) Updating the chart to point to new cis-operator tag that pulls the scheduled Scan functionality
- https://github.com/rancher/cis-operator/issues/27

2) Also removing the aggregator label from cis ClusterRoles since the aggregation does not apply to cluster scoped CIS CRDs
3) Also removing the namespace from ClusterRoles since namespace is not required for ClusterRoles that applies cluster wide.
- https://github.com/rancher/cis-operator/issues/41