### PR TITLE
Adding cpu, memory chart annotations

### DIFF
--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -16,3 +16,5 @@ annotations:
   catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.29.000-rc00
   catalog.cattle.io/display-name: "Istio"
   catalog.cattle.io/os: linux
+  catalog.cattle.io/requests-cpu: "710m"
+  catalog.cattle.io/requests-memory: "2314Mi"

--- a/packages/rancher-istio/package.yaml
+++ b/packages/rancher-istio/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 00
+releaseCandidateVersion: 01


### PR DESCRIPTION
**Issue**
V1 version of Istio chart had a minimum cpu and memory requirement for cluster - V2 needs the same thing

**Solution**
Chart annotations will be added for rancher to use to check space and added ui warning

**Issue**
https://github.com/rancher/rancher/issues/30144