### PR TITLE
Add kubelet and node-exporter pushprox

### DIFF
--- a/packages/rancher-monitoring/generated-changes/dependencies/hardenedKubelet/dependency.yaml
+++ b/packages/rancher-monitoring/generated-changes/dependencies/hardenedKubelet/dependency.yaml
@@ -1,0 +1,2 @@
+workingDir: ""
+url: packages/rancher-pushprox

--- a/packages/rancher-monitoring/generated-changes/dependencies/hardenedNodeExporter/dependency.yaml
+++ b/packages/rancher-monitoring/generated-changes/dependencies/hardenedNodeExporter/dependency.yaml
@@ -1,0 +1,2 @@
+workingDir: ""
+url: packages/rancher-pushprox

--- a/packages/rancher-monitoring/generated-changes/dependencies/k3sWorker/dependency.yaml
+++ b/packages/rancher-monitoring/generated-changes/dependencies/k3sWorker/dependency.yaml
@@ -1,0 +1,2 @@
+workingDir: ""
+url: packages/rancher-pushprox

--- a/packages/rancher-monitoring/generated-changes/patch/requirements.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/requirements.yaml.patch
@@ -1,0 +1,11 @@
+--- charts-original/requirements.yaml
++++ charts/requirements.yaml
+@@ -18,7 +18,7 @@
+ - name: hardenedNodeExporter
+   version: ""
+   repository: file://./charts/hardenedNodeExporter
+-  condition: hardenedNodeExporter.enabled
++  condition: nodeExporter.enabled
+   tags: []
+   enabled: false
+   importvalues: []

--- a/packages/rancher-monitoring/generated-changes/patch/templates/exporters/node-exporter/servicemonitor.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/templates/exporters/node-exporter/servicemonitor.yaml.patch
@@ -1,0 +1,8 @@
+--- charts-original/templates/exporters/node-exporter/servicemonitor.yaml
++++ charts/templates/exporters/node-exporter/servicemonitor.yaml
+@@ -1,4 +1,4 @@
+-{{- if .Values.nodeExporter.enabled }}
++{{- if (and .Values.nodeExporter.enabled .Values.nodeExporter.serviceMonitor.enabled) }}
+ apiVersion: monitoring.coreos.com/v1
+ kind: ServiceMonitor
+ metadata:

--- a/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/values.yaml
 +++ charts/values.yaml
-@@ -2,13 +2,291 @@
+@@ -2,13 +2,331 @@
  # This is a YAML-formatted file.
  # Declare variables to be passed into your templates.
  
@@ -106,6 +106,19 @@
 +  component: k3s-server
 +  clients:
 +    port: 10013
++    useLocalhost: true
++    tolerations:
++    - effect: "NoExecute"
++      operator: "Exists"
++    - effect: "NoSchedule"
++      operator: "Exists"
++
++k3sWorker:
++  enabled: false
++  metricsPort: 10250
++  component: k3s-worker
++  clients:
++    port: 10015
 +    useLocalhost: true
 +    tolerations:
 +    - effect: "NoExecute"
@@ -242,6 +255,33 @@
 +        key: node-role.kubernetes.io/master
 +        operator: "Equal"
 +
++hardenedKubelet:
++  enabled: false
++  metricsPort: 10250
++  component: kubelet
++  clients:
++    port: 10015
++    useLocalhost: true
++    tolerations:
++    - effect: "NoExecute"
++      operator: "Exists"
++    - effect: "NoSchedule"
++      operator: "Exists"
++
++## Enable prometheus node exporter pushprox for all distributions
++hardenedNodeExporter:
++  enabled: true
++  metricsPort: 9796
++  component: prometheus-node-exporter
++  clients:
++    port: 10016
++    useLocalhost: true
++  tolerations:
++    - effect: "NoExecute"
++      operator: "Exists"
++    - effect: "NoSchedule"
++      operator: "Exists"
++
 +## Component scraping nginx-ingress-controller
 +##
 +ingressNginx:
