### PR TITLE
Fix premature end block in default Prometheus CR

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring.patch
+++ b/packages/rancher-monitoring/rancher-monitoring.patch
@@ -1975,6 +1975,19 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/tem
  {{- end }}
  {{- if .Values.prometheus.prometheusSpec.initContainers }}
    initContainers:
+@@ -242,6 +245,7 @@
+ {{- if .Values.prometheus.prometheusSpec.disableCompaction }}
+   disableCompaction: {{ .Values.prometheus.prometheusSpec.disableCompaction }}
+ {{- end }}
++{{- if .Values.prometheus.prometheusSpec.portName }}
+   portName: {{ .Values.prometheus.prometheusSpec.portName }}
+ {{- end }}
+ {{- if .Values.prometheus.prometheusSpec.enforcedNamespaceLabel }}
+@@ -255,3 +259,4 @@
+   volumeMounts:
+ {{ toYaml .Values.prometheus.prometheusSpec.volumeMounts | indent 4 }}
+ {{- end }}
++{{- end }}
 diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-monitoring/charts-original/templates/prometheus/rules/etcd.yaml packages/rancher-monitoring/charts/templates/prometheus/rules/etcd.yaml
 --- packages/rancher-monitoring/charts-original/templates/prometheus/rules/etcd.yaml
 +++ packages/rancher-monitoring/charts/templates/prometheus/rules/etcd.yaml


### PR DESCRIPTION
When `prometheus.enabled=false`, the current chart fails to render the manifest since anything that comes after the premature end block is not excluded. As a result, we get the following error on install when trying to validate the created manifest:

```
Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: [apiVersion not set, kind not set]
```

This error also exists and is reproducible in [the upstream chart](https://github.com/prometheus-community/helm-charts/blob/5dc19ca22e6038b98c03e77df4d9b313b642acdb/charts/kube-prometheus-stack/templates/prometheus/prometheus.yaml#L264-L265'). Issue filed in upstream here: https://github.com/prometheus-community/helm-charts/issues/550.

Related Issue: https://github.com/rancher/rancher/issues/30712