### PR TITLE
Add context path for jaeger, added grafana urls

### DIFF
--- a/packages/rancher-istio/charts/README.md
+++ b/packages/rancher-istio/charts/README.md
@@ -14,18 +14,12 @@ A Rancher created chart that packages the istioctl binary to install via a helm 
 
 Kiali allows you to view and manage your istio-based service mesh through an easy to use dashboard.
 
-###  Dependencies
+####  Dependencies
 - rancher-monitoring chart or other Prometheus installation
 
 This dependecy installs the required CRDs for installing Kiali. Since Kiali is bundled in with Istio in this chart, if you do not have these dependencies installed, your Istio installation will fail. If you do not plan on using Kiali, set `kiali.enabled=false` when installing Istio for a succesful installation.
 
 > **Note:** The following configuration options assume you have installed the dependecies for Kiali. Please ensure you have Promtheus in your cluster before proceeding.
-
-The `kiali.external_services.prometheus` url is set in the values.yaml:
-```
-http://{{ .Values.nameOverride }}-prometheus.{{ .Values.namespaceOverride }}.svc:{{ prometheus.service.port }}
-```
-The url depends on the default values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port` being set in your rancher-monitoring or other monitoring instance.
 
 The Monitoring app sets `prometheus.prometheusSpec.ignoreNamespaceSelectors=false` which means all namespaces will be scraped by Prometheus by default. This ensures you can view traffic, metrics and graphs for resources deployed in other namespaces.
 
@@ -33,6 +27,29 @@ To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreN
 
 1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
 1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
+
+####  External Services
+
+##### Prometheus
+The `kiali.external_services.prometheus` url is set in the values.yaml:
+```
+http://{{ .Values.nameOverride }}-prometheus.{{ .Values.namespaceOverride }}.svc:{{ prometheus.service.port }}
+```
+The url depends on the default values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port` being set in your rancher-monitoring or other monitoring instance.
+
+##### Grafana
+The `kiali.external_services.grafana` url is set in the values.yaml:
+```
+http://{{ .Values.nameOverride }}-grafana.{{ .Values.namespaceOverride }}.svc:{{ grafana.service.port }}
+```
+The url depends on the default values for `nameOverride`, `namespaceOverride`, and `grafana.service.port` being set in your rancher-monitoring or other monitoring instance.
+
+##### Tracing
+The `kiali.external_services.tracing` url and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml:
+```
+http://tracing.{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+```
+The url depends on the default values for `namespaceOverride`, and `.Values.service.externalPort` being set in your rancher-tracing or other tracing instance.
 
 ## Jaeger
 

--- a/packages/rancher-istio/charts/app-readme.md
+++ b/packages/rancher-istio/charts/app-readme.md
@@ -23,9 +23,23 @@ To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreN
 
 **Custom Prometheus Installation with Kiali**
 
-To use a custom Monitoring installation, set the `kiali.external_services.prometheus` url in the values.yaml. This url depends on the values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port`:
+To use a custom Monitoring installation, set the `kiali.external_services.prometheus` url in the values.yaml. This url depends on the values for `nameOverride`, `namespaceOverride`, and `prometheus.service.port` in your rancher-monitoring or other monitoring instance:
 ```
 http://{{ .Values.nameOverride }}-prometheus.{{ .Values.namespaceOverride }}.svc:{{ prometheus.service.port }}
+```
+**Custom Grafana Installation with Kiali**
+
+To use a custom Grafana installation, set the `kiali.external_services.grafana` url in the values.yaml. This url depends on the values for `nameOverride`, `namespaceOverride`, and `granfa.service.port` in your rancher-monitoring or other grafana instance:
+```
+http://{{ .Values.nameOverride }}-grafana.{{ .Values.namespaceOverride }}.svc:{{ grafana.service.port }}
+```
+**Custom Tracing Installation with Kiali**
+
+To use a custom Tracing installation, set the `kiali.external_services.tracing` url and update the `.Values.tracing.contextPath` in the rancher-istio values.yaml.
+
+This url depends on the values for `namespaceOverride`, and `.Values.service.externalPort` in your rancher-tracing or other tracing instance.:
+```
+http://tracing.{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
 ```
 
 For more information on how to use the feature, refer to our [docs](https://rancher.com/docs/rancher/v2.x/en/istio/v2.5/).

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -90,10 +90,14 @@ kiali:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
       url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
     tracing:
-      in_cluster_url: "http://tracing.istio-system.svc:16686"
+      in_cluster_url: "http://tracing.istio-system.svc:16686/jaeger"
+    grafana:
+      in_cluster_url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"
+      url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"
 
 tracing:
   enabled: false
+  contextPath: "/jaeger"
   jaeger:
     repository: rancher/jaegertracing-all-in-one
     tag: 1.20.0

--- a/packages/rancher-istio/package.yaml
+++ b/packages/rancher-istio/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 01
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02


### PR DESCRIPTION
**Issue**
Kiali was showing error in dashboard indicating that it was unable to get Jaeger traces

**Solution**
Update Jaeger URL and Grafana URL to the correct urls to ensure Kiali has access to them

**Issue**
https://github.com/rancher/rancher/issues/30752