### PR TITLE
Updating CIS chart image tags to use non-rc tags

### DIFF
--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.0.3-rc6
+    tag: v1.0.3
   securityScan:
     repository: rancher/security-scan
-    tag: v0.2.2-rc5
+    tag: v0.2.2
   sonobuoy:
     repository: rancher/sonobuoy-sonobuoy
     tag: v0.16.3


### PR DESCRIPTION
Removing the rc tags from cis-operator and security-scan images for 2.5.4 release
