### PR TITLE
Kiali v1.32.0

### DIFF
--- a/packages/rancher-istio-1.8/charts/Chart.yaml
+++ b/packages/rancher-istio-1.8/charts/Chart.yaml
@@ -13,7 +13,7 @@ annotations:
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.29.100-rc01
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.32.100-rc01
   catalog.cattle.io/display-name: "Istio"
   catalog.cattle.io/os: linux
   catalog.cattle.io/requests-cpu: "710m"

--- a/packages/rancher-istio-1.8/charts/values.yaml
+++ b/packages/rancher-istio-1.8/charts/values.yaml
@@ -76,7 +76,7 @@ kiali:
   deployment:
     ingress_enabled: false
     repository: rancher/mirrored-kiali-kiali
-    tag: v1.29.0
+    tag: v1.32.0
   external_services:
     prometheus:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"

--- a/packages/rancher-istio-1.8/package.yaml
+++ b/packages/rancher-istio-1.8/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02

--- a/packages/rancher-istio-1.9/charts/Chart.yaml
+++ b/packages/rancher-istio-1.9/charts/Chart.yaml
@@ -13,7 +13,7 @@ annotations:
   catalog.cattle.io/release-name: rancher-istio
   catalog.cattle.io/ui-component: istio
   catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
-  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.29.100-rc01
+  catalog.cattle.io/auto-install: rancher-kiali-server-crd=1.32.100-rc01
   catalog.cattle.io/display-name: "Istio"
   catalog.cattle.io/os: linux
   catalog.cattle.io/requests-cpu: "710m"

--- a/packages/rancher-istio-1.9/charts/values.yaml
+++ b/packages/rancher-istio-1.9/charts/values.yaml
@@ -76,7 +76,7 @@ kiali:
   deployment:
     ingress_enabled: false
     repository: rancher/mirrored-kiali-kiali
-    tag: v1.29.0
+    tag: v1.32.0
   external_services:
     prometheus:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"

--- a/packages/rancher-istio-1.9/package.yaml
+++ b/packages/rancher-istio-1.9/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02

--- a/packages/rancher-kiali-server/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-kiali-server/generated-changes/patch/Chart.yaml.patch
@@ -2,7 +2,7 @@
 +++ charts/Chart.yaml
 @@ -1,20 +1,29 @@
  apiVersion: v2
- appVersion: v1.29.0
+ appVersion: v1.32.0
 -description: Kiali is an open source project for service mesh observability, refer
 -  to https://www.kiali.io for details.
 +description: Kiali is an open source project for service mesh observability, refer to https://www.kiali.io for details. This is installed as sub-chart with customized values in Rancher's Istio.
@@ -24,8 +24,8 @@
  - https://github.com/kiali/kiali-ui
  - https://github.com/kiali/kiali-operator
  - https://github.com/kiali/helm-charts
--version: 1.29.0
-+version: 1.29.1
+-version: 1.32.0
++version: 1.32.1
 +annotations:
 +  catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
 +  catalog.rancher.io/namespace: cattle-istio-system

--- a/packages/rancher-kiali-server/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-kiali-server/generated-changes/patch/values.yaml.patch
@@ -18,8 +18,8 @@
 +  repository: rancher/mirrored-kiali-kiali
    image_pull_policy: "Always"
    image_pull_secrets: []
--  image_version: v1.29.0
-+  tag: v1.29.0
+-  image_version: v1.32.0
++  tag: v1.32.0
    ingress_enabled: true
    logger:
      log_format: "text"

--- a/packages/rancher-kiali-server/package.yaml
+++ b/packages/rancher-kiali-server/package.yaml
@@ -1,4 +1,4 @@
-url: https://kiali.org/helm-charts/kiali-server-1.29.0.tgz
+url: https://kiali.org/helm-charts/kiali-server-1.32.0.tgz
 packageVersion: 00
 releaseCandidateVersion: 01
 additionalCharts:

--- a/packages/rancher-kiali-server/templates/crd-template/Chart.yaml
+++ b/packages/rancher-kiali-server/templates/crd-template/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.29.1
+version: 1.32.1
 description: Installs the CRDs for rancher-kiali-server.
 name: rancher-kiali-server-crd
 type: application


### PR DESCRIPTION
**Problem**
Warning is showing up in logs with ```Warning: CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+```. This was resolved upstream here: https://github.com/kiali/helm-charts/pull/35

**Solution**
Update Kiali to the most recent v1.32.0 version that has a fix for the crd api. The fix was implemented starting in version 1.29.1, but am going with the most recent because it contains the fix along with newer features. Kiali version >=v1.26 is compatible with Istio 1.8 and 1.9 (https://kiali.io/documentation/latest/installation-guide/#_version_compatibility) 

**Issues**
https://github.com/rancher/rancher/issues/31979
https://github.com/rancher/rancher/issues/31514