### PR TITLE
Add cni defaults

### DIFF
--- a/packages/rancher-istio/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio/charts/configs/istio-base.yaml
@@ -98,9 +98,5 @@ spec:
       image: {{ template "system_default_registry" . }}{{ .Values.cni.repository }}:{{ .Values.cni.tag }}
       excludeNamespaces:
       {{- toYaml .Values.cni.excludeNamespaces | nindent 8 }}
-<<<<<<< HEAD
-      logLevel: info
-=======
       logLevel: {{ .Values.cni.logLevel }}
->>>>>>> be87432 (Add cni values)
     {{- end }}

--- a/packages/rancher-istio/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio/charts/configs/istio-base.yaml
@@ -98,5 +98,9 @@ spec:
       image: {{ template "system_default_registry" . }}{{ .Values.cni.repository }}:{{ .Values.cni.tag }}
       excludeNamespaces:
       {{- toYaml .Values.cni.excludeNamespaces | nindent 8 }}
+<<<<<<< HEAD
       logLevel: info
+=======
+      logLevel: {{ .Values.cni.logLevel }}
+>>>>>>> be87432 (Add cni values)
     {{- end }}

--- a/packages/rancher-istio/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio/charts/configs/istio-base.yaml
@@ -96,4 +96,7 @@ spec:
     {{- if .Values.cni.enabled }}
     cni:
       image: {{ template "system_default_registry" . }}{{ .Values.cni.repository }}:{{ .Values.cni.tag }}
+      excludeNamespaces:
+      {{- toYaml .Values.cni.excludeNamespaces | nindent 8 }}
+      logLevel: info
     {{- end }}

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -23,6 +23,10 @@ cni:
   enabled: true
   repository: rancher/istio-install-cni
   tag: 1.7.3
+<<<<<<< HEAD
+=======
+  logLevel: info
+>>>>>>> be87432 (Add cni values)
   excludeNamespaces:
   - istio-system
   - kube-system

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -20,13 +20,10 @@ base:
   enabled: true
 
 cni:
-  enabled: true
+  enabled: false
   repository: rancher/istio-install-cni
   tag: 1.7.3
-<<<<<<< HEAD
-=======
   logLevel: info
->>>>>>> be87432 (Add cni values)
   excludeNamespaces:
   - istio-system
   - kube-system

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -20,9 +20,12 @@ base:
   enabled: true
 
 cni:
-  enabled: false
+  enabled: true
   repository: rancher/istio-install-cni
   tag: 1.7.3
+  excludeNamespaces:
+  - istio-system
+  - kube-system
 
 egressGateways:
   enabled: false


### PR DESCRIPTION
**Problem**
Istio CNI can be enabled via the values.yaml and ui, but the default values for it to work out of the box are not set

**Solution**
Add values needed for CNI to work without additional configuration
Note: CNI is still disabled by defautl

**Issue**
https://github.com/rancher/rancher/issues/27377

**How I tested it** 
1. Created a new cluster with podSecurityPolicy set to restricted
2. Follow step 1 of docs to allow istio to install properly https://rancher.com/docs/rancher/v2.x/en/istio/v2.3.x-v2.4.x/setup/enable-istio-in-cluster/enable-istio-with-psp/#1-configure-the-system-project-policy-to-allow-istio-install 
3. Installed istio, leaving cni disabled (this also requires installing rancher-monitoring, unless you disable kiali)
4. Installed the book info app
```
kubectl label namespace default istio-injection=enabled
kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.4/samples/bookinfo/platform/kube/bookinfo.yaml
kubectl apply -f https://raw.githubusercontent.com/istio/istio/release-1.4/samples/bookinfo/networking/bookinfo-gateway.yaml
```
These will fail to deploy - this is because cni is not enabled
4. Upgrade istio with `cni.enabled: true`
You should see the book info app deployments move to active status
