### PR TITLE
Update logging chart with upstream version 3.7.3

### DIFF
--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,4 +1,4 @@
-url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.6.0.tgz
+url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.7.3.tgz
 packageVersion: 01
 generateCRDChart:
   enabled: true

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -3,12 +3,12 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/Chart.
 +++ packages/rancher-logging/charts/Chart.yaml
 @@ -1,5 +1,16 @@
  apiVersion: v1
- appVersion: 3.6.0
+ appVersion: 3.7.3
 -description: A Helm chart to install Banzai Cloud logging-operator
 -name: logging-operator
-+description: Collects and filter logs using highly configurable CRDs.  Powered by Banzai Cloud Logging Operator.
++description: Collects and filter logs using highly configurable CRDs. Powered by Banzai Cloud Logging Operator.
 +name: rancher-logging
- version: 3.6.0
+ version: 3.7.3
 +icon: https://charts.rancher.io/assets/logos/logging.svg
 +keywords:
 +  - logging
@@ -67,9 +67,9 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
  replicaCount: 1
  
  image:
--  repository: banzaicloud/logging-operator
+-  repository: ghcr.io/banzaicloud/logging-operator
 +  repository: rancher/banzaicloud-logging-operator
-   tag: 3.6.0
+   tag: 3.7.3
    pullPolicy: IfNotPresent
  
 @@ -18,7 +18,7 @@
@@ -98,13 +98,13 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
  
  affinity: {}
  
-@@ -76,4 +81,49 @@
+@@ -76,4 +81,46 @@
  monitoring:
    # Create a Prometheus Operator ServiceMonitor object
    serviceMonitor:
 -    enabled: false
 \ No newline at end of file
-+    enabled: true
++    enabled: false
 +
 +disablePvc: true
 +
@@ -128,16 +128,13 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
 +    tag: v0.2.2
 +  fluentbit:
 +    repository: rancher/fluent-fluent-bit
-+    tag: 1.5.4
++    tag: 1.6.1
 +  fluentbit_debug:
 +    repository: rancher/fluent-fluent-bit
-+    tag: 1.5.4-debug
++    tag: 1.6.1-debug
 +  fluentd:
 +    repository: rancher/banzaicloud-fluentd
-+    tag: v1.11.2-alpine-2
-+  syslog_forwarder:
-+    repository: rancher/fluent-bit-out-syslog
-+    tag: 0.1.0
++    tag: v1.11.4-alpine-1
 +
 +fluentbit_tolerations:
 +  - key: node-role.kubernetes.io/controlplane


### PR DESCRIPTION
Update logging chart with upstream version 3.7.3 and disable
serviceMonitor installation.

EDIT: added second commit to support syslog (https://github.com/rancher/rancher/issues/29892)

Completes issue: [#29642](https://github.com/rancher/rancher/issues/29642)
Prerequisite for completing issue: [#28720](https://github.com/rancher/rancher/issues/28720)