### PR TITLE
Add back in linux-only toleration

### DIFF
--- a/packages/rancher-monitoring/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/Chart.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/Chart.yaml
 +++ charts/Chart.yaml
-@@ -5,18 +5,25 @@
+@@ -5,18 +5,26 @@
      - name: Upstream Project
        url: https://github.com/prometheus-operator/kube-prometheus
    artifacthub.io/operator: "true"
@@ -13,6 +13,7 @@
 +  catalog.cattle.io/auto-install: rancher-monitoring-crd=match
 +  catalog.cattle.io/requests-cpu: "4500m"
 +  catalog.cattle.io/requests-memory: "4000Mi"
++  catalog.cattle.io/os: linux
  apiVersion: v1
  appVersion: 0.38.1
 -description: kube-prometheus-stack collects Kubernetes manifests, Grafana dashboards,
@@ -30,7 +31,7 @@
  maintainers:
  - name: vsliouniaev
  - name: bismarck
-@@ -28,7 +35,9 @@
+@@ -28,7 +36,9 @@
    name: scottrigby
  - email: miroslav.hadzhiev@gmail.com
    name: Xtigyro

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-9.4.2/kube-prometheus-stack-9.4.2.tgz
 packageVersion: 03
-releaseCandidateVersion: 03
+releaseCandidateVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
This commit addresses a regression introduced in the charts script rewrite as seen in charts-diff [here](https://github.com/aiyengar2/charts-diff/blob/a6535725f6295921bd2c7bc830dad9f28b9a291a/diff/rancher-monitoring.diff#L17).

The annotation needs to be added back in till we get Windows Monitoring out, which is now scheduled for 2.5.7.

Related Issue: https://github.com/rancher/rancher/issues/31421