### PR TITLE
Revert "Add cleanup steps to make charts"

### DIFF
--- a/scripts/generate-charts
+++ b/scripts/generate-charts
@@ -31,14 +31,6 @@ for f in packages/*; do
 			cp -R ${f}/charts-crd/* charts/$(basename -- ${f})/charts-crd
 		fi
 		helm repo index --merge ./assets/index.yaml --url assets assets
-
-		# Clean up changes
-		if [[ -f ${f}/package.yaml ]]; then
-			yq w -i ${f}/charts/Chart.yaml 'version' "${version}"
-		fi
-		for file in $(find ./${f}/overlay -type f); do
-			rm ${f}/charts/${file#./${f}/overlay/}
-		done
 	fi
 done
 


### PR DESCRIPTION
This reverts commit f3d83c68fccd7ee33bd3edd1fac35743583ee7cc.

The original PR introduces a bug in the push-to-assets-branch process that makes the generated `charts/` directory not show the Chart version change + overlaid files.

Original PR: https://github.com/rancher/charts/pull/842

Related Issue: https://github.com/rancher/rancher/issues/29064