### PR TITLE
Bump kubectl and agent versions across feature charts

### DIFF
--- a/packages/rancher-cis-benchmark/charts/Chart.yaml
+++ b/packages/rancher-cis-benchmark/charts/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: v1.0.3
 description: The cis-operator enables running CIS benchmark security scans on a kubernetes cluster
 name: rancher-cis-benchmark
-version: 1.0.3
+version: 1.0.4
 icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
 keywords:
   - security

--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -37,7 +37,7 @@ global:
     clusterName: ""
   kubectl:
     repository: rancher/kubectl
-    tag: v1.18.6
+    tag: v1.20.2
 
 alerts:
   enabled: false

--- a/packages/rancher-cis-benchmark/package.yaml
+++ b/packages/rancher-cis-benchmark/package.yaml
@@ -1,6 +1,6 @@
 url: local
-packageVersion: 01
-releaseCandidateVersion: 01
+packageVersion: 00
+releaseCandidateVersion: 00
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-gatekeeper/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-gatekeeper/generated-changes/patch/values.yaml.patch
@@ -32,4 +32,4 @@
 +    systemDefaultRegistry: ""
 +  kubectl:
 +    repository: rancher/kubectl
-+    tag: v1.18.6
++    tag: v1.20.2

--- a/packages/rancher-gatekeeper/package.yaml
+++ b/packages/rancher-gatekeeper/package.yaml
@@ -1,6 +1,6 @@
 url: https://open-policy-agent.github.io/gatekeeper/charts/gatekeeper-3.3.0.tgz
-packageVersion: 00
-releaseCandidateVersion: 02
+packageVersion: 01
+releaseCandidateVersion: 00
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-gatekeeper/templates/crd-template/values.yaml
+++ b/packages/rancher-gatekeeper/templates/crd-template/values.yaml
@@ -8,4 +8,4 @@ global:
 
 image:
   repository: rancher/kubectl
-  tag: v1.18.6
+  tag: v1.20.2

--- a/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -302,7 +302,7 @@
 +    systemDefaultRegistry: ""
 +  kubectl:
 +     repository: rancher/kubectl
-+     tag: v1.18.6
++     tag: v1.20.2
 +     pullPolicy: IfNotPresent
    rbac:
 +    ## Create RBAC resources for ServiceAccounts and users 
@@ -462,7 +462,7 @@
 +    #
 +    image:
 +      repository: rancher/rancher-agent
-+      tag: v2.4.8
++      tag: v2.5.7
 +      pullPolicy: IfNotPresent
 +
 +    securityContext:

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-9.4.2/kube-prometheus-stack-9.4.2.tgz
 packageVersion: 04
-releaseCandidateVersion: 04
+releaseCandidateVersion: 05
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-monitoring/templates/crd-template/values.yaml
+++ b/packages/rancher-monitoring/templates/crd-template/values.yaml
@@ -8,4 +8,4 @@ global:
 
 image:
   repository: rancher/kubectl
-  tag: v1.18.6
+  tag: v1.20.2


### PR DESCRIPTION
Bumps images to the latest available today.

Modifies rancher-monitoring, rancher-gatekeeper, and rancher-cis-benchmark.

Related Issue: https://github.com/rancher/rancher/issues/31729