### PR TITLE
[2.5.4] Quote insecure skip verify to avoid parse errors

### DIFF
--- a/packages/rancher-backup/charts/Chart.yaml
+++ b/packages/rancher-backup/charts/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v1
-appVersion: v1.0.2
+appVersion: v1.0.3
 description: Provides ability to back up and restore the Rancher application running on any Kubernetes cluster
 name: rancher-backup
 keywords:
 - applications
 - infrastructure
-version: 1.0.201
+version: 1.0.300
 icon: https://charts.rancher.io/assets/logos/backup-restore.svg
 annotations:
   catalog.cattle.io/certified: rancher

--- a/packages/rancher-backup/charts/templates/s3-secret.yaml
+++ b/packages/rancher-backup/charts/templates/s3-secret.yaml
@@ -25,7 +25,7 @@ stringData:
   endpointCA: {{ .endpointCA }} 
   {{- end }}
   {{- if .insecureTLSSkipVerify }}
-  insecureTLSSkipVerify: {{ .insecureTLSSkipVerify }} 
+  insecureTLSSkipVerify: {{ .insecureTLSSkipVerify | quote }}
   {{- end }}
   {{- end }}
 {{ end }}

--- a/packages/rancher-backup/charts/values.yaml
+++ b/packages/rancher-backup/charts/values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: rancher/backup-restore-operator
-  tag: v1.0.2
+  tag: v1.0.3
 
 ## Default s3 bucket for storing all backup files created by the backup-restore-operator
 s3:


### PR DESCRIPTION
The s3 configuration details are passed to the backup-restore-operator through a Secret, setting the stringData field. InsecureSkipVerify cannot have boolean value as a part of stringData. So the operator will now parse this field as a string and then convert it to boolean while using it. This commit quotes the value to avoid errors related to stringData given in this bug
https://github.com/rancher/backup-restore-operator/issues/56

This only applies when installing/upgrading the chart.

https://github.com/rancher/charts/issues/864