@@ -294,7 +334,7 @@
  
  ## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.16.6
  ##
-@@ -76,8 +354,23 @@
+@@ -76,8 +394,23 @@
  
  ##
  global:
@@ -318,7 +358,7 @@
      pspEnabled: true
      pspAnnotations: {}
        ## Specify pod annotations
-@@ -130,6 +423,22 @@
+@@ -130,6 +463,22 @@
    ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
    ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
    ##
@@ -341,7 +381,7 @@
    config:
      global:
        resolve_timeout: 5m
-@@ -145,6 +454,8 @@
+@@ -145,6 +494,8 @@
          receiver: 'null'
      receivers:
      - name: 'null'
@@ -350,7 +390,7 @@
  
    ## Pass the Alertmanager configuration directives through Helm's templating
    ## engine. If the Alertmanager configuration contains Alertmanager templates,
-@@ -160,25 +471,76 @@
+@@ -160,25 +511,76 @@
    ## ref: https://prometheus.io/docs/alerting/notifications/
    ##      https://prometheus.io/docs/alerting/notification_examples/
    ##
@@ -446,7 +486,7 @@
  
    ingress:
      enabled: false
-@@ -208,6 +570,25 @@
+@@ -208,6 +610,25 @@
    ## Configuration for Alertmanager secret
    ##
    secret:
@@ -472,7 +512,7 @@
      annotations: {}
  
    ## Configuration for creating an Ingress that will map to each Alertmanager replica service
-@@ -334,7 +715,7 @@
+@@ -334,7 +755,7 @@
      ## Image of Alertmanager
      ##
      image:
@@ -481,7 +521,7 @@
        tag: v0.21.0
        sha: ""
  
-@@ -410,9 +791,13 @@
+@@ -410,9 +831,13 @@
      ## Define resources requests and limits for single Pods.
      ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
      ##
@@ -498,7 +538,7 @@
  
      ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
      ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
-@@ -487,10 +872,43 @@
+@@ -487,6 +912,27 @@
    enabled: true
    namespaceOverride: ""
  
@@ -526,394 +566,3 @@
    ## Deploy default dashboards.
    ##
    defaultDashboardsEnabled: true
