### PR TITLE
Rebase gatekeeper to v3.2.1 + add ui-component annotation

### DIFF
--- a/packages/rancher-gatekeeper/package.yaml
+++ b/packages/rancher-gatekeeper/package.yaml
@@ -1,4 +1,4 @@
-url: https://open-policy-agent.github.io/gatekeeper/charts/gatekeeper-3.1.1.tgz
-packageVersion: 01
+url: https://open-policy-agent.github.io/gatekeeper/charts/gatekeeper-3.2.1.tgz
+packageVersion: 00
 generateCRDChart:
   enabled: true

--- a/packages/rancher-gatekeeper/rancher-gatekeeper.patch
+++ b/packages/rancher-gatekeeper/rancher-gatekeeper.patch
@@ -1,9 +1,9 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Chart.yaml packages/rancher-gatekeeper/charts/Chart.yaml
 --- packages/rancher-gatekeeper/charts-original/Chart.yaml
 +++ packages/rancher-gatekeeper/charts/Chart.yaml
-@@ -1,10 +1,19 @@
+@@ -1,10 +1,20 @@
  apiVersion: v1
- appVersion: v3.1.1
+ appVersion: v3.2.1
 -description: A Helm chart for Gatekeeper
 +description: Modifies Open Policy Agent's upstream gatekeeper chart that provides policy-based control for cloud native environments
  home: https://github.com/open-policy-agent/gatekeeper
@@ -16,7 +16,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Cha
  sources:
 -- https://github.com/open-policy-agent/gatekeeper.git
 +  - https://github.com/open-policy-agent/gatekeeper.git
- version: 3.1.1
+ version: 3.2.1
 +icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
 +annotations:
 +  catalog.cattle.io/certified: rancher
@@ -25,6 +25,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/Cha
 +  catalog.cattle.io/release-name: rancher-gatekeeper
 +  catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
 +  catalog.cattle.io/display-name: "OPA Gatekeeper"
++  catalog.cattle.io/ui-component: gatekeeper
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/README.md packages/rancher-gatekeeper/charts/README.md
 --- packages/rancher-gatekeeper/charts-original/README.md
 +++ packages/rancher-gatekeeper/charts/README.md
@@ -274,16 +275,16 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-gatekeeper/charts-original/val
  emitAuditEvents: false
  image:
 -  repository: openpolicyagent/gatekeeper
--  release: v3.1.1
+-  release: v3.2.1
 +  repository: rancher/openpolicyagent-gatekeeper
-+  tag: v3.1.1
++  tag: v3.2.1
    pullPolicy: IfNotPresent
  nodeSelector: { kubernetes.io/os: linux }
  affinity: {}
-@@ -23,5 +23,9 @@
-   requests:
-     cpu: 100m
-     memory: 256Mi
+@@ -32,5 +32,9 @@
+     requests:
+       cpu: 100m
+       memory: 256Mi
 -customResourceDefinitions:
 -  create: true
 +global:


### PR DESCRIPTION
Rebase gatekeeper to v3.2.1 and add `ui-component` annotation

Related Issue: https://github.com/rancher/rancher/issues/30018

PR dependency: https://github.com/rancher/image-mirror/pull/53