### PR TITLE
CIS report changes and add CIS 1.6

### DIFF
--- a/packages/rancher-cis-benchmark/charts/crds/clusterscan.yaml
+++ b/packages/rancher-cis-benchmark/charts/crds/clusterscan.yaml
@@ -19,11 +19,17 @@ spec:
   - JSONPath: .status.summary.skip
     name: Skip
     type: string
+  - JSONPath: .status.summary.warn
+    name: Warn
+    type: string
   - JSONPath: .status.summary.notApplicable
     name: Not Applicable
     type: string
   - JSONPath: .status.lastRunTimestamp
     name: LastRunTimestamp
+    type: string
+  - JSONPath: .spec.cronSchedule
+    name: CronSchedule
     type: string
   group: cis.cattle.io
   names:
@@ -40,9 +46,38 @@ spec:
             scanProfileName:
               nullable: true
               type: string
+            scheduledScanConfig:
+              nullable: true
+              properties:
+                cronSchedule:
+                  nullable: true
+                  type: string
+                retentionCount:
+                  type: integer
+                scanAlertRule:
+                  nullable: true
+                  properties:
+                    alertOnComplete:
+                      type: boolean
+                    alertOnFailure:
+                      type: boolean
+                  type: object
+              type: object
+            scoreWarning:
+              enum:
+              - pass
+              - fail
+              nullable: true
+              type: string
           type: object
         status:
           properties:
+            NextScanAt:
+              nullable: true
+              type: string
+            ScanAlertingRuleName:
+              nullable: true
+              type: string
             conditions:
               items:
                 properties:
@@ -101,6 +136,8 @@ spec:
                 skip:
                   type: integer
                 total:
+                  type: integer
+                warn:
                   type: integer
               type: object
           type: object

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-cis-1.6.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-cis-1.6.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: cis-1.6
+spec:
+  clusterProvider: ""
+  minKubernetesVersion: "1.16.0"

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.6-hardened.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.6-hardened.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: rke-cis-1.6-hardened
+spec:
+  clusterProvider: rke
+  minKubernetesVersion: "1.16.0"

--- a/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.6-permissive.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/benchmark-rke-cis-1.6-permissive.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanBenchmark
+metadata:
+  name: rke-cis-1.6-permissive
+spec:
+  clusterProvider: rke
+  minKubernetesVersion: "1.16.0"

--- a/packages/rancher-cis-benchmark/charts/templates/configmap.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/configmap.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: {{ template "cis.namespace" . }}
 data:
   # Default ClusterScanProfiles per cluster provider type
-  rke: "rke-profile-permissive"
+  rke: "rke-profile-permissive-1.6"
   rke2: "rke2-cis-1.5-profile-permissive"
   eks: "eks-profile"
   gke: "gke-profile"
-  default: "cis-1.5-profile"
+  default: "cis-1.6-profile"

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofile-cis-1.6.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofile-cis-1.6.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: cis-1.6-profile
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: cis-1.6

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-1.6-hardened.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-1.6-hardened.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: rke-profile-hardened-1.6
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: rke-cis-1.6-hardened

--- a/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-1.6-permissive.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/scanprofile-rke-1.6-permissive.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: cis.cattle.io/v1
+kind: ClusterScanProfile
+metadata:
+  name: rke-profile-permissive-1.6
+  annotations:
+    clusterscanprofile.cis.cattle.io/builtin: "true"
+spec:
+  benchmarkVersion: rke-cis-1.6-permissive


### PR DESCRIPTION
This PR adds the CRs for CIS 1.6 benchmark and profiles. https://github.com/rancher/rancher/issues/29649
It also adds following changes to the clusterScan CRD:
1. AdditionalPrinterColumn "Warn" to show number of tests with "Warn" output. https://github.com/rancher/security-scan/issues/32
2. Field called `scoreWarning`, with which users can decide whether a scan should pass or fail if there are tests with "warn" output. https://github.com/rancher/cis-operator/issues/54