### PR TITLE
Adapt overridden kiali webroot to correct kiali service name

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.3
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.7.300
+version: 1.7.301
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking
@@ -13,5 +13,5 @@ annotations:
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.001
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.002
   catalog.cattle.io/display-name: "Istio"

--- a/packages/rancher-kiali-server/package.yaml
+++ b/packages/rancher-kiali-server/package.yaml
@@ -1,5 +1,5 @@
 url: https://kiali.org/helm-charts/kiali-server-1.24.0.tgz
-packageVersion: 01
+packageVersion: 02
 generateCRDChart:
   enabled: true
 

--- a/packages/rancher-kiali-server/rancher-kiali-server.patch
+++ b/packages/rancher-kiali-server/rancher-kiali-server.patch
@@ -122,7 +122,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/t
 +    {{- include "kiali-server.labels" . | nindent 4 }}
 +data:
 +  env.js: |
-+    window.WEB_ROOT='/k8s/clusters/{{ .Values.global.cattle.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:rancher-istio-kiali:20001/proxy';
++    window.WEB_ROOT='/k8s/clusters/{{ .Values.global.cattle.clusterId }}/api/v1/namespaces/{{ .Release.Namespace }}/services/http:kiali:20001/proxy/kiali';
 +{{- end }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/values.yaml packages/rancher-kiali-server/charts/values.yaml
 --- packages/rancher-kiali-server/charts-original/values.yaml


### PR DESCRIPTION
Signed-off-by: Bastian Hofmann <bashofmann@gmail.com>
Opening new to resolve merge conflicts so we can merge 

**Original PR**
https://github.com/rancher/charts/pull/826

**Problem**
The server.web_root has a helper method that is defaulting to /kiali so on refresh, the window.web_root is expected to have /kiali appended, but it doesn't so an error page occurs

**Solution**
Changed the window webroot to have `/kiali` appended on, so that it matched the default helper web_root. 

**Issue**
rancher/rancher#29898