- 
-+  # Additional options for defaultDashboards
-+  defaultDashboards:
-+    # The default namespace to place defaultDashboards within
-+    namespace: cattle-dashboards
-+    # Whether to create the default namespace as a Helm managed namespace or use an existing namespace
-+    # If false, the defaultDashboards.namespace will be created as a Helm managed namespace
-+    useExistingNamespace: false
-+    # Whether the Helm managed namespace created by this chart should be left behind on a Helm uninstall
-+    # If you place other dashboards in this namespace, then they will be deleted on a helm uninstall
-+    # Ignore if useExistingNamespace is true
-+    cleanupOnUninstall: false
-+
-   adminPassword: prom-operator
- 
-   ingress:
-@@ -530,6 +948,7 @@
-     dashboards:
-       enabled: true
-       label: grafana_dashboard
-+      searchNamespace: cattle-dashboards
- 
-       ## Annotations for Grafana dashboard configmaps
-       ##
-@@ -574,7 +993,60 @@
-   ## Passed to grafana subchart and used by servicemonitor below
-   ##
-   service:
--    portName: service
-+    portName: nginx-http
-+    ## Port for Grafana Service to listen on
-+    ##
-+    port: 80
-+    ## To be used with a proxy extraContainer port
-+    ##
-+    targetPort: 8080
-+    ## Port to expose on each node
-+    ## Only used if service.type is 'NodePort'
-+    ##
-+    nodePort: 30950
-+    ## Service type
-+    ##
-+    type: ClusterIP
-+
-+  proxy:
-+    image:
-+      repository: rancher/mirrored-library-nginx
-+      tag: 1.19.2-alpine
-+  
-+  ## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
-+  extraContainers: |
-+    - name: grafana-proxy
-+      args:
-+      - nginx
-+      - -g
-+      - daemon off;
-+      - -c
-+      - /nginx/nginx.conf
-+      image: "{{ template "system_default_registry" . }}{{ .Values.proxy.image.repository }}:{{ .Values.proxy.image.tag }}"
-+      ports:
-+      - containerPort: 8080
-+        name: nginx-http
-+        protocol: TCP
-+      volumeMounts:
-+      - mountPath: /nginx
-+        name: grafana-nginx
-+      - mountPath: /var/cache/nginx
-+        name: nginx-home
-+      securityContext:
-+        runAsUser: 101
-+        runAsGroup: 101
-+
-+  ## Volumes that can be used in containers
-+  extraContainerVolumes:
-+    - name: nginx-home
-+      emptyDir: {}
-+    - name: grafana-nginx
-+      configMap:
-+        name: grafana-nginx-proxy-config
-+        items:
-+        - key: nginx.conf
-+          mode: 438
-+          path: nginx.conf
- 
-   ## If true, create a serviceMonitor for grafana
-   ##
-@@ -600,6 +1072,14 @@
-     #   targetLabel: nodename
-     #   replacement: $1
-     #   action: replace
-+  
-+  resources:
-+    limits:
-+      memory: 200Mi
-+      cpu: 200m
-+    requests:
-+      memory: 100Mi
-+      cpu: 100m
- 
- ## Component scraping the kube api server
- ##
-@@ -756,7 +1236,7 @@
- ## Component scraping the kube controller manager
- ##
- kubeControllerManager:
--  enabled: true
-+  enabled: false
- 
-   ## If your kube controller manager is not deployed as a pod, specify IPs it can be found on
-   ##
-@@ -889,7 +1369,7 @@
- ## Component scraping etcd
- ##
- kubeEtcd:
--  enabled: true
-+  enabled: false
- 
-   ## If your etcd is not deployed as a pod, specify IPs it can be found on
-   ##
-@@ -949,7 +1429,7 @@
- ## Component scraping kube scheduler
- ##
- kubeScheduler:
--  enabled: true
-+  enabled: false
- 
-   ## If your kube scheduler is not deployed as a pod, specify IPs it can be found on
-   ##
-@@ -1002,7 +1482,7 @@
- ## Component scraping kube proxy
- ##
- kubeProxy:
--  enabled: true
-+  enabled: false
- 
-   ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
-   ##
-@@ -1076,6 +1556,13 @@
-     create: true
-   podSecurityPolicy:
-     enabled: true
-+  resources:
-+    limits:
-+      cpu: 100m
-+      memory: 200Mi
-+    requests:
-+      cpu: 100m
-+      memory: 130Mi
- 
- ## Deploy node exporter as a daemonset to all nodes
- ##
-@@ -1125,6 +1612,16 @@
-   extraArgs:
-     - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
-     - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
-+  service:
-+    port: 9796
-+    targetPort: 9796
-+  resources:
-+    limits:
-+      cpu: 200m
-+      memory: 50Mi
-+    requests:
-+      cpu: 100m
-+      memory: 30Mi
- 
- ## Manages Prometheus and Alertmanager components
- ##
-@@ -1138,7 +1635,7 @@
-   tlsProxy:
-     enabled: true
-     image:
--      repository: squareup/ghostunnel
-+      repository: rancher/mirrored-squareup-ghostunnel
-       tag: v1.5.2
-       sha: ""
-       pullPolicy: IfNotPresent
-@@ -1156,7 +1653,7 @@
-     patch:
-       enabled: true
-       image:
--        repository: jettech/kube-webhook-certgen
-+        repository: rancher/mirrored-jettech-kube-webhook-certgen
-         tag: v1.2.1
-         sha: ""
-         pullPolicy: IfNotPresent
-@@ -1285,13 +1782,13 @@
- 
-   ## Resource limits & requests
-   ##
--  resources: {}
--  # limits:
--  #   cpu: 200m
--  #   memory: 200Mi
--  # requests:
--  #   cpu: 100m
--  #   memory: 100Mi
-+  resources:
-+    limits:
-+      cpu: 200m
-+      memory: 500Mi
-+    requests:
-+      cpu: 100m
-+      memory: 100Mi
- 
-   # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
-   # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
-@@ -1335,7 +1832,7 @@
-   ## Prometheus-operator image
-   ##
-   image:
--    repository: quay.io/coreos/prometheus-operator
-+    repository: rancher/mirrored-coreos-prometheus-operator
-     tag: v0.38.1
-     sha: ""
-     pullPolicy: IfNotPresent
-@@ -1343,14 +1840,14 @@
-   ## Configmap-reload image to use for reloading configmaps
-   ##
-   configmapReloadImage:
--    repository: docker.io/jimmidyson/configmap-reload
-+    repository: rancher/mirrored-jimmidyson-configmap-reload
-     tag: v0.3.0
-     sha: ""
- 
-   ## Prometheus-config-reloader image to use for config and rule reloading
-   ##
-   prometheusConfigReloaderImage:
--    repository: quay.io/coreos/prometheus-config-reloader
-+    repository: rancher/mirrored-coreos-prometheus-config-reloader
-     tag: v0.38.1
-     sha: ""
- 
-@@ -1366,14 +1863,6 @@
-   ##
-   secretFieldSelector: ""
- 
--  ## Hyperkube image to use when cleaning up
--  ##
--  hyperkubeImage:
--    repository: k8s.gcr.io/hyperkube
--    tag: v1.16.12
--    sha: ""
--    pullPolicy: IfNotPresent
--
- ## Deploy a Prometheus instance
- ##
- prometheus:
-@@ -1403,7 +1892,7 @@
-     port: 9090
- 
-     ## To be used with a proxy extraContainer port
--    targetPort: 9090
-+    targetPort: 8080
- 
-     ## List of IP addresses at which the Prometheus server service is available
-     ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-@@ -1614,7 +2103,7 @@
-     ## Image of Prometheus.
-     ##
-     image:
--      repository: quay.io/prometheus/prometheus
-+      repository: rancher/mirrored-prom-prometheus
-       tag: v2.18.2
-       sha: ""
- 
-@@ -1666,6 +2155,11 @@
-     ##
-     externalUrl: ""
- 
-+    ## Ignore NamespaceSelector settings from the PodMonitor and ServiceMonitor configs
-+    ## If true, PodMonitors and ServiceMonitors can only discover Pods and Services within the namespace they are deployed into
-+    ##
-+    ignoreNamespaceSelectors: false
-+
-     ## Define which Nodes the Pods are scheduled on.
-     ## ref: https://kubernetes.io/docs/user-guide/node-selection/
-     ##
-@@ -1698,7 +2192,7 @@
-     ## prometheus resource to be created with selectors based on values in the helm deployment,
-     ## which will also match the PrometheusRule resources created
-     ##
--    ruleSelectorNilUsesHelmValues: true
-+    ruleSelectorNilUsesHelmValues: false
- 
-     ## PrometheusRules to be selected for target discovery.
-     ## If {}, select all ServiceMonitors
-@@ -1723,7 +2217,7 @@
-     ## prometheus resource to be created with selectors based on values in the helm deployment,
-     ## which will also match the servicemonitors created
-     ##
--    serviceMonitorSelectorNilUsesHelmValues: true
-+    serviceMonitorSelectorNilUsesHelmValues: false
- 
-     ## ServiceMonitors to be selected for target discovery.
-     ## If {}, select all ServiceMonitors
-@@ -1743,7 +2237,7 @@
-     ## prometheus resource to be created with selectors based on values in the helm deployment,
-     ## which will also match the podmonitors created
-     ##
--    podMonitorSelectorNilUsesHelmValues: true
-+    podMonitorSelectorNilUsesHelmValues: false
- 
-     ## PodMonitors to be selected for target discovery.
-     ## If {}, select all PodMonitors
-@@ -1840,9 +2334,13 @@
- 
-     ## Resource limits & requests
-     ##
--    resources: {}
--    # requests:
--    #   memory: 400Mi
-+    resources:
-+      limits:
-+        memory: 1500Mi
-+        cpu: 1000m
-+      requests:
-+        memory: 750Mi
-+        cpu: 750m
- 
-     ## Prometheus StorageSpec for persistent data
-     ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md
-@@ -1857,11 +2355,6 @@
-     #          storage: 50Gi
-     #    selector: {}
- 
--    # Additional volumes on the output StatefulSet definition.
--    volumes: []
--    # Additional VolumeMounts on the output StatefulSet definition.
--    volumeMounts: []
--
-     ## AdditionalScrapeConfigs allows specifying additional Prometheus scrape configurations. Scrape configurations
-     ## are appended to the configurations generated by the Prometheus Operator. Job configurations must have the form
-     ## as specified in the official Prometheus documentation:
-@@ -1964,9 +2457,46 @@
-     ##
-     thanos: {}
- 
-+    proxy:
-+      image:
-+        repository: rancher/mirrored-library-nginx
-+        tag: 1.19.2-alpine
-+
-     ## Containers allows injecting additional containers. This is meant to allow adding an authentication proxy to a Prometheus pod.
-     ##  if using proxy extraContainer  update targetPort with proxy container port
--    containers: []
-+    containers: |
-+      - name: prometheus-proxy
-+        args:
-+        - nginx
-+        - -g
-+        - daemon off;
-+        - -c
-+        - /nginx/nginx.conf
-+        image: "{{ template "system_default_registry" . }}{{ .Values.prometheus.prometheusSpec.proxy.image.repository }}:{{ .Values.prometheus.prometheusSpec.proxy.image.tag }}"
-+        ports:
-+        - containerPort: 8080
-+          name: nginx-http
-+          protocol: TCP
-+        volumeMounts:
-+        - mountPath: /nginx
-+          name: prometheus-nginx
-+        - mountPath: /var/cache/nginx
-+          name: nginx-home
-+        securityContext:
-+          runAsUser: 101
-+          runAsGroup: 101
-+
-+    # Additional volumes on the output StatefulSet definition.
-+    volumes: 
-+      - name: nginx-home
-+        emptyDir: {}
-+      - name: prometheus-nginx
-+        configMap:
-+          name: prometheus-nginx-proxy-config
-+          defaultMode: 438
-+
-+    # Additional VolumeMounts on the output StatefulSet definition.
-+    volumeMounts: []
- 
-     ## InitContainers allows injecting additional initContainers. This is meant to allow doing some changes
-     ## (permissions, dir tree) on mounted volumes before starting prometheus
-@@ -1974,7 +2504,7 @@
- 
-     ## PortName to use for Prometheus.
-     ##
--    portName: "web"
-+    portName: "nginx-http"
- 
-   additionalServiceMonitors: []
-   ## Name of the ServiceMonitor to create

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -1,6 +1,6 @@
 url: https://github.com/prometheus-community/helm-charts/releases/download/kube-prometheus-stack-9.4.2/kube-prometheus-stack-9.4.2.tgz
 packageVersion: 04
-releaseCandidateVersion: 09
+releaseCandidateVersion: 10
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Fixes #1051 

Adds a pushprox for the kubelet and for node-exporter which runs on the host network.

Kubelet ServiceMonitor is still enabled by default, will disable it using values in the dashboard after this is merged.  The node-exporter ServiceMonitor is disabled, and the node-exporter pushprox is enabled by default.