### PR TITLE
Add rancher version constraint to HAproxy chart

### DIFF
--- a/charts/haproxy/v1.1.4/questions.yml
+++ b/charts/haproxy/v1.1.4/questions.yml
@@ -1,4 +1,4 @@
-rancher_max_version: 2.5.6
+rancher_max_version: 2.5.7
 categories:
 - Ingress
 - Proxy

--- a/charts/haproxy/v1.1.4/questions.yml
+++ b/charts/haproxy/v1.1.4/questions.yml
@@ -1,3 +1,4 @@
+rancher_max_version: 2.5.6
 categories:
 - Ingress
 - Proxy

--- a/charts/haproxy/v1.4.2/questions.yml
+++ b/charts/haproxy/v1.4.2/questions.yml
@@ -1,4 +1,4 @@
-rancher_max_version: 2.5.6
+rancher_max_version: 2.5.7
 categories:
 - Ingress
 - Proxy

--- a/charts/haproxy/v1.4.2/questions.yml
+++ b/charts/haproxy/v1.4.2/questions.yml
@@ -1,3 +1,4 @@
+rancher_max_version: 2.5.6
 categories:
 - Ingress
 - Proxy


### PR DESCRIPTION
To ensure these charts are not used in newer releases of Rancher in favour of the updated “Partner Charts”