### PR TITLE
Add rancher-windows-exporter

### DIFF
--- a/packages/rancher-monitoring/generated-changes/dependencies/windowsExporter/dependency.yaml
+++ b/packages/rancher-monitoring/generated-changes/dependencies/windowsExporter/dependency.yaml
@@ -1,0 +1,2 @@
+workingDir: ""
+url: packages/rancher-windows-exporter

--- a/packages/rancher-monitoring/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/Chart.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -5,18 +5,26 @@
+@@ -5,18 +5,25 @@
      - name: Upstream Project
        url: https://github.com/prometheus-operator/kube-prometheus
    artifacthub.io/operator: "true"
@@ -13,7 +13,6 @@
 +  catalog.cattle.io/auto-install: rancher-monitoring-crd=match
 +  catalog.cattle.io/requests-cpu: "4500m"
 +  catalog.cattle.io/requests-memory: "4000Mi"
-+  catalog.cattle.io/os: linux
  apiVersion: v1
  appVersion: 0.38.1
 -description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards,
@@ -31,7 +30,7 @@
  maintainers:
  - name: vsliouniaev
  - name: bismarck
-@@ -28,7 +36,9 @@
+@@ -28,7 +35,9 @@
    name: scottrigby
  - email: miroslav.hadzhiev@gmail.com
    name: Xtigyro

--- a/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -2,13 +2,283 @@
+@@ -2,13 +2,291 @@
  # This is a YAML-formatted file.
  # Declare variables to be passed into your templates.
  
@@ -24,7 +24,7 @@
 +    create: true
 +
 +## RKE PushProx Monitoring
-+## ref: https://github.com/rancher/charts/tree/master/packages/rancher-pushprox
++## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 +##
 +rkeControllerManager:
 +  enabled: false
@@ -89,8 +89,16 @@
 +    - effect: "NoSchedule"
 +      operator: "Exists"
 +
++## Windows Monitoring (note: currently RKE1 only)
++## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-windows-exporter
++## Runs https://github.com/prometheus-community/windows_exporter as a DaemonSet
++## Relies on the existence of a wins server of version v0.1.0+ on every Windows host to allow 
++## windows_exporter to run as a host process that can publish host metrics to a port on the Pod
++windowsExporter:
++  enabled: true
++
 +## k3s PushProx Monitoring
-+## ref: https://github.com/rancher/charts/tree/master/packages/rancher-pushprox
++## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 +##
 +k3sServer:
 +  enabled: false
@@ -106,7 +114,7 @@
 +      operator: "Exists"
 +
 +## KubeADM PushProx Monitoring
-+## ref: https://github.com/rancher/charts/tree/master/packages/rancher-pushprox
++## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 +##
 +kubeAdmControllerManager:
 +  enabled: false
@@ -175,7 +183,7 @@
 +      operator: "Exists"
 +
 +## rke2 PushProx Monitoring
-+## ref: https://github.com/rancher/charts/tree/master/packages/rancher-pushprox
++## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 +##
 +rke2ControllerManager:
 +  enabled: false
@@ -286,7 +294,7 @@
  
  ## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.16.6
  ##
-@@ -76,8 +346,23 @@
+@@ -76,8 +354,23 @@
  
  ##
  global:
@@ -310,7 +318,7 @@
      pspEnabled: true
      pspAnnotations: {}
        ## Specify pod annotations
-@@ -130,6 +415,22 @@
+@@ -130,6 +423,22 @@
    ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
    ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
    ##
@@ -333,7 +341,7 @@
    config:
      global:
        resolve_timeout: 5m
-@@ -145,6 +446,8 @@
+@@ -145,6 +454,8 @@
          receiver: 'null'
      receivers:
      - name: 'null'
@@ -342,7 +350,7 @@
  
    ## Pass the Alertmanager configuration directives through Helm's templating
    ## engine. If the Alertmanager configuration contains Alertmanager templates,
-@@ -160,25 +463,76 @@
+@@ -160,25 +471,76 @@
    ## ref: https://prometheus.io/docs/alerting/notifications/
    ##      https://prometheus.io/docs/alerting/notification_examples/
    ##
