### PR TITLE
Add liveness probe to fluentd

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
@@ -52,4 +52,7 @@ spec:
     {{- with .Values.fluentd.resources }}
     resources: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
@@ -53,4 +53,7 @@ spec:
     {{- with .Values.fluentd.resources }}
     resources: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
@@ -52,4 +52,7 @@ spec:
     {{- with .Values.fluentd.resources }}
     resources: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -62,4 +62,7 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -62,4 +62,7 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -67,4 +67,7 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
@@ -69,3 +69,6 @@ spec:
     resources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,7 @@
  rbac:
    enabled: true
    psp:
-@@ -80,3 +88,64 @@
+@@ -80,3 +88,69 @@
      additionalLabels: {}
      metricRelabelings: []
      relabelings: []
@@ -79,6 +79,11 @@
 +# enabled in "additionalLoggingSources". Changing these affects every Logging CR installed.
 +fluentd:
 +  resources: {}
++  livenessProbe:
++    tcpSocket:
++      port: 24240
++    initialDelaySeconds: 30
++    periodSeconds: 15
 +fluentbit:
 +  resources: {}
 +  tolerations:

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.0.tgz
 packageVersion: 02
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Fluentd process can silently die, leaving the container running.  Have added a liveness probe to check that the Fluentd port is open and listening

Fixes #1043 