### PR TITLE
Expose fluentbit mountPath for Docker root dir

### DIFF
--- a/packages/rancher-logging/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/aks/logging.yaml
@@ -15,7 +15,10 @@ spec:
     inputTail:
       Tag: "aks"
       Path: "/var/log/azure/kubelet-status.log"
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.aks.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.aks.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
   {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/eks/logging.yaml
@@ -16,7 +16,10 @@ spec:
       Tag: "eks"
       Path: "/var/log/messages"
       Parser: "syslog"
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.eks.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.eks.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
   {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/gke/logging.yaml
@@ -15,7 +15,10 @@ spec:
     inputTail:
       Tag: "gke"
       Path: "/var/log/kube-proxy.log"
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.gke.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.gke.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
   {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -19,7 +19,10 @@ spec:
       - source: "/var/log/"
         destination: "/var/log"
         readOnly: true
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -19,7 +19,10 @@ spec:
       - source: "/var/log/"
         destination: "/var/log"
         readOnly: true
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke/daemonset.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke/daemonset.yaml
@@ -50,7 +50,7 @@ spec:
         - name: config
           configMap:
             name: "{{ .Release.Name }}-rke"
-      {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+      {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
       {{- with $total_tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke/logging-rke.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke/logging-rke.yaml
@@ -20,7 +20,10 @@ spec:
       - source: "/var/lib/rancher/logging/"
         destination: "/var/lib/rancher/logging/"
         readOnly: true
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.rke.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.rke.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -17,7 +17,10 @@ spec:
       - source: "/var/log/containers/"
         destination: "/var/log/containers/"
         readOnly: true
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-journald.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-journald.yaml
@@ -17,7 +17,10 @@ spec:
       - source: "/etc/rancher/logging/logs/"
         destination: "/etc/rancher/logging/logs/"
         readOnly: true
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
+    mountPath: {{ .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/root/logging.yaml
@@ -11,7 +11,10 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
       tag: {{ .Values.images.fluentbit.tag }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
+  {{- if .Values.fluentbit.mountPath }}
+    mountPath: {{ .Values.fluentbit.mountPath }}
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -100,7 +100,7 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
  
  affinity: {}
  
-@@ -76,4 +81,50 @@
+@@ -76,4 +81,69 @@
  monitoring:
    # Create a Prometheus Operator ServiceMonitor object
    serviceMonitor:
@@ -114,19 +114,30 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
 +  rke:
 +    enabled: false
 +    fluentbit:
++      mountPath: ""
 +      log_level: "info"
 +      mem_buffer_limit: "5MB"
 +  rke2:
 +    enabled: false
++    fluentbit:
++      mountPath: ""
 +  k3s:
 +    enabled: false
++    fluentbit:
++      mountPath: ""
 +    container_engine: "systemd"
 +  aks:
 +    enabled: false
++    fluentbit:
++      mountPath: ""
 +  eks:
 +    enabled: false
++    fluentbit:
++      mountPath: ""
 +  gke:
 +    enabled: false
++    fluentbit:
++      mountPath: ""
 +
 +images:
 +  config_reloader:
@@ -142,13 +153,21 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
 +    repository: rancher/banzaicloud-fluentd
 +    tag: v1.11.5-alpine-1
 +
-+fluentbit_tolerations:
-+  - key: node-role.kubernetes.io/controlplane
-+    value: "true"
-+    effect: NoSchedule
-+  - key: node-role.kubernetes.io/etcd
-+    value: "true"
-+    effect: NoExecute
++fluentbit:
++  # This "mountPath" applies to the root Logging CR, which is always created when installing this
++  # chart. If you would like to change the "mountPath" for vendor Logging CRs, such as RKE, use
++  # the "mountPath" for your provider/vendor in "additionalLoggingSources".
++  mountPath: ""
++  # These "tolerations" apply to every Logging CR, including vendor Logging CRs enabled in
++  # "additionalLoggingSources". Unlike "mountPath", changing "tolerations" affects every Logging CR
++  # installed.
++  tolerations:
++    - key: node-role.kubernetes.io/controlplane
++      value: "true"
++      effect: NoSchedule
++    - key: node-role.kubernetes.io/etcd
++      value: "true"
++      effect: NoExecute
 +
 +global:
 +  cattle:


### PR DESCRIPTION
Expose fluentbit mountPath for Docker root directory. Move
fluentbit_tolerations to the same location as mountPath in values.yaml.

Relevant issue: https://github.com/rancher/rancher/issues/30329

This change should at least be a partial fix to the above issue.