### PR TITLE
Add workflows to keep dev-v2.6 in sync

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -16,7 +16,7 @@ jobs:
         run: sudo make pull-scripts
 
       - name: Pull in all relevant branches
-        run: git fetch origin dev-v2.5-source dev-v2.5 release-v2.5
+        run: git fetch origin dev-v2.5-source dev-v2.5 release-v2.5 dev-v2.6 release-v2.6
       
       - name: Validate 
         run: sudo make validate

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,7 @@ jobs:
       run: sudo make pull-scripts
 
     - name: Pull in all relevant branches
-      run: git fetch origin dev-v2.5-source dev-v2.5 release-v2.5
+      run: git fetch origin dev-v2.5-source dev-v2.5 release-v2.5 dev-v2.6 release-v2.6
 
     - name: Checkout staging branch
       run: git checkout dev-v2.5
@@ -28,3 +28,15 @@ jobs:
 
     - name: Push assets
       run: git push origin dev-v2.5
+
+    - name: (temporary) Checkout staging branch
+      run: git checkout dev-v2.6
+
+    - name: (temporary) Synchronize
+      run: sudo make sync
+      
+    - name: (temporary) Add assets to branch
+      run: git add . && git -c user.name="actions" -c user.email="actions@github.com" commit -m "$(git log -b dev-v2.5-source --oneline -n1 --pretty=format:'%B')" || true
+
+    - name: (temporary) Push assets
+      run: git push origin dev-v2.6

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -6,3 +6,8 @@ validate:
 - url: https://github.com/rancher/charts.git
   branch: release-v2.5
   dropReleaseCandidates: true
+- url: https://github.com/rancher/charts.git
+  branch: dev-v2.6
+- url: https://github.com/rancher/charts.git
+  branch: release-v2.6
+  dropReleaseCandidates: true


### PR DESCRIPTION
Temporarily modifies our PR workflows to validate that we aren't corrupting changes in the dev-v2.6 branch and modifies our push workflow to also trigger a make sync on dev-v2.6, which will absorb changes from dev-v2.5-source pending https://github.com/rancher/charts/pull/1068.