### PR TITLE
Update logging chart to 3.8.2 for syslog fix

### DIFF
--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,4 +1,4 @@
-url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.8.0.tgz
+url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.8.2.tgz
 packageVersion: 01
 generateCRDChart:
   enabled: true

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -3,12 +3,12 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/Chart.
 +++ packages/rancher-logging/charts/Chart.yaml
 @@ -1,5 +1,17 @@
  apiVersion: v1
- appVersion: 3.8.0
+ appVersion: 3.8.2
 -description: A Helm chart to install Banzai Cloud logging-operator
 -name: logging-operator
 +description: Collects and filter logs using highly configurable CRDs. Powered by Banzai Cloud Logging Operator.
 +name: rancher-logging
- version: 3.8.0
+ version: 3.8.2
 +icon: https://charts.rancher.io/assets/logos/logging.svg
 +keywords:
 +  - logging
@@ -70,7 +70,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
  image:
 -  repository: ghcr.io/banzaicloud/logging-operator
 +  repository: rancher/banzaicloud-logging-operator
-   tag: 3.8.0
+   tag: 3.8.2
    pullPolicy: IfNotPresent
  
 @@ -18,7 +18,7 @@


### PR DESCRIPTION
Update logging chart to 3.8.2 for syslog fix. This fixes the syslog
output inclusion into the outputs CRD.

Relevant issue: https://github.com/rancher/rancher/issues/29892
Dependent PR: https://github.com/rancher/image-mirror/pull/57