### PR TITLE
Change Istio version to 1.7.6

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.7.3
+appVersion: 1.7.6
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.7.301
+version: 1.7.600
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,11 +1,11 @@
 overlayFile: ""
-tag: 1.7.3
+tag: 1.7.6
 ##Setting forceInstall: true will remove the check for istio version < 1.6.x and will not analyze your install cluster prior to install
 forceInstall: false
 
 installer:
   repository: rancher/istio-installer
-  tag: 1.7.3-rancher2
+  tag: 1.7.6-rancher1
 
 istiocoredns:
   enabled: false
@@ -22,7 +22,7 @@ base:
 cni:
   enabled: false
   repository: rancher/istio-install-cni
-  tag: 1.7.3
+  tag: 1.7.6
   logLevel: info
   excludeNamespaces:
   - istio-system
@@ -42,13 +42,13 @@ istiodRemote:
 pilot:
   enabled: true
   repository: rancher/istio-pilot
-  tag: 1.7.3
+  tag: 1.7.6
 
 #Mixer Policy is deprecated in 1.7.x, will not be supported in 1.8.x 
 policy:
   enabled: false
   repository: rancher/istio-mixer
-  tag: 1.7.3
+  tag: 1.7.6
 
 telemetry:
   enabled: true
@@ -56,26 +56,19 @@ telemetry:
   v1:
     enabled: false
     repository: rancher/istio-mixer
-    tag: 1.7.3
+    tag: 1.7.6
   v2:
     enabled: true
-
-sidecarInjectorWebhook:
-  enableNamespacesByDefault: false
-  objectSelector:
-    enabled: true
-    autoInject: true
-  rewriteAppHTTPProbe: true
 
 global:
   cattle:
     systemDefaultRegistry: ""
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.7.3
+    tag: 1.7.6
   proxy_init:
     repository: rancher/istio-proxyv2
-    tag: 1.7.3
+    tag: 1.7.6
   defaultPodDisruptionBudget:
     enabled: true
 


### PR DESCRIPTION
**Problem**
Update to Istio 1.7.6 to support small issue fixes

**Solution**
Add support for 1.7.6

No changes were needed for the Operator Overlay file. 
sidecarInjectorWebhook values were not being used in any templates so they were removed to avoid confusion. 

**Issue**
https://github.com/rancher/rancher/issues/29812

**Dependent PR**
https://github.com/rancher/istio-installer/pull/14
https://github.com/rancher/image-mirror/pull/61
