### PR TITLE
CIS v2 charts PR for Scheduling and Alerting

### DIFF
--- a/packages/rancher-cis-benchmark/charts/templates/alertingrule.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/alertingrule.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.alerts.enabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: rancher-cis-pod-monitor
+  namespace: {{ template "cis.namespace" . }}
+spec:
+  selector:
+    matchLabels:
+      cis.cattle.io/operator: cis-operator
+  podMetricsEndpoints:
+  - port: cismetrics
+{{- end }}

--- a/packages/rancher-cis-benchmark/charts/templates/deployment.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
       - name: cis-operator
         image: '{{ template "system_default_registry" . }}{{ .Values.image.cisoperator.repository }}:{{ .Values.image.cisoperator.tag }}'
         imagePullPolicy: Always
+        ports:
+        - name: cismetrics
+          containerPort: {{ .Values.alerts.metricsPort }}
         env:
         - name: SECURITY_SCAN_IMAGE
           value: {{ template "system_default_registry" . }}{{ .Values.image.securityScan.repository }}
@@ -28,6 +31,10 @@ spec:
           value: {{ template "system_default_registry" . }}{{ .Values.image.sonobuoy.repository }}
         - name: SONOBUOY_IMAGE_TAG
           value: {{ .Values.image.sonobuoy.tag }}
+        - name: CIS_ALERTS_METRICS_PORT
+          value: '{{ .Values.alerts.metricsPort }}'
+        - name: CIS_ALERTS_SEVERITY
+          value: {{ .Values.alerts.severity }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
       nodeSelector:

--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -37,3 +37,8 @@ global:
   kubectl:
     repository: rancher/kubectl
     tag: v1.18.6
+
+alerts:
+  enabled: false
+  severity: warning
+  metricsPort: 8080


### PR DESCRIPTION
- Add new cis-operator image for delivering scheduling - already has been added upstream by other CIS changes.
- Add alertingrule and podmonitor
- Expose containrPort to export metrics from cis-operator
- Update ClusterScan CRD - already done by another CIS charts PR

https://github.com/rancher/cis-operator/issues/27
https://github.com/rancher/cis-operator/issues/28
https://github.com/rancher/cis-operator/issues/6