### PR TITLE
[DNM v2.5.9/v2.6] Add additional config options for fluentd

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
@@ -31,6 +31,10 @@ spec:
     resources: {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -43,10 +47,10 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
@@ -54,5 +58,11 @@ spec:
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
@@ -32,6 +32,10 @@ spec:
     resources: {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -44,10 +48,10 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
@@ -56,4 +60,10 @@ spec:
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }} 
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
@@ -31,6 +31,10 @@ spec:
     resources: {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -43,10 +47,10 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
@@ -54,5 +58,11 @@ spec:
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -38,6 +38,10 @@ spec:
       {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -50,11 +54,11 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -64,5 +68,11 @@ spec:
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -38,6 +38,10 @@ spec:
       {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -50,11 +54,11 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -65,4 +69,10 @@ spec:
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }} 
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -43,6 +43,10 @@ spec:
       {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -55,11 +59,11 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -69,5 +73,11 @@ spec:
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
@@ -82,6 +82,10 @@ spec:
       {{- toYaml . | nindent 6 }}
   {{- end }}
   fluentd:
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
       tag: {{ .Values.images.fluentd.tag }}
@@ -94,11 +98,11 @@ spec:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
@@ -108,4 +112,10 @@ spec:
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- end }}

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,7 @@
  rbac:
    enabled: true
    psp:
-@@ -85,3 +93,77 @@
+@@ -85,3 +93,80 @@
      additionalLabels: {}
      metricRelabelings: []
      relabelings: []
@@ -90,6 +90,9 @@
 +      port: 24240
 +    initialDelaySeconds: 30
 +    periodSeconds: 15
++  nodeSelector: {}
++  tolerations: {}
++  bufferStorageVolume: {}
 +fluentbit:
 +  resources: {}
 +  tolerations:

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.4.tgz
-packageVersion: 00
-releaseCandidateVersion: 03
+packageVersion: 01
+releaseCandidateVersion: 00
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
This change should meet the requirements for https://github.com/rancher/rancher/issues/31807

The replicas setting may be one worth plumbing through to the UI, but I haven't done this yet.

For tolerations and nodeSelectors, fluentd will use the chart wide settings unless overridden with fluent specific settings.