### PR TITLE
Change default webroot helper

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.3
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.7.300
+version: 1.7.301
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking
@@ -13,5 +13,5 @@ annotations:
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.001
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.002
   catalog.cattle.io/display-name: "Istio"

--- a/packages/rancher-kiali-server/package.yaml
+++ b/packages/rancher-kiali-server/package.yaml
@@ -1,5 +1,4 @@
 url: https://kiali.org/helm-charts/kiali-server-1.24.0.tgz
-packageVersion: 01
+packageVersion: 02
 generateCRDChart:
   enabled: true
-

--- a/packages/rancher-kiali-server/rancher-kiali-server.patch
+++ b/packages/rancher-kiali-server/rancher-kiali-server.patch
@@ -57,7 +57,20 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/t
  {{- end }}
  {{- end }}
  
-@@ -170,3 +166,11 @@
+@@ -101,11 +97,7 @@
+ {{- if .Values.server.web_root  }}
+   {{- .Values.server.web_root | trimSuffix "/" }}
+ {{- else }}
+-  {{- if .Capabilities.APIVersions.Has "route.openshift.io/v1" }}
+-    {{- "/" }}
+-  {{- else }}
+-    {{- "/kiali" }}
+-  {{- end }}
++  {{- "/" }}
+ {{- end }}
+ {{- end }}
+ 
+@@ -170,3 +162,11 @@
    {{- end }}
  {{- end }}
  {{- end }}
@@ -122,7 +135,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/t
 +    {{- include "kiali-server.labels" . | nindent 4 }}
 +data:
 +  env.js: |
-+    window.WEB_ROOT='/k8s/clusters/{{ .Values.global.cattle.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:rancher-istio-kiali:20001/proxy';
++    window.WEB_ROOT='/k8s/clusters/{{ .Values.global.cattle.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:kiali:20001/proxy';
 +{{- end }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/values.yaml packages/rancher-kiali-server/charts/values.yaml
 --- packages/rancher-kiali-server/charts-original/values.yaml


### PR DESCRIPTION
**Problem** 
The server.web_root has a helper method that is defaulting to `/kiali` so on refresh, the window.web_root is expected to have `/kiali` appended, but it doesn't so an error page occurs

**Solution**
Changed the helper method to be `/` by default if web_root is not set
Update window web_root to match the kiali server name

**2nd Solution**
https://github.com/rancher/charts/pull/826/files

**3rd Solution that was not implemented**
Set the nameOverride to `nameOverride: "rancher-istio-kiali"`
Set the fullNameOverride to `fullnameOverride: "rancher-istio-kiali"`
Changed the helper method to be `/` by default if web_root is not set
Do not change the window web_root
* UI change needed so that the kiali url dashboard will update based on if an older version name kiali or newer version named rancher-istio-kiali is deployed. 


**Issue**
https://github.com/rancher/rancher/issues/29898