@@ -438,7 +446,7 @@
  
    ingress:
      enabled: false
-@@ -208,6 +562,25 @@
+@@ -208,6 +570,25 @@
    ## Configuration for Alertmanager secret
    ##
    secret:
@@ -464,7 +472,7 @@
      annotations: {}
  
    ## Configuration for creating an Ingress that will map to each Alertmanager replica service
-@@ -334,7 +707,7 @@
+@@ -334,7 +715,7 @@
      ## Image of Alertmanager
      ##
      image:
@@ -473,7 +481,7 @@
        tag: v0.21.0
        sha: ""
  
-@@ -410,9 +783,13 @@
+@@ -410,9 +791,13 @@
      ## Define resources requests and limits for single Pods.
      ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
      ##
@@ -490,7 +498,7 @@
  
      ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
      ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
-@@ -487,6 +864,27 @@
+@@ -487,6 +872,27 @@
    enabled: true
    namespaceOverride: ""
  
@@ -518,7 +526,7 @@
    ## Deploy default dashboards.
    ##
    defaultDashboardsEnabled: true
-@@ -530,6 +928,7 @@
+@@ -530,6 +936,7 @@
      dashboards:
        enabled: true
        label: grafana_dashboard
@@ -526,7 +534,7 @@
  
        ## Annotations for Grafana dashboard configmaps
        ##
-@@ -574,7 +973,60 @@
+@@ -574,7 +981,60 @@
    ## Passed to grafana subchart and used by servicemonitor below
    ##
    service:
@@ -588,7 +596,7 @@
  
    ## If true, create a serviceMonitor for grafana
    ##
-@@ -600,6 +1052,14 @@
+@@ -600,6 +1060,14 @@
      #   targetLabel: nodename
      #   replacement: $1
      #   action: replace
@@ -603,7 +611,7 @@
  
  ## Component scraping the kube api server
  ##
-@@ -756,7 +1216,7 @@
+@@ -756,7 +1224,7 @@
  ## Component scraping the kube controller manager
  ##
  kubeControllerManager:
@@ -612,7 +620,7 @@
  
    ## If your kube controller manager is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -889,7 +1349,7 @@
+@@ -889,7 +1357,7 @@
  ## Component scraping etcd
  ##
  kubeEtcd:
@@ -621,7 +629,7 @@
  
    ## If your etcd is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -949,7 +1409,7 @@
+@@ -949,7 +1417,7 @@
  ## Component scraping kube scheduler
  ##
  kubeScheduler:
@@ -630,7 +638,7 @@
  
    ## If your kube scheduler is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1002,7 +1462,7 @@
+@@ -1002,7 +1470,7 @@
  ## Component scraping kube proxy
  ##
  kubeProxy:
@@ -639,7 +647,7 @@
  
    ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1076,6 +1536,13 @@
+@@ -1076,6 +1544,13 @@
      create: true
    podSecurityPolicy:
      enabled: true
@@ -653,7 +661,7 @@
  
  ## Deploy node exporter as a daemonset to all nodes
  ##
-@@ -1125,6 +1592,16 @@
+@@ -1125,6 +1600,16 @@
    extraArgs:
      - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
      - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
@@ -670,7 +678,7 @@
  
  ## Manages Prometheus and Alertmanager components
  ##
-@@ -1138,7 +1615,7 @@
+@@ -1138,7 +1623,7 @@
    tlsProxy:
      enabled: true
      image:
@@ -679,7 +687,7 @@
        tag: v1.5.2
        sha: ""
        pullPolicy: IfNotPresent
-@@ -1156,7 +1633,7 @@
+@@ -1156,7 +1641,7 @@
      patch:
        enabled: true
        image:
@@ -688,7 +696,7 @@
          tag: v1.2.1
          sha: ""
          pullPolicy: IfNotPresent
-@@ -1285,13 +1762,13 @@
+@@ -1285,13 +1770,13 @@
  
    ## Resource limits & requests
    ##
@@ -709,7 +717,7 @@
  
    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
    # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
-@@ -1335,7 +1812,7 @@
+@@ -1335,7 +1820,7 @@
    ## Prometheus-operator image
    ##
    image:
