### PR TITLE
Add PodSecurityPolicies for istio, tracing and kiali

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -13,6 +13,6 @@ annotations:
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.003
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.24.004
   catalog.cattle.io/display-name: "Istio"
   catalog.cattle.io/os: linux

--- a/packages/rancher-istio/charts/requirements.yaml
+++ b/packages/rancher-istio/charts/requirements.yaml
@@ -9,5 +9,5 @@ dependencies:
   - name: rancher-tracing
     alias: tracing
     condition: tracing.enabled
-    version: 1.20.001
+    version: 1.20.002
     repository: file://../../rancher-tracing/charts

--- a/packages/rancher-istio/charts/templates/clusterrole.yaml
+++ b/packages/rancher-istio/charts/templates/clusterrole.yaml
@@ -110,3 +110,11 @@ rules:
   - serviceaccounts
   verbs:
   - '*'
+- apiGroups:
+  - policy
+  resourceNames:
+  - istio-installer
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/packages/rancher-istio/charts/templates/istio-cni-psp.yaml
+++ b/packages/rancher-istio/charts/templates/istio-cni-psp.yaml
@@ -1,0 +1,47 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: psp-istio-cni
+  namespace: istio-system
+spec:
+  allowPrivilegeEscalation: true
+  fsGroup:
+      rule: RunAsAny
+  hostNetwork: true
+  runAsUser:
+      rule: RunAsAny
+  seLinux:
+      rule: RunAsAny
+  supplementalGroups:
+      rule: RunAsAny
+  volumes:
+  - secret
+  - configMap
+  - emptyDir
+  - hostPath
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: psp-istio-cni
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: psp-istio-cni
+subjects:
+  - kind: ServiceAccount
+    name: istio-cni
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: psp-istio-cni
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - psp-istio-cni
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use

--- a/packages/rancher-istio/charts/templates/istio-install-job.yaml
+++ b/packages/rancher-istio/charts/templates/istio-install-job.yaml
@@ -42,4 +42,7 @@ spec:
             name: istio-installer-overlay
         {{- end }}
       serviceAccountName: istio-installer
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
       restartPolicy: Never

--- a/packages/rancher-istio/charts/templates/istio-install-psp.yaml
+++ b/packages/rancher-istio/charts/templates/istio-install-psp.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: istio-installer
+  namespace: istio-system
+spec:
+  privileged: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'configMap'
+    - 'secret'

--- a/packages/rancher-istio/charts/templates/istio-psp.yaml
+++ b/packages/rancher-istio/charts/templates/istio-psp.yaml
@@ -1,0 +1,79 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: istio-psp
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: istio-psp
+subjects:
+  - kind: ServiceAccount
+    name: istio-egressgateway-service-account
+  - kind: ServiceAccount
+    name: istio-ingressgateway-service-account
+  - kind: ServiceAccount
+    name: istio-mixer-service-account
+  - kind: ServiceAccount
+    name: istio-operator-authproxy
+  - kind: ServiceAccount
+    name: istiod-service-account
+  - kind: ServiceAccount
+    name: istio-sidecar-injector-service-account
+  - kind: ServiceAccount
+    name: istiocoredns-service-account
+  - kind: ServiceAccount
+    name: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: istio-psp
+  namespace: istio-system
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - istio-psp
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: istio-psp
+  namespace: istio-system
+spec:
+  allowPrivilegeEscalation: false
+  forbiddenSysctls:
+  - '*'
+  fsGroup:
+      ranges:
+        - max: 65535
+          min: 1
+      rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+      rule: MustRunAsNonRoot
+  runAsGroup:
+      rule: MustRunAs
+      ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+      rule: RunAsAny
+  supplementalGroups:
+      ranges:
+        - max: 65535
+          min: 1
+      rule: MustRunAs
+  volumes:
+  - configMap
+  - emptyDir
+  - projected
+  - secret
+  - downwardAPI
+  - persistentVolumeClaim

--- a/packages/rancher-istio/charts/templates/istio-uninstall-job.yaml
+++ b/packages/rancher-istio/charts/templates/istio-uninstall-job.yaml
@@ -39,4 +39,7 @@ spec:
             name: istio-installer-overlay
         {{ end }}
       serviceAccountName: istio-installer
+      securityContext:
+        runAsUser: 101
+        runAsGroup: 101
       restartPolicy: OnFailure

--- a/packages/rancher-kiali-server/package.yaml
+++ b/packages/rancher-kiali-server/package.yaml
@@ -1,4 +1,4 @@
 url: https://kiali.org/helm-charts/kiali-server-1.24.0.tgz
