### PR TITLE
Add catalog.cattle.io/os=linux to monitoring and minor fix to patch

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring.patch
+++ b/packages/rancher-monitoring/rancher-monitoring.patch
@@ -61,14 +61,14 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/REA
 --- packages/rancher-monitoring/charts-original/README.md
 +++ packages/rancher-monitoring/charts/README.md
 @@ -15,7 +15,7 @@
-
+ 
  ```console
  helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 -helm repo add stable https://kubernetes-charts.storage.googleapis.com/
 +helm repo add stable https://charts.helm.sh/stable/
  helm repo update
  ```
-
+ 
 @@ -127,7 +127,41 @@
  helm show values prometheus-community/kube-prometheus-stack
  ```
@@ -349,7 +349,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
 +  runAsNonRoot: true
    runAsGroup: 65534
    runAsUser: 65534
-   fsGroup: 65534                                                        | `{}`                                        |
+   fsGroup: 65534
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/charts/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml packages/rancher-monitoring/charts/charts/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
 --- packages/rancher-monitoring/charts-original/charts/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
 +++ packages/rancher-monitoring/charts/charts/prometheus-adapter/templates/custom-metrics-apiserver-deployment.yaml
@@ -373,7 +373,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/cha
 +  repository: rancher/directxman12-k8s-prometheus-adapter-amd64
    tag: v0.7.0
    pullPolicy: IfNotPresent
-
+ 
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/charts/prometheus-node-exporter/OWNERS packages/rancher-monitoring/charts/charts/prometheus-node-exporter/OWNERS
 --- packages/rancher-monitoring/charts-original/charts/prometheus-node-exporter/OWNERS
 +++ packages/rancher-monitoring/charts/charts/prometheus-node-exporter/OWNERS
@@ -2643,7 +2643,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
  ## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.16.6
  ##
-@@ -76,8 +308,23 @@
+@@ -76,8 +310,23 @@
  
  ##
  global:
@@ -2667,7 +2667,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
      pspEnabled: true
      pspAnnotations: {}
        ## Specify pod annotations
-@@ -130,6 +377,22 @@
+@@ -130,6 +379,22 @@
    ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
    ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
    ##
@@ -2690,7 +2690,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
    config:
      global:
        resolve_timeout: 5m
-@@ -145,6 +408,8 @@
+@@ -145,6 +410,8 @@
          receiver: 'null'
      receivers:
      - name: 'null'
@@ -2699,7 +2699,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ## Pass the Alertmanager configuration directives through Helm's templating
    ## engine. If the Alertmanager configuration contains Alertmanager templates,
-@@ -160,25 +425,76 @@
+@@ -160,25 +427,76 @@
    ## ref: https://prometheus.io/docs/alerting/notifications/
    ##      https://prometheus.io/docs/alerting/notification_examples/
    ##
@@ -2795,7 +2795,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ingress:
      enabled: false
-@@ -208,6 +524,25 @@
+@@ -208,6 +526,25 @@
    ## Configuration for Alertmanager secret
    ##
    secret:
@@ -2821,7 +2821,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
      annotations: {}
  
    ## Configuration for creating an Ingress that will map to each Alertmanager replica service
-@@ -334,7 +669,7 @@
+@@ -334,7 +671,7 @@
      ## Image of Alertmanager
      ##
      image:
@@ -2830,7 +2830,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
        tag: v0.21.0
        sha: ""
  
-@@ -410,9 +745,13 @@
+@@ -410,9 +747,13 @@
      ## Define resources requests and limits for single Pods.
      ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
      ##
@@ -2847,7 +2847,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
      ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
-@@ -487,6 +826,27 @@
+@@ -487,6 +828,27 @@
    enabled: true
    namespaceOverride: ""
  
@@ -2875,7 +2875,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
    ## Deploy default dashboards.
    ##
    defaultDashboardsEnabled: true
-@@ -530,6 +890,7 @@
+@@ -530,6 +892,7 @@
      dashboards:
        enabled: true
        label: grafana_dashboard
@@ -2883,7 +2883,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
        ## Annotations for Grafana dashboard configmaps
        ##
-@@ -574,7 +935,60 @@
+@@ -574,7 +937,60 @@
    ## Passed to grafana subchart and used by servicemonitor below
    ##
    service:
@@ -2945,7 +2945,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ## If true, create a serviceMonitor for grafana
    ##
-@@ -600,6 +1014,14 @@
+@@ -600,6 +1016,14 @@
      #   targetLabel: nodename
      #   replacement: $1
      #   action: replace
@@ -2960,7 +2960,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
  ## Component scraping the kube api server
  ##
-@@ -756,7 +1178,7 @@
+@@ -756,7 +1180,7 @@
  ## Component scraping the kube controller manager
  ##
  kubeControllerManager:
@@ -2969,7 +2969,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ## If your kube controller manager is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -889,7 +1311,7 @@
+@@ -889,7 +1313,7 @@
  ## Component scraping etcd
  ##
  kubeEtcd:
@@ -2978,7 +2978,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ## If your etcd is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -949,7 +1371,7 @@
+@@ -949,7 +1373,7 @@
  ## Component scraping kube scheduler
  ##
  kubeScheduler:
@@ -2987,7 +2987,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ## If your kube scheduler is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1002,7 +1424,7 @@
+@@ -1002,7 +1426,7 @@
  ## Component scraping kube proxy
  ##
  kubeProxy:
@@ -2996,7 +2996,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1076,6 +1498,13 @@
+@@ -1076,6 +1500,13 @@
      create: true
    podSecurityPolicy:
      enabled: true
@@ -3010,7 +3010,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
  ## Deploy node exporter as a daemonset to all nodes
  ##
-@@ -1125,6 +1554,16 @@
+@@ -1125,6 +1556,16 @@
    extraArgs:
      - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
      - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
@@ -3027,7 +3027,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
  ## Manages Prometheus and Alertmanager components
  ##
-@@ -1138,7 +1577,7 @@
+@@ -1138,7 +1579,7 @@
    tlsProxy:
      enabled: true
      image:
@@ -3036,7 +3036,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
        tag: v1.5.2
        sha: ""
        pullPolicy: IfNotPresent
-@@ -1156,7 +1595,7 @@
+@@ -1156,7 +1597,7 @@
      patch:
        enabled: true
        image:
@@ -3045,7 +3045,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
          tag: v1.2.1
          sha: ""
          pullPolicy: IfNotPresent
-@@ -1285,13 +1724,13 @@
+@@ -1285,13 +1726,13 @@
  
    ## Resource limits & requests
    ##
@@ -3066,7 +3066,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
    # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
-@@ -1335,7 +1774,7 @@
+@@ -1335,7 +1776,7 @@
    ## Prometheus-operator image
    ##
    image:
@@ -3075,7 +3075,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
      tag: v0.38.1
      sha: ""
      pullPolicy: IfNotPresent
-@@ -1343,14 +1782,14 @@
+@@ -1343,14 +1784,14 @@
    ## Configmap-reload image to use for reloading configmaps
    ##
    configmapReloadImage:
@@ -3092,7 +3092,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
      tag: v0.38.1
      sha: ""
  
-@@ -1366,14 +1805,6 @@
+@@ -1366,14 +1807,6 @@
    ##
    secretFieldSelector: ""
  
@@ -3107,7 +3107,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  ## Deploy a Prometheus instance
  ##
  prometheus:
-@@ -1403,7 +1834,7 @@
+@@ -1403,7 +1836,7 @@
      port: 9090
  
      ## To be used with a proxy extraContainer port
@@ -3116,7 +3116,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## List of IP addresses at which the Prometheus server service is available
      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-@@ -1614,7 +2045,7 @@
+@@ -1614,7 +2047,7 @@
      ## Image of Prometheus.
      ##
      image:
@@ -3125,7 +3125,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
        tag: v2.18.2
        sha: ""
  
-@@ -1666,6 +2097,11 @@
+@@ -1666,6 +2099,11 @@
      ##
      externalUrl: ""
  
@@ -3137,7 +3137,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
      ## Define which Nodes the Pods are scheduled on.
      ## ref: https://kubernetes.io/docs/user-guide/node-selection/
      ##
-@@ -1698,7 +2134,7 @@
+@@ -1698,7 +2136,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the PrometheusRule resources created
      ##
@@ -3146,7 +3146,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## PrometheusRules to be selected for target discovery.
      ## If {}, select all ServiceMonitors
-@@ -1723,7 +2159,7 @@
+@@ -1723,7 +2161,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the servicemonitors created
      ##
@@ -3155,7 +3155,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## ServiceMonitors to be selected for target discovery.
      ## If {}, select all ServiceMonitors
-@@ -1743,7 +2179,7 @@
+@@ -1743,7 +2181,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the podmonitors created
      ##
@@ -3164,7 +3164,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## PodMonitors to be selected for target discovery.
      ## If {}, select all PodMonitors
-@@ -1840,9 +2276,13 @@
+@@ -1840,9 +2278,13 @@
  
      ## Resource limits & requests
      ##
@@ -3181,7 +3181,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## Prometheus StorageSpec for persistent data
      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md
-@@ -1857,11 +2297,6 @@
+@@ -1857,11 +2299,6 @@
      #          storage: 50Gi
      #    selector: {}
  
@@ -3193,7 +3193,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
      ## AdditionalScrapeConfigs allows specifying additional Prometheus scrape configurations. Scrape configurations
      ## are appended to the configurations generated by the Prometheus Operator. Job configurations must have the form
      ## as specified in the official Prometheus documentation:
-@@ -1964,9 +2399,46 @@
+@@ -1964,9 +2401,46 @@
      ##
      thanos: {}
  
@@ -3241,7 +3241,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/val
  
      ## InitContainers allows injecting additional initContainers. This is meant to allow doing some changes
      ## (permissions, dir tree) on mounted volumes before starting prometheus
-@@ -1974,7 +2446,7 @@
+@@ -1974,7 +2448,7 @@
  
      ## PortName to use for Prometheus.
      ##

--- a/packages/rancher-monitoring/rancher-monitoring.patch
+++ b/packages/rancher-monitoring/rancher-monitoring.patch
@@ -1,7 +1,7 @@
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/Chart.yaml packages/rancher-monitoring/charts/Chart.yaml
 --- packages/rancher-monitoring/charts-original/Chart.yaml
 +++ packages/rancher-monitoring/charts/Chart.yaml
-@@ -5,31 +5,35 @@
+@@ -5,31 +5,36 @@
      - name: Upstream Project
        url: https://github.com/prometheus-operator/kube-prometheus
    artifacthub.io/operator: "true"
@@ -11,6 +11,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/Cha
 +  catalog.cattle.io/ui-component: monitoring
 +  catalog.cattle.io/provides-gvr: monitoring.coreos.com.prometheus/v1
 +  catalog.cattle.io/display-name: "Monitoring"
++  catalog.cattle.io/os: linux
  apiVersion: v1
  appVersion: 0.38.1
 -description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards,


### PR DESCRIPTION
The first commit is a quick fix to the patch file due to a change probably introduced in https://github.com/rancher/charts/pull/844/commits/004adafa21ae7baf7a9bbf2f617bad3aa21ce3a4.

It was never caught before probably because we never ran make prepare + make patch after making the changes.

The second commit adds the annotation.

Related Issue: https://github.com/rancher/rancher/issues/30450