### PR TITLE
Add runAsNonRoot to false to override init container

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring.patch
+++ b/packages/rancher-monitoring/rancher-monitoring.patch
@@ -119,7 +119,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
  {{- define "grafana.pod" -}}
  {{- if .Values.schedulerName }}
  schedulerName: "{{ .Values.schedulerName }}"
-@@ -21,9 +20,9 @@
+@@ -21,12 +20,13 @@
  {{- if ( and .Values.persistence.enabled .Values.initChownData.enabled ) }}
    - name: init-chown-data
      {{- if .Values.initChownData.image.sha }}
@@ -131,7 +131,11 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
      {{- end }}
      imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
      securityContext:
-@@ -41,9 +40,9 @@
++      runAsNonRoot: false
+       runAsUser: 0
+     command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/var/lib/grafana"]
+     resources:
+@@ -41,9 +41,9 @@
  {{- if .Values.dashboards }}
    - name: download-dashboards
      {{- if .Values.downloadDashboardsImage.sha }}
@@ -143,7 +147,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
      {{- end }}
      imagePullPolicy: {{ .Values.downloadDashboardsImage.pullPolicy }}
      command: ["/bin/sh"]
-@@ -73,9 +72,9 @@
+@@ -73,9 +73,9 @@
  {{- if .Values.sidecar.datasources.enabled }}
    - name: {{ template "grafana.name" . }}-sc-datasources
      {{- if .Values.sidecar.image.sha }}
@@ -155,7 +159,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
      {{- end }}
      imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
      env:
-@@ -108,9 +107,9 @@
+@@ -108,9 +108,9 @@
  {{- if .Values.sidecar.notifiers.enabled }}
    - name: {{ template "grafana.name" . }}-sc-notifiers
      {{- if .Values.sidecar.image.sha }}
@@ -167,7 +171,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
      {{- end }}
      imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
      env:
-@@ -153,9 +152,9 @@
+@@ -153,9 +153,9 @@
  {{- if .Values.sidecar.dashboards.enabled }}
    - name: {{ template "grafana.name" . }}-sc-dashboard
      {{- if .Values.sidecar.image.sha }}
@@ -179,7 +183,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
      {{- end }}
      imagePullPolicy: {{ .Values.sidecar.imagePullPolicy }}
      env:
-@@ -187,9 +186,9 @@
+@@ -187,9 +187,9 @@
  {{- end}}
    - name: {{ .Chart.Name }}
      {{- if .Values.image.sha }}
@@ -191,7 +195,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
      {{- end }}
      imagePullPolicy: {{ .Values.image.pullPolicy }}
    {{- if .Values.command }}
-@@ -285,7 +284,7 @@
+@@ -285,7 +285,7 @@
      {{- end }}
      ports:
        - name: {{ .Values.service.portName }}


### PR DESCRIPTION
The initChown container needs to run as root user so that runAsNonRoot
has to be disabled to respect root user setting