### PR TITLE
Adding Istio 1.8.3

### DIFF
--- a/packages/rancher-backup/package.yaml
+++ b/packages/rancher-backup/package.yaml
@@ -1,6 +1,6 @@
 url: local
 packageVersion: 01
-releaseCandidateVersion: 00
+releaseCandidateVersion: 01
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-istio/charts/Chart.yaml
+++ b/packages/rancher-istio/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.8.1
+appVersion: 1.8.3
 description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/ for details.
 name: rancher-istio
-version: 1.8.1
+version: 1.8.3
 icon: https://charts.rancher.io/assets/logos/istio.svg
 keywords:
 - networking

--- a/packages/rancher-istio/charts/README.md
+++ b/packages/rancher-istio/charts/README.md
@@ -7,6 +7,12 @@ A Rancher created chart that packages the istioctl binary to install via a helm 
 ## Chart Dependencies
 - rancher-kiali-server-crd chart
 
+# Uninstallation Requirements 
+To ensure rancher-istio uninstalls correctly, you must uninstall rancher-istio prior to uninstalling chart dependencies (see installation requirements for chart dependencies). This is because all definitions need to be available in order to properly build the rancher-istio objects for removal.
+
+If you remove dependent CRD charts prior to removing rancher-istio, you may encounter the following error::
+
+`Error: uninstallation completed with 1 error(s): unable to build kubernetes objects for delete: unable to recognize "": no matches for kind "MonitoringDashboard" in version "monitoring.kiali.io/v1alpha1"`
 
 # Addons
 

--- a/packages/rancher-istio/charts/values.yaml
+++ b/packages/rancher-istio/charts/values.yaml
@@ -1,11 +1,11 @@
 overlayFile: ""
-tag: 1.8.1
+tag: 1.8.3
 ##Setting forceInstall: true will remove the check for istio version < 1.6.x and will not analyze your install cluster prior to install
 forceInstall: false
 
 installer:
   repository: rancher/istio-installer
-  tag: 1.8.1-rancher1
+  tag: 1.8.3-rancher1
 
 istiocoredns:
   enabled: false
@@ -22,7 +22,7 @@ base:
 cni:
   enabled: false
   repository: rancher/istio-install-cni
-  tag: 1.8.1
+  tag: 1.8.3
   logLevel: info
   excludeNamespaces:
   - istio-system
@@ -42,7 +42,7 @@ istiodRemote:
 pilot:
   enabled: true
   repository: rancher/istio-pilot
-  tag: 1.8.1
+  tag: 1.8.3
 
 telemetry:
   enabled: true
@@ -54,10 +54,10 @@ global:
     systemDefaultRegistry: ""
   proxy:
     repository: rancher/istio-proxyv2
-    tag: 1.8.1
+    tag: 1.8.3
   proxy_init:
     repository: rancher/istio-proxyv2
-    tag: 1.8.1
+    tag: 1.8.3
   defaultPodDisruptionBudget:
     enabled: true
 

--- a/packages/rancher-istio/package.yaml
+++ b/packages/rancher-istio/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 00


### PR DESCRIPTION
**Problem**
1. Istio release new Istio 1.8.3 version
2. Uninstall error occurs when chart dependencies are removed prior to rancher-istio gets removed

**Solution**
1.Add a chart to support Istio 1.8.3
2.Add documentation about the uninstall process to chart readme. 

**Issue**
https://github.com/rancher/rancher/issues/31187
https://github.com/rancher/rancher/issues/31046

**Dependent PRs**
https://github.com/rancher/image-mirror/pull/73
https://github.com/rancher/istio-installer/pull/17

**Additional Notes**
Kiali and Jaeger version did not change from 1.8.1 to 1.8.3