### PR TITLE
Remove hostPath type from PushProx client

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring.patch
+++ b/packages/rancher-monitoring/rancher-monitoring.patch
@@ -517,79 +517,79 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/req
 +
 +  - name: rancher-pushprox
 +    alias: rkeControllerManager
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rkeControllerManager.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rkeScheduler
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rkeScheduler.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rkeProxy
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rkeProxy.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rkeEtcd
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rkeEtcd.enabled
 +
 +  - name: rancher-pushprox
 +    alias: k3sServer
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: k3sServer.enabled
 +
 +  - name: rancher-pushprox
 +    alias: kubeAdmControllerManager
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: kubeAdmControllerManager.enabled
 +
 +  - name: rancher-pushprox
 +    alias: kubeAdmScheduler
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: kubeAdmScheduler.enabled
 +
 +  - name: rancher-pushprox
 +    alias: kubeAdmProxy
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: kubeAdmProxy.enabled
 +
 +  - name: rancher-pushprox
 +    alias: kubeAdmEtcd
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: kubeAdmEtcd.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rke2ControllerManager
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rke2ControllerManager.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rke2Scheduler
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rke2Scheduler.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rke2Proxy
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rke2Proxy.enabled
 +
 +  - name: rancher-pushprox
 +    alias: rke2Etcd
-+    version: 0.1.0
++    version: 0.1.1
 +    repository: file://../../rancher-pushprox/charts
 +    condition: rke2Etcd.enabled
 \ No newline at end of file

--- a/packages/rancher-pushprox/charts/Chart.yaml
+++ b/packages/rancher-pushprox/charts/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: 0.1.0
+version: 0.1.1
 appVersion: 0.1.0
 annotations:
   catalog.rancher.io/certified: rancher

--- a/packages/rancher-pushprox/charts/templates/pushprox-clients.yaml
+++ b/packages/rancher-pushprox/charts/templates/pushprox-clients.yaml
@@ -127,7 +127,6 @@ spec:
       - name: metrics-cert-dir-source
         hostPath:
           path: {{ required "Need access to volume on host with the SSL cert files to use HTTPs" .Values.clients.https.certDir }}
-          type: Directory
       - name: metrics-cert-dir
         emptyDir: {}
       {{- end }}


### PR DESCRIPTION
The issue in https://github.com/kubernetes/kubernetes/issues/83125 was encountered when trying to use /opt/rke/etc/kubernetes/ssl as the hostPath. Removing this resolves it.

Related Issue: https://github.com/rancher/rancher/issues/29815