@@ -718,7 +726,7 @@
      tag: v0.38.1
      sha: ""
      pullPolicy: IfNotPresent
-@@ -1343,14 +1820,14 @@
+@@ -1343,14 +1828,14 @@
    ## Configmap-reload image to use for reloading configmaps
    ##
    configmapReloadImage:
@@ -735,7 +743,7 @@
      tag: v0.38.1
      sha: ""
  
-@@ -1366,14 +1843,6 @@
+@@ -1366,14 +1851,6 @@
    ##
    secretFieldSelector: ""
  
@@ -750,7 +758,7 @@
  ## Deploy a Prometheus instance
  ##
  prometheus:
-@@ -1403,7 +1872,7 @@
+@@ -1403,7 +1880,7 @@
      port: 9090
  
      ## To be used with a proxy extraContainer port
@@ -759,7 +767,7 @@
  
      ## List of IP addresses at which the Prometheus server service is available
      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-@@ -1614,7 +2083,7 @@
+@@ -1614,7 +2091,7 @@
      ## Image of Prometheus.
      ##
      image:
@@ -768,7 +776,7 @@
        tag: v2.18.2
        sha: ""
  
-@@ -1666,6 +2135,11 @@
+@@ -1666,6 +2143,11 @@
      ##
      externalUrl: ""
  
@@ -780,7 +788,7 @@
      ## Define which Nodes the Pods are scheduled on.
      ## ref: https://kubernetes.io/docs/user-guide/node-selection/
      ##
-@@ -1698,7 +2172,7 @@
+@@ -1698,7 +2180,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the PrometheusRule resources created
      ##
@@ -789,7 +797,7 @@
  
      ## PrometheusRules to be selected for target discovery.
      ## If {}, select all ServiceMonitors
-@@ -1723,7 +2197,7 @@
+@@ -1723,7 +2205,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the servicemonitors created
      ##
@@ -798,7 +806,7 @@
  
      ## ServiceMonitors to be selected for target discovery.
      ## If {}, select all ServiceMonitors
-@@ -1743,7 +2217,7 @@
+@@ -1743,7 +2225,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the podmonitors created
      ##
@@ -807,7 +815,7 @@
  
      ## PodMonitors to be selected for target discovery.
      ## If {}, select all PodMonitors
-@@ -1840,9 +2314,13 @@
+@@ -1840,9 +2322,13 @@
  
      ## Resource limits & requests
      ##
@@ -824,7 +832,7 @@
  
      ## Prometheus StorageSpec for persistent data
      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md
-@@ -1857,11 +2335,6 @@
+@@ -1857,11 +2343,6 @@
      #          storage: 50Gi
      #    selector: {}
  
@@ -836,7 +844,7 @@
      ## AdditionalScrapeConfigs allows specifying additional Prometheus scrape configurations. Scrape configurations
      ## are appended to the configurations generated by the Prometheus Operator. Job configurations must have the form
      ## as specified in the official Prometheus documentation:
-@@ -1964,9 +2437,46 @@
+@@ -1964,9 +2445,46 @@
      ##
      thanos: {}
  
@@ -884,7 +892,7 @@
  
      ## InitContainers allows injecting additional initContainers. This is meant to allow doing some changes
      ## (permissions, dir tree) on mounted volumes before starting prometheus
-@@ -1974,7 +2484,7 @@
+@@ -1974,7 +2492,7 @@
  
      ## PortName to use for Prometheus.
      ##

--- a/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -95,7 +95,7 @@
 +## Relies on the existence of a wins server of version v0.1.0+ on every Windows host to allow 
 +## windows_exporter to run as a host process that can publish host metrics to a port on the Pod
 +windowsExporter:
-+  enabled: true
++  enabled: false
 +
 +## k3s PushProx Monitoring
 +## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-9.4.2/kube-prometheus-stack-9.4.2.tgz
 packageVersion: 04
