### PR TITLE
[DNM - 2.5.4] Split up CRDs based on ConfigMap 1mb limit for assumeOwnershipOfCRDs

### DIFF
--- a/scripts/chart-templates/crd-assume-ownership/templates/_helpers.tpl
+++ b/scripts/chart-templates/crd-assume-ownership/templates/_helpers.tpl
@@ -5,3 +5,47 @@
 {{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Creates a list of ConfigMaps that contain CRD files with the following format.
+It ensures that no ConfigMap is >1mb in size.
+name: $name-manifest-xx
+crds:
+  {{ path }}: {{ File }}
+size: {{ size in characters }}
+*/}}
+{{- define "crd_manifest_configmaps" -}}
+{{- \$currentScope := . -}}
+{{- \$counter := dict "i" 0 -}}
+{{/* Initialize the first configMap and add it to the list of ConfigMaps necessary */}}
+{{- \$currName := (printf "%s-manifest-%02d" \$currentScope.Chart.Name (get \$counter "i")) -}}
+{{- \$currConfigMap := dict "name" \$currName "size" 0 "crds" (dict) -}}
+{{- \$configMaps := dict \$currName \$currConfigMap -}}
+{{/* Iterate through the CRDs to add to the configMap or create a new one */}}
+{{- range \$filepath, \$_ :=  (.Files.Glob "crd-manifest/**.yaml") -}}
+{{- with \$currentScope -}}
+{{/* Get current values from the dictionary */}}
+{{- \$currConfigMap := get \$configMaps \$currName -}}
+{{- \$currSize := get \$currConfigMap "size" -}}
+{{- \$currCRDs := get \$currConfigMap "crds" -}}
+{{/* Get the next CRD file that needs to be added to a ConfigMap */}}
+{{- \$path := base \$filepath -}}
+{{- \$file := .Files.Get \$filepath -}}
+{{/* Check if the file size of the CRD causes size to exceed 1048576 characters, which requires a new ConfigMap */}}
+{{- \$currSize := (add \$currSize (len \$file)) -}}
+{{- if ge \$currSize 1000000 -}}
+{{/* Create a new configMap */}}
+{{- \$_ := set \$counter "i" (add (get \$counter "i") 1) }}
+{{- \$currName := (printf "%s-manifest-%02d" \$currentScope.Chart.Name (get \$counter "i")) -}}
+{{- \$currConfigMap := dict "name" \$currName "size" (len \$file) "crds" (dict \$path \$file) -}}
+{{- \$_ := set \$configMaps \$currName \$currConfigMap -}}
+{{- else -}}
+{{/* Update the configMap */}}
+{{- \$_ := set \$currCRDs \$path \$file -}}
+{{- \$_ := set \$currConfigMap "crds" \$currCRDs -}}
+{{- \$_ := set \$currConfigMap "size" \$currSize -}}
+{{- \$_ := set \$configMaps \$currName \$currConfigMap -}}
+{{- end -}}
+{{- end -}}{{- end -}}
+{{ \$configMaps | toYaml }}
+{{- end -}}

