### PR TITLE
Update logging chart with upstream version 3.8.0

### DIFF
--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,4 +1,4 @@
-url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.7.3.tgz
+url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.8.0.tgz
 packageVersion: 01
 generateCRDChart:
   enabled: true

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -3,12 +3,12 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/Chart.
 +++ packages/rancher-logging/charts/Chart.yaml
 @@ -1,5 +1,17 @@
  apiVersion: v1
- appVersion: 3.7.3
+ appVersion: 3.8.0
 -description: A Helm chart to install Banzai Cloud logging-operator
 -name: logging-operator
 +description: Collects and filter logs using highly configurable CRDs. Powered by Banzai Cloud Logging Operator.
 +name: rancher-logging
- version: 3.7.3
+ version: 3.8.0
 +icon: https://charts.rancher.io/assets/logos/logging.svg
 +keywords:
 +  - logging
@@ -70,7 +70,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
  image:
 -  repository: ghcr.io/banzaicloud/logging-operator
 +  repository: rancher/banzaicloud-logging-operator
-   tag: 3.7.3
+   tag: 3.8.0
    pullPolicy: IfNotPresent
  
 @@ -18,7 +18,7 @@
@@ -129,13 +129,13 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
 +    tag: v0.2.2
 +  fluentbit:
 +    repository: rancher/fluent-fluent-bit
-+    tag: 1.6.1
++    tag: 1.6.4
 +  fluentbit_debug:
 +    repository: rancher/fluent-fluent-bit
-+    tag: 1.6.1-debug
++    tag: 1.6.4-debug
 +  fluentd:
 +    repository: rancher/banzaicloud-fluentd
-+    tag: v1.11.4-alpine-1
++    tag: v1.11.5-alpine-1
 +
 +fluentbit_tolerations:
 +  - key: node-role.kubernetes.io/controlplane


### PR DESCRIPTION
Update logging chart with upstream version 3.8.0. This adds syslog
output support.

Relevant issue: https://github.com/rancher/rancher/issues/29892
Dependent PR: https://github.com/rancher/image-mirror/pull/54