### PR TITLE
Add annotation to hide backup chart from windows cluster

### DIFF
--- a/packages/rancher-backup/charts/Chart.yaml
+++ b/packages/rancher-backup/charts/Chart.yaml
@@ -15,3 +15,4 @@ annotations:
   catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
   catalog.cattle.io/scope: management
   catalog.cattle.io/display-name: "Rancher Backups"
+  catalog.cattle.io/os: linux


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/30450