### PR TITLE
Give monitoring-ui-view full permissions on service/proxy

### DIFF
--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/clusterrole.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/clusterrole.yaml
@@ -109,7 +109,7 @@ rules:
   - "http:{{ include "call-nested" (list . "grafana" "grafana.fullname") }}:{{ .Values.grafana.service.port }}"
   - "https:{{ include "call-nested" (list . "grafana" "grafana.fullname") }}:{{ .Values.grafana.service.port }}"
   verbs:
-  - 'get'
+  - '*'
 - apiGroups:
   - ""
   resourceNames:

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-9.4.2/kube-prometheus-stack-9.4.2.tgz
 packageVersion: 04
-releaseCandidateVersion: 04
+releaseCandidateVersion: 05
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Followup for https://github.com/rancher/charts/pull/1008.

Gives * permissions instead of get permissions so that a user can make POST and other requests as well.

Related Issue: https://github.com/rancher/rancher/issues/31411