### PR TITLE
[2.5.8] Add global seLinux toggle to rancher-logging

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
@@ -29,6 +29,11 @@ spec:
             - mountPath: /fluent-bit/etc/fluent-bit.conf
               name: config
               subPath: fluent-bit.conf
+          {{- if .Values.global.seLinux.enabled }}
+          securityContext:
+            seLinuxOptions:
+              type: rke_logreader_t
+          {{- end }}
       volumes:
         - name: indir
           hostPath:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -17,10 +17,17 @@ spec:
       - source: "/var/log/containers/"
         destination: "/var/log/containers/"
         readOnly: true
-    {{- if .Values.global.psp.enabled }}
+    {{- if or .Values.global.psp.enabled .Values.global.seLinux.enabled }}
     security:
+    {{- end }}
+    {{- if or .Values.global.psp.enabled }}
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- if .Values.global.seLinux.enabled }}
+      securityContext:
+        seLinuxOptions:
+          type: rke_logreader_t
     {{- end }}
   {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
   {{- with $total_tolerations }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
@@ -12,10 +12,17 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
       tag: {{ .Values.images.fluentbit.tag }}
-    {{- if .Values.global.psp.enabled }}
+    {{- if or .Values.global.psp.enabled .Values.global.seLinux.enabled }}
     security:
+    {{- end }}
+    {{- if .Values.global.psp.enabled }}
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- if .Values.global.seLinux.enabled }}
+      securityContext:
+        seLinuxOptions:
+          type: rke_logreader_t
     {{- end }}
   {{- if .Values.global.dockerRootDirectory }}
     mountPath: {{ $containers }}

--- a/packages/rancher-logging/generated-changes/patch/README.md.patch
+++ b/packages/rancher-logging/generated-changes/patch/README.md.patch
@@ -1,0 +1,10 @@
+--- charts-original/README.md
++++ charts/README.md
+@@ -67,6 +67,7 @@
+ | `securityContext`                                   | Container SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) | `{"allowPrivilegeEscalation": false, "readOnlyRootFilesystem": true}` |
+ | `createCustomResource`                              | Create CRDs. | `true` |
+ | `monitoring.serviceMonitor.enabled`                 | Create Prometheus Operator servicemonitor. | `false` |
++| `global.seLinux.enabled`                            | Add seLinuxOptions to Logging resources, requires the [rke2-selinux RPM](https://github.com/rancher/rke2-selinux/releases) | `false` |
+ 
+ Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+ 

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,7 @@
  rbac:
    enabled: true
    psp:
-@@ -80,3 +88,62 @@
+@@ -80,3 +88,64 @@
      additionalLabels: {}
      metricRelabelings: []
      relabelings: []
@@ -99,3 +99,5 @@
 +  # logging operator.
 +  psp:
 +    enabled: true
++  seLinux:
++    enabled: false

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.0.tgz
-packageVersion: 01
-releaseCandidateVersion: 08
+packageVersion: 02
+releaseCandidateVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Add a new value to the rancher-logging chart to enable setting the
seLinuxOptions securityContext attribute for Logging resources and the
rke-aggregator DaemonSet. This is applied to any resource that needs to
read from /var/log/containers or /var/lib/docker/containers.

Without this patch, components in the rancher-logging chart mount and
attempt to read and sometimes write files on several hostPaths, and when
SELinux is enabled on the host, will fail because the containers are
unauthorized to do so. The added seLinuxOptions attribute in this patch
causes the fluentbit and rke-aggregator DaemonSets to run with the
SELinux context type `rke_logreader_t`, which is provided by the
rke2-linux package and enables the container to read files with the
label `container_log_t`, which includes files like
/var/log/containers/*.log, and files with type `rke_container_var_lib_t`
which the docker log files are relabeled to.

The logging aggregator will still fail to read and write log data from
/var/lib/rancher/logging, but this will be addressed in a different way
(https://github.com/rancher/rancher/issues/31309).

https://github.com/rancher/rancher/issues/30949

Depends on https://github.com/rancher/rke2-selinux/pull/13