-releaseCandidateVersion: 03
+releaseCandidateVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-windows-exporter/charts/.helmignore
+++ b/packages/rancher-windows-exporter/charts/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/packages/rancher-windows-exporter/charts/Chart.yaml
+++ b/packages/rancher-windows-exporter/charts/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+version: 0.1.0
+appVersion: 0.0.4
+annotations:
+  catalog.rancher.io/certified: rancher
+  catalog.rancher.io/namespace: cattle-monitoring-system
+  catalog.rancher.io/release-name: rancher-windows-exporter
+  catalog.cattle.io/os: windows
+description: Sets up monitoring metrics from Windows nodes via Prometheus windows-exporter
+name: rancher-windows-exporter
+maintainers:
+- name: aiyengar2
+  email: arvind.iyengar@rancher.com
+type: application

--- a/packages/rancher-windows-exporter/charts/README.md
+++ b/packages/rancher-windows-exporter/charts/README.md
@@ -1,0 +1,17 @@
+# rancher-windows-exporter
+
+A Rancher chart based on the [prometheus-community/windows-exporter](https://github.com/prometheus-community/windows_exporter) project (previously called wmi-exporter) that sets up a DaemonSet of clients that can scrape windows-exporter metrics from Windows nodes on a Kubernetes cluster.
+
+A [Prometheus Operator](https://github.com/coreos/prometheus-operator) ServiceMonitor CR and PrometheusRule CR are also created by this chart to collect metrics and add some recording rules to map `windows_` series with their OS-agnostic counterparts.
+
+## Node Requirements
+
+Since Windows does not support privileged pods, this chart expects a Named Pipe (`\\.\pipe\rancher_wins`) to exist on the Windows host that allows containers to communicate with the host. This is done by deploying a [rancher/wins](https://github.com/rancher/wins) server on the host.
+
+The image used by the chart, [windows_exporter-package](https://github.com/rancher/windows_exporter-package), is configured to create a wins client that communicates with the wins server, alongside a running copy of a particular version of [windows-exporter](https://github.com/prometheus-community/windows_exporter). Through the wins client and wins server, the windows-exporter is able to communicate directly with the Windows host to collect metrics and expose them.
+
+If the cluster you are installing this chart on is a custom cluster that was created via RKE1 with Windows Support enabled, your nodes should already have the wins server running; this should have been added as part of [the bootstrapping process for adding the Windows node onto your RKE1 cluster](https://github.com/rancher/rancher/blob/master/package/windows/bootstrap.ps1).
+
+## Configuration
+
+See [rancher-monitoring](https://github.com/rancher/charts/tree/gh-pages/packages/rancher-monitoring) for an example of how this chart can be used.

--- a/packages/rancher-windows-exporter/charts/scripts/copy-binary.ps1
+++ b/packages/rancher-windows-exporter/charts/scripts/copy-binary.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+
+function Create-Directory
+{
+    param (
+        [parameter(Mandatory = $false, ValueFromPipeline = $true)] [string]$Path
+    )
+
+    if (Test-Path -Path $Path) {
+        if (-not (Test-Path -Path $Path -PathType Container)) {
+            # clean the same path file
+            Remove-Item -Recurse -Force -Path $Path -ErrorAction Ignore | Out-Null
+        }
+
+        return
+    }
+
+    New-Item -Force -ItemType Directory -Path $Path | Out-Null
+}
+
+function Transfer-File
+{
+    param (
+        [parameter(Mandatory = $true)] [string]$Src,
+        [parameter(Mandatory = $true)] [string]$Dst
+    )
+
+    if (Test-Path -PathType leaf -Path $Dst) {
+        $dstHasher = Get-FileHash -Path $Dst
+        $srcHasher = Get-FileHash -Path $Src
+        if ($dstHasher.Hash -eq $srcHasher.Hash) {
+            return
+        }
+    }
+
+    $null = Copy-Item -Force -Path $Src -Destination $Dst
+}
+
+Create-Directory -Path "c:\host\etc\windows-exporter"
+Transfer-File -Src "c:\etc\windows-exporter\windows-exporter.exe" -Dst "c:\host\etc\windows-exporter\windows-exporter.exe"

--- a/packages/rancher-windows-exporter/charts/scripts/proxy-entry.ps1
+++ b/packages/rancher-windows-exporter/charts/scripts/proxy-entry.ps1
@@ -1,0 +1,11 @@
+# default
+$listenPort = "9796"
+
+if ($env:LISTEN_PORT) {
+    $listenPort = $env:LISTEN_PORT
+}
+
+# format "UDP:4789 TCP:8080"
+$winsPublish = $('TCP:{0}' -f $listenPort)
+
+wins.exe cli proxy --publish $winsPublish

--- a/packages/rancher-windows-exporter/charts/templates/_helpers.tpl
+++ b/packages/rancher-windows-exporter/charts/templates/_helpers.tpl
@@ -1,0 +1,64 @@
+# Rancher
+
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- end -}}
+{{- end -}}
+
+# General
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+The components in this chart create additional resources that expand the longest created name strings.
+The longest name that gets created adds and extra 37 characters, so truncation should be 63-35=26.
+*/}}
+{{- define "windowsExporter.name" -}}
+{{ printf "%s-windows-exporter" .Release.Name }}
+{{- end -}}
+
+{{- define "windowsExporter.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end -}}
+
+{{- define "windowsExporter.labels" -}}
+k8s-app: {{ template "windowsExporter.name" . }}
+release: {{ .Release.Name }}
+component: "kube-windows"
+provider: kubernetes
+{{- end -}}
+
+# Client
+
+{{- define "windowsExporter.client.nodeSelector" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+beta.kubernetes.io/os: windows
+{{- else -}}
+kubernetes.io/os: windows
+{{- end -}}
+{{- if .Values.clients.nodeSelector }}
+{{ toYaml .Values.clients.nodeSelector }}
+{{- end }}
+{{- end -}}
+
+{{- define "windowsExporter.client.tolerations" -}}
+{{- if .Values.clients.tolerations -}}
+{{ toYaml .Values.clients.tolerations }}
+{{- else -}}
+- operator: Exists
+{{- end -}}
+{{- end -}}
+
+{{- define "windowsExporter.client.env" -}}
+- name: LISTEN_PORT
+  value: {{ required "Need .Values.clients.port to figure out where to get metrics from" .Values.clients.port | quote }}
+{{- if .Values.clients.enabledCollectors }}
+- name: ENABLED_COLLECTORS
+  value: {{ .Values.clients.enabledCollectors | quote }}
+{{- end }}
+{{- if .Values.clients.env }}
+{{ toYaml .Values.clients.env }}
+{{- end }}
+{{- end -}}

--- a/packages/rancher-windows-exporter/charts/templates/configmap.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "windowsExporter.name" . }}-scripts
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+data:
+  copy-binary.ps1: |-
+{{ .Files.Get "scripts/copy-binary.ps1" | indent 4 }}
+  proxy-entry.ps1: |-
+{{ .Files.Get "scripts/proxy-entry.ps1" | indent 4 }}

--- a/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.clients }}{{ if .Values.clients.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels: {{ include "windowsExporter.labels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{ include "windowsExporter.labels" . | nindent 8 }}
+    spec:
+      nodeSelector: {{ include "windowsExporter.client.nodeSelector" . | nindent 8 }}
+      tolerations: {{ include "windowsExporter.client.tolerations" . | nindent 8 }}
+      serviceAccountName: {{ template "windowsExporter.name" . }}
+      containers:
+      - name: exporter-node-proxy
+        image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
+        command: ["pwsh", "-f", "c:/scripts/proxy-entry.ps1"]
+        ports:
+        - name: http
+          containerPort: {{ required "Need .Values.clients.port to figure out where to get metrics from" .Values.clients.port }}
+        env: {{ include "windowsExporter.client.env" . | nindent 10 }}
+{{- if .Values.resources }}
+        resources: {{ toYaml .Values.clients.proxy.resources | nindent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: wins-pipe-proxy
+          mountPath: \\.\pipe\rancher_wins_proxy
+        - name: exporter-scripts
+          mountPath: c:/scripts/
+      - name: exporter-node
+        image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
+{{- if .Values.clients.args }}
+        args: {{ .Values.clients.args }}
+{{- end }}
+        env: {{ include "windowsExporter.client.env" . | nindent 10 }}
+{{- if .Values.resources }}
+        resources: {{ toYaml .Values.clients.resources | nindent 10 }}
+{{- end }}
+        volumeMounts:
+        - name: wins-pipe
+          mountPath: \\.\pipe\rancher_wins
+      initContainers:
+      - name: exporter-node-binary-copy
+        image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
+        command: ["pwsh", "-f", "c:/scripts/copy-binary.ps1"]
+        volumeMounts:
+        - name: binary-host-path
+          mountPath: c:/host/etc/windows-exporter
+        - name: exporter-scripts
+          mountPath: c:/scripts/
+      volumes:
+      - name: wins-pipe
+        hostPath:
+          path: \\.\pipe\rancher_wins
+      - name: wins-pipe-proxy
+        hostPath:
+          path: \\.\pipe\rancher_wins_proxy
+      - name: binary-host-path
+        hostPath:
+          path: c:/etc/windows-exporter
+          type: DirectoryOrCreate
+      - name: exporter-scripts
+        configMap:
+          name: {{ template "windowsExporter.name" . }}-scripts
+{{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/templates/rbac.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/rbac.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.clients }}{{ if .Values.clients.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+rules:
+- apiGroups: ['authentication.k8s.io']
+  resources: ['tokenreviews']
+  verbs: ['create']
+- apiGroups: ['authorization.k8s.io']
+  resources: ['subjectaccessreviews']
+  verbs: ['create']
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames: ['{{ template "windowsExporter.name" . }}']
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "windowsExporter.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+{{- if .Values.clients.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.clients.imagePullSecrets | nindent 2 }}
+{{- end }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 0
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'secret'
+    - 'hostPath'
+  allowedHostPaths:
+  - pathPrefix: \\.\pipe\rancher_wins
+  - pathPrefix: \\.\pipe\rancher_wins_proxy
+  - pathPrefix: c:/etc/windows-exporter
+{{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/templates/service.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/service.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.serviceMonitor .Values.clients }}{{- if and .Values.serviceMonitor.enabled .Values.clients.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: windows-metrics
+    port: {{ required "Need .Values.clients.port to figure out where to get metrics from" .Values.clients.port }}
+    protocol: TCP
+    targetPort: {{ .Values.clients.port }}
+  selector: {{ include "windowsExporter.labels" . | nindent 4 }}
+{{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/templates/servicemonitor.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/servicemonitor.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.serviceMonitor .Values.clients }}{{- if and .Values.serviceMonitor.enabled .Values.clients.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+  name: {{ template "windowsExporter.name" . }}
+  namespace: {{ template "windowsExporter.namespace" . }}
+spec:
+  selector:
+    matchLabels: {{ include "windowsExporter.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ template "windowsExporter.namespace" . }}
+  endpoints:
+  - port: windows-metrics
+    metricRelabelings:
+    - sourceLabels: [__name__]
+      regex: 'wmi_(.*)'
+      replacement: 'windows_$1'
+      targetLabel: __name__
+    - sourceLabels: [__name__]
+      regex: windows_mssql_transactions_active_total
+      replacement: 'windows_mssql_transactions_active'
+      targetLabel: __name__
+    - sourceLabels: [volume, nic]
+      regex: (.*);(.*)
+      separator: ''
+      targetLabel: device
+      action: replace
+      replacement: $1$2
+    - sourceLabels: [__name__]
+      regex: windows_cs_logical_processors
+      replacement: 'system'
+      targetLabel: mode
+{{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/templates/windows-relabel-rule.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/windows-relabel-rule.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.prometheusRule .Values.serviceMonitor .Values.clients }}{{- if and .Values.prometheusRule.enabled .Values.serviceMonitor.enabled .Values.clients.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels: {{ include "windowsExporter.labels" . | nindent 4 }}
+  name: {{ template "windowsExporter.name" . }}-relabel-rules
+  namespace: {{ template "windowsExporter.namespace" . }}
+spec:
+  groups:
+  - name: windows-cpu-recording.rules
+    rules:
+    - record: node_cpu_seconds_total
+      expr: wmi_cpu_time_total
+    - record: node_load1
+      expr: avg_over_time(wmi_system_processor_queue_length[1m])
+    - record: node_load5
+      expr: avg_over_time(wmi_system_processor_queue_length[5m])
+    - record: node_load15
+      expr: avg_over_time(wmi_system_processor_queue_length[15m])
+    - record: node_load15
+      expr: avg_over_time(wmi_system_processor_queue_length[15m])
+  - name: windows-memory-recording.rules
+    rules:
+    - record: node_memory_MemAvailable_bytes
+      expr: wmi_os_physical_memory_free_bytes
+    - record: node_memory_MemTotal_bytes
+      expr: wmi_cs_physical_memory_bytes
+  - name: windows-network-io-recording.rules
+    rules:
+    - record: node_network_receive_bytes_total
+      expr: wmi_net_bytes_received_total
+    - record: node_network_transmit_bytes_total
+      expr: wmi_net_bytes_sent_total
+  - name: windows-network-packet-recording.rules
+    rules:
+    - record: node_network_receive_packets_total
+      expr: wmi_net_packets_received_total
+    - record: node_network_transmit_packets_total
+      expr: wmi_net_packets_sent_total
+    - record: node_network_receive_drop_total
+      expr: wmi_net_packets_received_discarded
+    - record: node_network_receive_errs_total
+      expr: wmi_net_packets_received_errors
+    - record: node_network_transmit_drop_total
+      expr: wmi_net_packets_outbound_discarded
+  - name: windows-disk-io-recording.rules
+    rules:
+    - record: node_disk_written_bytes_total
+      expr: wmi_logical_disk_write_bytes_total
+    - record: node_disk_read_bytes_total
+      expr: wmi_logical_disk_read_bytes_total
+  - name: windows-file-usage-recording.rules
+    rules:
+    - record: node_filesystem_size_bytes
+      expr: wmi_logical_disk_size_bytes
+    - record: node_filesystem_free_bytes
+      expr: wmi_logical_disk_free_bytes
+{{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/values.yaml
+++ b/packages/rancher-windows-exporter/charts/values.yaml
@@ -1,0 +1,48 @@
+# Default values for rancher-windows-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# Configuration
+
+global:
+  cattle:
+    systemDefaultRegistry: ""
+
+# Configure ServiceMonitor that monitors metrics
+serviceMonitor: 
+  enabled: true
+
+# Configure PrometheusRule that relabels metrics
+prometheusRule: 
+  enabled: true
+
+## Components scraping metrics from Windows nodes
+##
+clients:
+  enabled: true
+
+  port: 9796
+  image:
+    repository: rancher/windows_exporter-package
+    tag: v0.0.1
+
+  # Specify the IP addresses of nodes that you want to collect metrics from
+  endpoints: []
+
+  # Get more details on https://github.com/prometheus-community/windows_exporter
+  args: []
+  env: {}
+  enabledCollectors: "net,os,service,system,cpu,cs,logical_disk,tcp,memory,container"
+
+  # Resource limits
+  resources: {}
+  
+  # Options to select nodes to target for scraping Windows metrics
+  nodeSelector: {} # Note: {<beta.>kubernetes.io/os: windows} is default and cannot be overridden
+  tolerations: []  # Note: if not specified, the default option is to use [{operator: Exists}]
+
+  # Image Pull Secrets for the service account used by the clients
+  imagePullSecrets: {}
+
+  proxy:
+    resources: {}

--- a/packages/rancher-windows-exporter/package.yaml
+++ b/packages/rancher-windows-exporter/package.yaml
@@ -1,0 +1,3 @@
+url: local
+packageVersion: 00
+releaseCandidateVersion: 00


### PR DESCRIPTION
Forward ports a newer version of exporter-node-windows from Monitoring V1.

The charts are content-wise the same but structured very differently, so no base copy commit was added.

Blocked on creation of image:
- [x] Merge https://github.com/rancher/windows_exporter-package/pull/1
- [x] Cut release for wins v0.1.0
- [x] Ensure that rancher/windows_exporter-package:v0.0.1 exists
- [x] Merge https://github.com/rancher/windows_exporter-package/pull/2

Related Issue: https://github.com/rancher/rancher/issues/28327, https://github.com/rancher/rancher/issues/31497