### PR TITLE
Fix Github Push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -15,7 +15,7 @@ jobs:
       run: sudo make pull-scripts
 
     - name: Pull in all relevant branches
-      run: git fetch origin dev-v2.5-source dev-v2.5 release-v2.5 dev-v2.6 release-v2.6
+      run: git fetch origin dev-v2.5-source dev-v2.5
 
     - name: Checkout staging branch
       run: git checkout dev-v2.5
@@ -28,6 +28,15 @@ jobs:
 
     - name: Push assets
       run: git push origin dev-v2.5
+
+    - name: (temporary) Clean up Git
+      run: git checkout -- .; git clean -xdf
+
+    - name: (temporary) Pull scripts
+      run: sudo make pull-scripts
+
+    - name: (temporary) Pull in all relevant branches
+      run: git fetch origin dev-v2.6-source dev-v2.6
 
     - name: (temporary) Checkout staging branch
       run: git checkout dev-v2.6


### PR DESCRIPTION
Fixes issues that require restarts due to unclean Git as a result of adding the 2.6 steps by just cleaning up Git entirely before running the 2.6 synchronization.