### PR TITLE
Add generateCRDChart.assumeOwnershipOfCRDs for rancher-gatekeeper

### DIFF
--- a/packages/rancher-gatekeeper/package.yaml
+++ b/packages/rancher-gatekeeper/package.yaml
@@ -1,4 +1,5 @@
 url: https://open-policy-agent.github.io/gatekeeper/charts/gatekeeper-3.2.1.tgz
-packageVersion: 00
+packageVersion: 01
 generateCRDChart:
   enabled: true
+  assumeOwnershipOfCRDs: true


### PR DESCRIPTION
If gatekeeper is already installed on a rancher-2.4 cluster, then after upgrading to 2.5 if user wants to update gatekeeper app to its latest GA chart, there is no upgrade path. 
User has to uninstall the 2.4 gatekeeper via ember UI and then re-install the new rancher-gatekeeper app via Cluster-Explorer

Even if the previous gatekeeper is uninstalled, helm2 does not delete the crds. These crds are installed by another helm release and so while installing the 2.5 rancher-gatekeeper the crd installation errors out.

The CRD's have not changed between the 2 gatekeeper releases, hence we can just transfer the ownership to the 2.5 helm release by adding flag assumeOwnershipOfCRD to the chart

https://github.com/rancher/rancher/issues/29188


After applying this fix following tests have been performed and working fine:
A] Uninstalling OPA v1 on Rancher 2.4.8 and installing OPA v2 after upgrading to Rancher 2.5
1) On HA setup install Rancher v2.4.8 and then enable OPA Gatekeeper v1 via Dashboard
2) Create few constraints and make sure they work
3) Now Upgrade Rancher to v2.5 
4) OPA Gatekeeper v1 is still working
5) Now delete OPA Gatekeeper v1 by Removing the App from Ember UI or ClusterManager
6) After uninstall, go to ClusterExplorer and Install new rancher-gatekeeper App
7) Installation succeeds and you can check via kubectl that the 2 v1 CRDs are present and 2 new v2 CRDS are added.

8) Also gatekeeper v2 versions can be upgraded 