--- a/scripts/chart-templates/crd-assume-ownership/templates/jobs.yaml
+++ b/scripts/chart-templates/crd-assume-ownership/templates/jobs.yaml
@@ -1,3 +1,4 @@
+{{- \$currentScope := . -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -20,23 +21,29 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       containers:
-        - name: create-crds
+{{- range \$configMap := (include "crd_manifest_configmaps" . | fromYaml) }}
+{{- with \$currentScope }}
+        - name: create-crds-{{ get \$configMap "name" }}
           image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: IfNotPresent
           command:
           - /bin/kubectl
           - apply
           - -f
-          - /etc/config/crd-manifest.yaml
+          - /etc/config/crd-manifest/{{ get \$configMap "name" }}
           volumeMounts:
-            - name: crd-manifest
-              readOnly: true
-              mountPath: /etc/config
+          - name: {{ get \$configMap "name" }}
+            readOnly: true
+            mountPath: /etc/config/crd-manifest/{{ get \$configMap "name" }}
+{{- end }}{{- end }}
       restartPolicy: OnFailure
       volumes:
-      - name: crd-manifest
+{{- range \$configMap := (include "crd_manifest_configmaps" . | fromYaml) }}
+{{- with \$currentScope }}
+      - name: {{ get \$configMap "name" }}
         configMap:
-          name: {{ .Chart.Name }}-manifest
+          name: {{ get \$configMap "name" }}
+{{- end }}{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -60,33 +67,43 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
       initContainers:
-        - name: remove-finalizers
+{{- range \$configMap := (include "crd_manifest_configmaps" . | fromYaml) }}
+{{- with \$currentScope }}
+        - name: remove-finalzers-{{ get \$configMap "name" }}
           image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: IfNotPresent
           command:
           - /bin/kubectl
           - apply
           - -f
-          - /etc/config/crd-manifest.yaml
+          - /etc/config/crd-manifest/{{ get \$configMap "name" }}
           volumeMounts:
-            - name: crd-manifest
-              readOnly: true
-              mountPath: /etc/config
+          - name: {{ get \$configMap "name" }}
+            readOnly: true
+            mountPath: /etc/config/crd-manifest/{{ get \$configMap "name" }}
+{{- end }}{{- end }}
       containers:
-        - name: delete-crds
+{{- range \$configMap := (include "crd_manifest_configmaps" . | fromYaml) }}
+{{- with \$currentScope }}
+        - name: delete-crds-{{ get \$configMap "name" }}
           image: {{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: IfNotPresent
           command:
           - /bin/kubectl
           - delete
           - -f
-          - /etc/config/crd-manifest.yaml
+          - /etc/config/crd-manifest/{{ get \$configMap "name" }}
           volumeMounts:
-            - name: crd-manifest
-              readOnly: true
-              mountPath: /etc/config
+          - name: {{ get \$configMap "name" }}
+            readOnly: true
+            mountPath: /etc/config/crd-manifest/{{ get \$configMap "name" }}
+{{- end }}{{- end }}
       restartPolicy: OnFailure
       volumes:
-      - name: crd-manifest
+{{- range \$configMap := (include "crd_manifest_configmaps" . | fromYaml) }}
+{{- with \$currentScope }}
+      - name: {{ get \$configMap "name" }}
         configMap:
-          name: {{ .Chart.Name }}-manifest
+          name: {{ get \$configMap "name" }}
+{{- end }}{{- end }}
+

--- a/scripts/chart-templates/crd-assume-ownership/templates/manifest.yaml
+++ b/scripts/chart-templates/crd-assume-ownership/templates/manifest.yaml
@@ -1,14 +1,15 @@
+{{- \$currentScope := . -}}
+{{- range \$configMap := (include "crd_manifest_configmaps" . | fromYaml) }}
+{{- with \$currentScope -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Chart.Name }}-manifest
+  name: {{ get \$configMap "name" }}
   namespace: {{ .Release.Namespace }}
 data:
-  crd-manifest.yaml: |
-    {{- \$currentScope := . -}}
-    {{- \$crds := (.Files.Glob  "crd-manifest/**.yaml") -}}
-    {{- range \$path, \$_ :=  \$crds -}}
-    {{- with \$currentScope -}}
-    {{ .Files.Get \$path | nindent 4 }}
-    ---
-    {{- end -}}{{- end -}}
+{{- range \$path, \$file := (get \$configMap "crds") }}
+{{ \$path | indent 2 }}: |
+{{ \$file | indent 4 }}
+{{- end }}
+---
+{{- end }}{{- end }}


### PR DESCRIPTION
This PR changes the chart template for `assumeOwnershipOfCRDs` to create a new ConfigMap if a single ConfigMap has over 1mb in it. It only affects charts that use `assumeOwnershipOfCRDs`.

The previous behavior was to use one ConfigMap for all CRDs, which does not work for Rancher Monitoring since it has exceeded that (see issue).

Related Issue: https://github.com/rancher/rancher/issues/29973