### PR TITLE
Add in jaeger tracing all-in-one

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.3
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.7.301
+version: 1.7.302
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking

--- a/packages/rancher-istio/charts/README.md
+++ b/packages/rancher-istio/charts/README.md
@@ -8,7 +8,11 @@ A Rancher created chart that packages the istioctl binary to install via a helm 
 - rancher-kiali-server-crd chart
 
 
+# Addons
+
 ## Kiali
+
+Kiali allows you to view and manage your istio-based service mesh through an easy to use dashboard.
 
 ###  Dependencies
 - rancher-monitoring chart or other Prometheus installation
@@ -29,6 +33,12 @@ To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreN
 
 1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
 1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
+
+## Jaeger
+
+Jaeger allows you to trace and monitor distributed microservices.
+
+> **Note:** This addon is using the basic all-in-one Jaeger installation which is not qualified for production. Use the [Jaeger Tracing](https://www.jaegertracing.io/docs/1.21/getting-started/) documentation to determine which installation you will need for your production needs.
 
 # Installation
 ```

--- a/packages/rancher-istio/charts/app-readme.md
+++ b/packages/rancher-istio/charts/app-readme.md
@@ -2,6 +2,7 @@
 
 Our [Istio](https://istio.io/) installer wraps the istioctl binary commands in a handy helm chart, including an overlay file option to allow complex customization. It also includes:
 * **[Kiali](https://kiali.io/)**: Used for graphing traffic flow throughout the mesh
+* **[Jaeger](https://www.jaegertracing.io/)**: A quick start, all-in-one installation used for tracing distributed systemm. This is not production qualified, please refer to jaeger documentation to determine which installation you may need instead.
 
 ### Dependencies
 

--- a/packages/rancher-istio/charts/requirements.yaml
+++ b/packages/rancher-istio/charts/requirements.yaml
@@ -5,3 +5,9 @@ dependencies:
     condition: kiali.enabled
     version: 1.24.0
     repository: file://../../rancher-kiali-server/charts
+    
+  - name: rancher-tracing
+    alias: tracing
+    condition: tracing.enabled
+    version: 1.20.001
+    repository: file://../../rancher-tracing/charts

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -93,4 +93,10 @@ kiali:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
       url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
     tracing:
-      enabled: false
+      in_cluster_url: "http://tracing.istio-system.svc:16686"
+
+tracing:
+  enabled: false
+  jaeger:
+    repository: rancher/jaegertracing-all-in-one
+    tag: 1.20.0

--- a/packages/rancher-tracing/charts/.helmignore
+++ b/packages/rancher-tracing/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/rancher-tracing/charts/Chart.yaml
+++ b/packages/rancher-tracing/charts/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+appVersion: 1.20.0
+description: A quick start Jaeger Tracing installation using the all-in-one demo. This is not production qualified. Refer to https://www.jaegertracing.io/ for details.
+name: rancher-tracing
+version: 1.20.001
+annotations:
+  catalog.rancher.io/certified: rancher
+  catalog.rancher.io/namespace: istio-system
+  catalog.rancher.io/release-name: rancher-tracing
+  catalog.cattle.io/hidden: "true"

--- a/packages/rancher-tracing/charts/README.md
+++ b/packages/rancher-tracing/charts/README.md
@@ -1,0 +1,5 @@
+# Jaeger
+
+A Rancher chart based on the Jaeger all-in-one quick installation option. This chart will allow you to trace and monitor distributed microservices.
+
+> **Note:** The basic all-in-one Jaeger installation which is not qualified for production. Use the [Jaeger Tracing](https://www.jaegertracing.io) documentation to determine which installation you will need for your production needs.

--- a/packages/rancher-tracing/charts/templates/_affinity.tpl
+++ b/packages/rancher-tracing/charts/templates/_affinity.tpl
@@ -1,0 +1,92 @@
+{{/* affinity - https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ */}}
+{{- define "nodeAffinity" }}
+  nodeAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityRequiredDuringScheduling" . }}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "nodeAffinityPreferredDuringScheduling" . }}
+{{- end }}
+
+{{- define "nodeAffinityRequiredDuringScheduling" }}
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+        {{- range $key, $val := .Values.global.arch }}
+          {{- if gt ($val | int) 0 }}
+          - {{ $key | quote }}
+          {{- end }}
+        {{- end }}
+        {{- $nodeSelector := default .Values.global.defaultNodeSelector .Values.nodeSelector -}}
+        {{- range $key, $val := $nodeSelector }}
+        - key: {{ $key }}
+          operator: In
+          values:
+          - {{ $val | quote }}
+        {{- end }}
+{{- end }}
+
+{{- define "nodeAffinityPreferredDuringScheduling" }}
+  {{- range $key, $val := .Values.global.arch }}
+    {{- if gt ($val | int) 0 }}
+    - weight: {{ $val | int }}
+      preference:
+        matchExpressions:
+        - key: beta.kubernetes.io/arch
+          operator: In
+          values:
+          - {{ $key | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- define "podAntiAffinity" }}
+{{- if or .Values.podAntiAffinityLabelSelector .Values.podAntiAffinityTermLabelSelector}}
+  podAntiAffinity:
+    {{- if .Values.podAntiAffinityLabelSelector }}
+    requiredDuringSchedulingIgnoredDuringExecution:
+    {{- include "podAntiAffinityRequiredDuringScheduling" . }}
+    {{- end }}
+    {{- if or .Values.podAntiAffinityTermLabelSelector}}
+    preferredDuringSchedulingIgnoredDuringExecution:
+    {{- include "podAntiAffinityPreferredDuringScheduling" . }}
+    {{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "podAntiAffinityRequiredDuringScheduling" }}
+    {{- range $index, $item := .Values.podAntiAffinityLabelSelector }}
+    - labelSelector:
+        matchExpressions:
+        - key: {{ $item.key }}
+          operator: {{ $item.operator }}
+          {{- if $item.values }}
+          values:
+          {{- $vals := split "," $item.values }}
+          {{- range $i, $v := $vals }}
+          - {{ $v | quote }}
+          {{- end }}
+          {{- end }}
+      topologyKey: {{ $item.topologyKey }}
+    {{- end }}
+{{- end }}
+
+{{- define "podAntiAffinityPreferredDuringScheduling" }}
+    {{- range $index, $item := .Values.podAntiAffinityTermLabelSelector }}
+    - podAffinityTerm:
+        labelSelector:
+          matchExpressions:
+          - key: {{ $item.key }}
+            operator: {{ $item.operator }}
+            {{- if $item.values }}
+            values:
+            {{- $vals := split "," $item.values }}
+            {{- range $i, $v := $vals }}
+            - {{ $v | quote }}
+            {{- end }}
+            {{- end }}
+        topologyKey: {{ $item.topologyKey }}
+      weight: 100
+    {{- end }}
+{{- end }}

--- a/packages/rancher-tracing/charts/templates/_helpers.tpl
+++ b/packages/rancher-tracing/charts/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "tracing.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "tracing.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/packages/rancher-tracing/charts/templates/deployment.yaml
+++ b/packages/rancher-tracing/charts/templates/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "tracing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.provider }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.provider }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+      annotations:
+        sidecar.istio.io/inject: "false"
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "14269"
+{{- if .Values.jaeger.podAnnotations }}
+{{ toYaml .Values.jaeger.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - name: jaeger
+          image: "{{ template "system_default_registry" . }}{{ .Values.jaeger.repository }}:{{ .Values.jaeger.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+          {{- if eq .Values.jaeger.spanStorageType "badger" }}
+          - name: BADGER_EPHEMERAL
+            value: "false"
+          - name: SPAN_STORAGE_TYPE
+            value: "badger"
+          - name: BADGER_DIRECTORY_VALUE
+            value: "/badger/data"
+          - name: BADGER_DIRECTORY_KEY
+            value: "/badger/key"
+          {{- end }}
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            value: "9411"
+          - name: MEMORY_MAX_TRACES
+            value: "{{ .Values.jaeger.memory.max_traces }}"
+          - name: QUERY_BASE_PATH
+            value: {{ if .Values.contextPath }} {{ .Values.contextPath }} {{ else }} /{{ .Values.provider }} {{ end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 14269
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 14269
+{{- if eq .Values.jaeger.spanStorageType "badger" }}
+          volumeMounts:
+            - name: data
+              mountPath: /badger
+{{- end }}
+          resources:
+{{- if .Values.jaeger.resources }}
+{{ toYaml .Values.jaeger.resources | indent 12 }}
+{{- else }}
+{{ toYaml .Values.global.defaultResources | indent 12 }}
+{{- end }}
+      affinity:
+      {{- include "nodeAffinity" . | indent 6 }}
+      {{- include "podAntiAffinity" . | indent 6 }}
+{{- if eq .Values.jaeger.spanStorageType "badger" }}
+      volumes:
+      - name: data
+{{- if .Values.jaeger.persistentVolumeClaim.enabled }}
+        persistentVolumeClaim:
+          claimName: istio-jaeger-pvc
+{{- else }}
+        emptyDir: {}
+{{- end }}
+{{- end }}

--- a/packages/rancher-tracing/charts/templates/pvc.yaml
+++ b/packages/rancher-tracing/charts/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.jaeger.persistentVolumeClaim.enabled }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: istio-jaeger-pvc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+spec:
+  storageClassName: {{ .Values.jaeger.storageClassName }}
+  accessModes:
+    - {{ .Values.jaeger.accessMode }}
+  resources:
+    requests:
+      storage: {{.Values.jaeger.persistentVolumeClaim.storage }}
+{{- end }}

--- a/packages/rancher-tracing/charts/templates/service.yaml
+++ b/packages/rancher-tracing/charts/templates/service.yaml
@@ -1,0 +1,63 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tracing
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    {{- range $key, $val := .Values.service.annotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.service.externalPort }}
+      protocol: TCP
+      targetPort: 16686
+  selector:
+    app: {{ .Values.provider }}
+---
+# Jaeger implements the Zipkin API. To support swapping out the tracing backend, we use a Service named Zipkin.
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: zipkin
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  ports:
+    - name: {{ .Values.service.name }}
+      port: {{ .Values.zipkin.queryPort }}
+      targetPort: {{ .Values.zipkin.queryPort }}
+  selector:
+    app: {{ .Values.provider }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jaeger-collector
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  type: ClusterIP
+  ports:
+  - name: jaeger-collector-http
+    port: 14268
+    targetPort: 14268
+    protocol: TCP
+  - name: jaeger-collector-grpc
+    port: 14250
+    targetPort: 14250
+    protocol: TCP
+  selector:
+    app: {{ .Values.provider }}

--- a/packages/rancher-tracing/charts/values.yaml
+++ b/packages/rancher-tracing/charts/values.yaml
@@ -1,0 +1,42 @@
+provider: jaeger
+contextPath: ""
+nodeSelector: {}
+podAntiAffinityLabelSelector: []
+podAntiAffinityTermLabelSelector: []
+nameOverride: ""
+fullnameOverride: ""
+
+global:
+  cattle:
+    systemDefaultRegistry: ""
+  defaultResources: {}
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  arch:
+    amd64: 2
+    s390x: 2
+    ppc64le: 2
+  defaultNodeSelector: {}
+
+jaeger:
+  repository: jaegertracing/all-in-one
+  tag: 1.20.0
+  # spanStorageType value can be "memory" and "badger" for all-in-one image
+  spanStorageType: badger
+  resources:
+    requests:
+      cpu: 10m
+  persistentVolumeClaim: 
+    enabled: false
+    storage: 5Gi
+  storageClassName: ""
+  accessMode: ReadWriteMany
+  memory:
+    max_traces: 50000
+zipkin:
+  queryPort: 9411
+service:
+  annotations: {}
+  name: http-query
+  type: ClusterIP
+  externalPort: 16686


### PR DESCRIPTION
**Problem**
Istio 1.7.x needs Jaeger support

**Solution**
No upstream helm chart of jaeger all-in-one exists, so added jaeger all in one templates to istio chart

This is not a solution that is for heavy production needs and is the same Jaeger installation type that was provided as part Istio V1. This is documented in the app-readme. 

**Issues**
https://github.com/rancher/rancher/issues/29903

**Dependent PRs**
https://github.com/rancher/image-mirror/pull/52

Related Issues:
https://github.com/rancher/dashboard/issues/1928
https://github.com/rancher/dashboard/issues/1863

Additional Information: 
Here are the additional Jaeger upstream charts https://github.com/jaegertracing/helm-charts/tree/master/charts
Using Jaeger with Istio: https://istio.io/latest/docs/tasks/observability/distributed-tracing/jaeger/
