### PR TITLE
Add make release to Staging branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ CHARTS_BUILD_SCRIPT_VERSION := fdf0565
 pull-scripts:
 	./scripts/pull-scripts
 
+release:
+	./scripts/release-assets
+
 TARGETS := prepare patch charts clean sync validate rebase docs
 
 $(TARGETS):

--- a/scripts/release-assets
+++ b/scripts/release-assets
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)
+
+cd ..
+
+mkdir -p released
+
+if ! [[ -d assets ]] || ! [[ -d charts ]]; then
+    echo "No assets to move to released/"
+    exit 0
+fi
+
+cp -R assets/ released/assets
+rm released/assets/README.md
+rm -R $(ls -1 -d charts/*/) $(ls -1 -d assets/*/)
+
+helm repo index --merge ./released/assets/index.yaml --url released/assets released/assets
+cp released/assets/index.yaml index.yaml


### PR DESCRIPTION
Add the ability to quickly move assets into the released/ directory and update the index.yamls.

On release, a release captain is expected to run this script to get the Staging branch ready to absorb commits from a new release.

Devs still will be forced to update the packageVersion since the Source branch validates against already released assets in the Live branch anyways.