### PR TITLE
Add PodSecurityPolicies for rancher-logging

### DIFF
--- a/packages/rancher-logging/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/aks/logging.yaml
@@ -15,6 +15,9 @@ spec:
     inputTail:
       Tag: "aks"
       Path: "/var/log/azure/kubelet-status.log"
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
@@ -30,6 +33,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/eks/logging.yaml
@@ -16,6 +16,9 @@ spec:
       Tag: "eks"
       Path: "/var/log/messages"
       Parser: "syslog"
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
@@ -31,6 +34,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/gke/logging.yaml
@@ -15,6 +15,9 @@ spec:
     inputTail:
       Tag: "gke"
       Path: "/var/log/kube-proxy.log"
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
@@ -30,6 +33,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -19,6 +19,9 @@ spec:
       - source: "/var/log/"
         destination: "/var/log"
         readOnly: true
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
@@ -36,6 +39,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -19,6 +19,9 @@ spec:
       - source: "/var/log/"
         destination: "/var/log"
         readOnly: true
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
@@ -36,6 +39,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke/daemonset.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke/daemonset.yaml
@@ -40,6 +40,7 @@ spec:
         - name: config
           configMap:
             name: "{{ .Release.Name }}-rke"
+      serviceAccountName: "{{ .Release.Name }}-rke-aggregator"
       {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
       {{- with $total_tolerations }}
       tolerations:
@@ -49,4 +50,65 @@ spec:
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+rules:
+  - apiGroups:
+    - policy
+    resourceNames:
+    - "{{ .Release.Name }}-rke-aggregator"
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ .Release.Name }}-rke-aggregator"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ .Release.Name }}-rke-aggregator"
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  allowPrivilegeEscalation: false
+  allowedHostPaths:
+  - pathPrefix: /var/lib/docker/containers/
+    readOnly: false
+  - pathPrefix: /var/lib/rancher/rke/log/
+    readOnly: false
+  - pathPrefix: /var/lib/rancher/logging/
+    readOnly: false
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - secret
+  - hostPath
 {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke/logging-rke.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke/logging-rke.yaml
@@ -20,6 +20,9 @@ spec:
       - source: "/var/lib/rancher/logging/"
         destination: "/var/lib/rancher/logging/"
         readOnly: true
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
@@ -37,6 +40,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke2/daemonset.yaml
@@ -31,6 +31,7 @@ spec:
           nodeSelector:
             {{- toYaml . | nindent 6 }}
           {{- end }}
+      serviceAccountName: "{{ .Release.Name }}-rke2-journald-aggregator"        
       volumes:
         - name: logdir
           hostPath:
@@ -38,4 +39,61 @@ spec:
         - name: config
           configMap:
             name: "{{ .Release.Name }}-rke2"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+rules:
+  - apiGroups:
+    - policy
+    resourceNames:
+    - "{{ .Release.Name }}-rke2-journald-aggregator"
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ .Release.Name }}-rke2-journald-aggregator"
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  allowPrivilegeEscalation: false
+  allowedHostPaths:
+  - pathPrefix: /etc/rancher/logging/logs
+    readOnly: false
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - secret
+  - hostPath
 {{- end }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -17,6 +17,9 @@ spec:
       - source: "/var/log/containers/"
         destination: "/var/log/containers/"
         readOnly: true
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
@@ -34,6 +37,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-journald.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/rke2/logging-rke2-journald.yaml
@@ -17,6 +17,9 @@ spec:
       - source: "/etc/rancher/logging/logs/"
         destination: "/etc/rancher/logging/logs/"
         readOnly: true
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
@@ -34,6 +37,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/overlay/templates/loggings/root/logging.yaml
@@ -11,6 +11,9 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
       tag: {{ .Values.images.fluentbit.tag }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit_tolerations) }}
   {{- with $total_tolerations }}
     tolerations:
@@ -28,6 +31,9 @@ spec:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
     disablePvc: {{ .Values.disablePvc }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
     {{- with .Values.tolerations }}
     tolerations:
       {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,4 +1,4 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.8.2.tgz
-packageVersion: 01
+packageVersion: 02
 generateCRDChart:
   enabled: true

--- a/packages/rancher-logging/rancher-logging.patch
+++ b/packages/rancher-logging/rancher-logging.patch
@@ -100,6 +100,10 @@ diff -x '*.tgz' -x '*.lock' -uNr packages/rancher-logging/charts-original/values
  
  affinity: {}
  
+@@ -55,2 +60,2 @@
+  psp:
+-    enabled: false
++    enabled: true
 @@ -76,4 +81,50 @@
  monitoring:
    # Create a Prometheus Operator ServiceMonitor object


### PR DESCRIPTION
Add PodSecurityPolicies for rancher-logging.

Addresses https://github.com/rancher/rancher/issues/30771

A branch with the compiled charts for testing is available at https://github.com/bashofmann/charts-1/tree/rancher-logging-psp-built3.