### PR TITLE
Create default ClusterRole for accessing Monitoring UIs

### DIFF
--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/clusterrole.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/clusterrole.yaml
@@ -90,4 +90,34 @@ rules:
   - 'get'
   - 'list'
   - 'watch'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: monitoring-ui-view
+  labels: {{ include "kube-prometheus-stack.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services/proxy
+  resourceNames:
+  - "http:{{ template "kube-prometheus-stack.fullname" . }}-prometheus:{{ .Values.prometheus.service.port }}"
+  - "https:{{ template "kube-prometheus-stack.fullname" . }}-prometheus:{{ .Values.prometheus.service.port }}"
+  - "http:{{ template "kube-prometheus-stack.fullname" . }}-alertmanager:{{ .Values.alertmanager.service.port }}"
+  - "https:{{ template "kube-prometheus-stack.fullname" . }}-alertmanager:{{ .Values.alertmanager.service.port }}"
+  - "http:{{ include "call-nested" (list . "grafana" "grafana.fullname") }}:{{ .Values.grafana.service.port }}"
+  - "https:{{ include "call-nested" (list . "grafana" "grafana.fullname") }}:{{ .Values.grafana.service.port }}"
+  verbs:
+  - 'get'
+- apiGroups:
+  - ""
+  resourceNames:
+  - {{ template "kube-prometheus-stack.fullname" . }}-prometheus
+  - {{ template "kube-prometheus-stack.fullname" . }}-alertmanager
+  - {{ include "call-nested" (list . "grafana" "grafana.fullname") }}
+  resources:
+  - endpoints
+  verbs:
+  - list
 {{- end }}

--- a/packages/rancher-monitoring/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,12 +1,28 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -1,3 +1,94 @@
+@@ -1,3 +1,110 @@
 +# Rancher
 +{{- define "system_default_registry" -}}
 +{{- if .Values.global.cattle.systemDefaultRegistry -}}
 +{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
 +{{- end -}}
 +{{- end -}}
++
++{{/*
++https://github.com/helm/helm/issues/4535#issuecomment-477778391
++Usage: {{ include "call-nested" (list . "SUBCHART_NAME" "TEMPLATE") }}
++e.g. {{ include "call-nested" (list . "grafana" "grafana.fullname") }}
++*/}}
++{{- define "call-nested" }}
++{{- $dot := index . 0 }}
++{{- $subchart := index . 1 | splitList "." }}
++{{- $template := index . 2 }}
++{{- $values := $dot.Values }}
++{{- range $subchart }}
++{{- $values = index $values . }}
++{{- end }}
++{{- include $template (dict "Chart" (dict "Name" (last $subchart)) "Values" $values "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
++{{- end }}
 +
 +# Special Exporters
 +{{- define "exporter.kubeEtcd.enabled" -}}

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-9.4.2/kube-prometheus-stack-9.4.2.tgz
 packageVersion: 04
-releaseCandidateVersion: 02
+releaseCandidateVersion: 03
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
This commit adds the minimal permissions required for users to be able to access the various UIs for accessing Prometheus, Grafana, and Alertmanager via a kubectl proxy and access the Monitoring Pane.

Related Issue: https://github.com/rancher/rancher/issues/31411