### PR TITLE
Consolidate mountPath to dockerRootDir for logging

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
@@ -20,11 +20,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.aks.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.aks.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
@@ -21,11 +21,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.eks.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.eks.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
@@ -20,11 +20,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.gke.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.gke.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -24,11 +24,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -24,11 +24,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.k3s.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
@@ -23,7 +23,7 @@ spec:
               name: indir
             - mountPath: /var/lib/rancher/logging/
               name: outdir
-            - mountPath: /var/lib/docker/containers/
+            - mountPath: {{ .Values.global.dockerRootDirectory | default "/var/lib/docker/containers/" | quote }}
               name: containers
             - mountPath: /tail-db
               name: tail-db
@@ -41,7 +41,7 @@ spec:
             type: DirectoryOrCreate
         - name: containers
           hostPath:
-            path: /var/lib/docker/containers/
+            path: {{ .Values.global.dockerRootDirectory | default "/var/lib/docker/containers/" | quote }}
             type: DirectoryOrCreate
         - name: tail-db
           hostPath:
@@ -102,7 +102,7 @@ metadata:
 spec:
   allowPrivilegeEscalation: false
   allowedHostPaths:
-  - pathPrefix: /var/lib/docker/containers/
+  - pathPrefix: {{ .Values.global.dockerRootDirectory | default "/var/lib/docker/containers/" | quote }}
     readOnly: false
   - pathPrefix: /var/lib/rancher/rke/log/
     readOnly: false

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/logging-rke.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/logging-rke.yaml
@@ -25,10 +25,8 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.rke.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.rke.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
+  {{- if .Values.global.dockerRootDirectory }}
+    mountPath: {{ .Values.global.dockerRootDirectory }}
   {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -22,11 +22,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-journald.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-journald.yaml
@@ -22,11 +22,6 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
-    mountPath: {{ .Values.additionalLoggingSources.rke2.fluentbit.mountPath }}
-  {{- else if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
-  {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}
     tolerations:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
@@ -16,8 +16,8 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- if .Values.fluentbit.mountPath }}
-    mountPath: {{ .Values.fluentbit.mountPath }}
+  {{- if .Values.global.dockerRootDirectory }}
+    mountPath: {{ .Values.global.dockerRootDirectory }}
   {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,7 @@
  rbac:
    enabled: true
    psp:
-@@ -80,3 +88,74 @@
+@@ -80,3 +88,62 @@
      additionalLabels: {}
      metricRelabelings: []
      relabelings: []
@@ -49,28 +49,17 @@
 +    fluentbit:
 +      log_level: "info"
 +      mem_buffer_limit: "5MB"
-+      mountPath: ""
 +  rke2:
 +    enabled: false
-+    fluentbit:
-+      mountPath: ""
 +  k3s:
 +    enabled: false
 +    container_engine: "systemd"
-+    fluentbit:
-+      mountPath: ""
 +  aks:
 +    enabled: false
-+    fluentbit:
-+      mountPath: ""
 +  eks:
 +    enabled: false
-+    fluentbit:
-+      mountPath: ""
 +  gke:
 +    enabled: false
-+    fluentbit:
-+      mountPath: ""
 +
 +images:
 +  config_reloader:
@@ -87,13 +76,10 @@
 +    tag: v1.11.5-alpine-9
 +
 +# These "fluentd" and "fluentbit" settings apply to every Logging CR, including vendor Logging CRs
-+# enabled in "additionalLoggingSources". Changing these affects every Logging CR installed. However,
-+# you can override the "fluentbit.mountPath" setting in the corresponding Logging CR(s) for a given
-+# vendor (i.e. k3s).
++# enabled in "additionalLoggingSources". Changing these affects every Logging CR installed.
 +fluentd:
 +  resources: {}
 +fluentbit:
-+  mountPath: ""
 +  resources: {}
 +  tolerations:
 +    - key: node-role.kubernetes.io/controlplane
@@ -104,10 +90,12 @@
 +      effect: NoExecute
 +
 +global:
-+  # This psp settings differs from the upstream "rbac.psp" by only enabling psp settings for the
++  cattle:
++    systemDefaultRegistry: ""
++  # Change the "dockerRootDirectory" if the default Docker directory has changed.
++  dockerRootDirectory: ""
++  # This psp setting differs from the upstream "rbac.psp" by only enabling psp settings for the
 +  # overlay files, which include the Logging CRs created, whereas the upstream "rbac.psp" affects the
 +  # logging operator.
 +  psp:
 +    enabled: true
-+  cattle:
-+    systemDefaultRegistry: ""

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.0.tgz
 packageVersion: 00
-releaseCandidateVersion: 04
+releaseCandidateVersion: 05
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/rancher/issues/30329

**Summary:** exposing `mountPath` for every `additionalLoggingSource` is unnecessary since the _provider_ determines the logging source. However the `root` logging CR and the `rke` logging CR specifically use `/var/docker/containers`. Thus, in order to solve the original issue, the chart's `mountPath` has be refocused to addressing the `dockerRootDirectory` only.