### PR TITLE
Change istio version so it is only one version up from current produc…

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.7.3
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.7.302
+version: 1.7.301
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking


### PR DESCRIPTION
**Problem**
Multiple changes were completed for Istio for the 2.5.4 release which caused the Istio version to get bumped twice. This will be confusing for users since 1.7.300 is the current version in production. 

**Solution**
Now that all changes are in, update the istio version to be one up from the current production version

**Issue**
https://github.com/rancher/rancher/issues/30598

**Dependent PR**
https://github.com/rancher/charts/pull/906