-packageVersion: 03
+packageVersion: 04
 generateCRDChart:
   enabled: true

--- a/packages/rancher-kiali-server/rancher-kiali-server.patch
+++ b/packages/rancher-kiali-server/rancher-kiali-server.patch
@@ -163,3 +163,72 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/v
 +  cattle:
 +    systemDefaultRegistry: ""
 +    clusterId:
+diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-kiali-server/charts-original/templates/kiali-psp.yaml packages/rancher-kiali-server/charts/templates/kiali-psp.yaml
+--- packages/rancher-kiali-server/charts-original/templates/kiali-psp.yaml
++++ packages/rancher-kiali-server/charts/templates/kiali-psp.yaml
+@@ -0,0 +1,65 @@
++apiVersion: rbac.authorization.k8s.io/v1
++kind: RoleBinding
++metadata:
++  name: kiali-psp
++  namespace: istio-system
++roleRef:
++  apiGroup: rbac.authorization.k8s.io
++  kind: Role
++  name: kiali-psp
++subjects:
++  - kind: ServiceAccount
++    name: kiali
++---
++apiVersion: rbac.authorization.k8s.io/v1
++kind: Role
++metadata:
++  name: kiali-psp
++  namespace: istio-system
++rules:
++- apiGroups:
++  - policy
++  resourceNames:
++  - kiali-psp
++  resources:
++  - podsecuritypolicies
++  verbs:
++  - use
++---
++apiVersion: policy/v1beta1
++kind: PodSecurityPolicy
++metadata:
++  name: kiali-psp
++  namespace: istio-system
++spec:
++  allowPrivilegeEscalation: false
++  forbiddenSysctls:
++  - '*'
++  fsGroup:
++      ranges:
++        - max: 65535
++          min: 1
++      rule: MustRunAs
++  requiredDropCapabilities:
++  - ALL
++  runAsUser:
++      rule: MustRunAsNonRoot
++  runAsGroup:
++      rule: MustRunAs
++      ranges:
++      - min: 1
++        max: 65535
++  seLinux:
++      rule: RunAsAny
++  supplementalGroups:
++      ranges:
++        - max: 65535
++          min: 1
++      rule: MustRunAs
++  volumes:
++  - configMap
++  - emptyDir
++  - projected
++  - secret
++  - downwardAPI
++  - persistentVolumeClaim

--- a/packages/rancher-tracing/charts/Chart.yaml
+++ b/packages/rancher-tracing/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A quick start Jaeger Tracing installation using the all-in-one demo. This is not production qualified. Refer to https://www.jaegertracing.io/ for details.
 name: rancher-tracing
-version: 1.20.001
+version: 1.20.002
 annotations:
   catalog.rancher.io/certified: rancher
   catalog.rancher.io/namespace: istio-system

--- a/packages/rancher-tracing/charts/templates/deployment.yaml
+++ b/packages/rancher-tracing/charts/templates/deployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
       {{- include "nodeAffinity" . | indent 6 }}
       {{- include "podAntiAffinity" . | indent 6 }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      serviceAccountName: {{ include "tracing.fullname" . }}
 {{- if eq .Values.jaeger.spanStorageType "badger" }}
       volumes:
       - name: data

--- a/packages/rancher-tracing/charts/templates/psp.yaml
+++ b/packages/rancher-tracing/charts/templates/psp.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "tracing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "tracing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "tracing.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "tracing.fullname" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "tracing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - policy
+  resourceNames:
+  - {{ include "tracing.fullname" . }}
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "tracing.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.provider }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+spec:
+  allowPrivilegeEscalation: false
+  forbiddenSysctls:
+  - '*'
+  fsGroup:
+      ranges:
+        - max: 65535
+          min: 1
+      rule: MustRunAs
+  requiredDropCapabilities:
+  - ALL
+  runAsUser:
+      rule: MustRunAsNonRoot
+  runAsGroup:
+      rule: MustRunAs
+      ranges:
+      - min: 1
+        max: 65535
+  seLinux:
+      rule: RunAsAny
+  supplementalGroups:
+      ranges:
+        - max: 65535
+          min: 1
+      rule: MustRunAs
+  volumes:
+  - emptyDir
+  - secret
+  - persistentVolumeClaim


### PR DESCRIPTION
Add PodSecurityPolicies for rancher-istio, rancher-tracing and rancher-kiali-server.

Addresses: https://github.com/rancher/rancher/issues/30744

A branch with the compiled charts for this PR is available for testing at https://github.com/bashofmann/charts-1/tree/rancher-istio-psp-built2.