### PR TITLE
Keep dev-v2.6 in sync with dev-v2.5-source

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -3,6 +3,8 @@ template: staging
 sync:
 - url: https://github.com/rancher/charts.git
   branch: dev-v2.6-source
+- url: https://github.com/rancher/charts.git
+  branch: dev-v2.5-source
 validate:
 - url: https://github.com/rancher/charts.git
   branch: release-v2.6


### PR DESCRIPTION
Allows https://github.com/rancher/charts/pull/1067 to run `make sync` to keep dev-v2.6 in sync with both dev-v2.5 and dev-v2.6