### PR TITLE
Fix RKE2 aggregator DaemonSet for rancher-logging

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
@@ -23,15 +23,15 @@ spec:
               name: logdir
             - mountPath: /fluent-bit/etc/
               name: config
-          {{- with .Values.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 6 }}
-          {{- end }}
-          {{- with .Values.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 6 }}
-          {{- end }}
-      serviceAccountName: "{{ .Release.Name }}-rke2-journald-aggregator"        
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: "{{ .Release.Name }}-rke2-journald-aggregator"
       volumes:
         - name: logdir
           hostPath:

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.0.tgz
 packageVersion: 00
-releaseCandidateVersion: 05
+releaseCandidateVersion: 06
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Without this patch, the rancher-logging chart fails to install when RKE2
is included:

```
$ helm install rancher-logging rancher/rancher-logging --set additionalLoggingSources.rke2.enabled=true
Error: YAML parse error on rancher-logging/templates/loggings/rke2/daemonset.yaml: error converting YAML to JSON: yaml: line 25: did not find expected key
```

This is because the indentation being generated was invalid, which
itself was caused by the invalid use of `tolerations` and `nodeSelector`
under the `containers` object, when these are only Pod attributes. This
change fixes the indendation so that the end result is a valid pod spec
and the chart installs correctly.

https://github.com/rancher/rancher/issues/31372