### PR TITLE
fixed journald aggregation for rke2

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/configmap.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/configmap.yaml
@@ -10,7 +10,8 @@ data:
     [INPUT]
         Name              systemd
         Tag               rke2
-        Systemd_Filter    _SYSTEMD_UNIT=rke2.service
+        Path              {{ .Values.systemdLogPath | default "/var/log/journal" }}
+        Systemd_Filter    _SYSTEMD_UNIT=rke2-server.service
 
     [OUTPUT]
         Name              forward

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
@@ -26,8 +26,11 @@ spec:
           volumeMounts:
             - mountPath: /fluent-bit/etc/
               name: config
-            - mountPath: /run/log/journal
+            - mountPath: {{ .Values.systemdLogPath | default "/var/log/journal" }}
               name: journal
+              readOnly: true
+            - mountPath: /etc/machine-id
+              name: machine-id
               readOnly: true
       {{- with .Values.tolerations }}
       tolerations:
@@ -44,7 +47,10 @@ spec:
             name: "{{ .Release.Name }}-rke2"
         - name: journal
           hostPath:
-            path: /run/log/journal
+            path: {{ .Values.systemdLogPath | default "/var/log/journal" }}
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,12 +36,14 @@
  rbac:
    enabled: true
    psp:
-@@ -85,3 +93,77 @@
+@@ -85,3 +93,79 @@
      additionalLabels: {}
      metricRelabelings: []
      relabelings: []
 +
 +disablePvc: true
++
++systemdLogPath: "/var/log/journal"
 +
 +additionalLoggingSources:
 +  rke:

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.4.tgz
 packageVersion: 00
-releaseCandidateVersion: 03
+releaseCandidateVersion: 04
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
PROBLEM:
we were not getting any of the rke2 systemd logs

SOLUTION:
fluentbit's journald plugin needs the machine id to work correctly

TESTING:
installed logging on an rke2 cluster and was able to get this log message

```
{"_MACHINE_ID":"59e806f5bba74a5d8addb46a60a7ce78","PRIORITY":"6","SYSLOG_FACILITY":"3","_UID":"0","_GID":"0","_SELINUX_CONTEXT":"unconfined\n","_SYSTEMD_SLICE":"system.slice","_TRANSPORT":"stdout","_CAP_EFFECTIVE":"3fffffffff","_HOSTNAME":"jpayne-rke2","SYSLOG_IDENTIFIER":"rke2","_COMM":"rke2","_EXE":"/usr/local/bin/rke2","_SYSTEMD_CGROUP":"/system.slice/rke2-server.service","_SYSTEMD_UNIT":"rke2-server.service","_CMDLINE":"/usr/local/bin/rke2 server","_BOOT_ID":"caa7ced9023945a482a7e0bb726c1dbf","_STREAM_ID":"837d3787b0f548fc9cc3f633c08b988f","_PID":"15517","_SYSTEMD_INVOCATION_ID":"0db756f3fcc44b13902c01badc67e7b8","MESSAGE":"I0412 19:10:13.724172   15517 controllermanager.go:238] Started \"cloud-node-lifecycle\""}
```