### PR TITLE
Update default profiles configmap to carry k8s version info for rke profiles

### DIFF
--- a/packages/rancher-cis-benchmark/charts/templates/configmap.yaml
+++ b/packages/rancher-cis-benchmark/charts/templates/configmap.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ template "cis.namespace" . }}
 data:
   # Default ClusterScanProfiles per cluster provider type
-  rke: "rke-profile-permissive-1.6"
+  rke: |-
+    <1.16.0: rke-profile-permissive-1.5
+    >=1.16.0: rke-profile-permissive-1.6
   rke2: "rke2-cis-1.5-profile-permissive"
   eks: "eks-profile"
   gke: "gke-profile"

--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -5,7 +5,7 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.0.3-rc5
+    tag: v1.0.3-rc6
   securityScan:
     repository: rancher/security-scan
     tag: v0.2.2-rc5


### PR DESCRIPTION
Carry information about multiple rke profiles according to k8s major versions supported.

https://github.com/rancher/cis-operator/issues/84