### PR TITLE
Use a different prefix for Rancher dashboards than the Chart name

### DIFF
--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/default-dashboard.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/default-dashboard.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Values.grafana.defaultDashboards.namespace }}
-  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) "home" | trunc 63 | trimSuffix "-" }}
+  name: rancher-default-dashboards-home
   annotations:
 {{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
   labels:

--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/etcd-dashboards.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/etcd-dashboards.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Values.grafana.defaultDashboards.namespace }}
-  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) "etcd" | trunc 63 | trimSuffix "-" }}
+  name: rancher-default-dashboards-etcd
   annotations:
 {{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
   labels:

--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/k8s-dashboards.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/k8s-dashboards.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Values.grafana.defaultDashboards.namespace }}
-  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) "k8s" | trunc 63 | trimSuffix "-" }}
+  name: rancher-default-dashboards-k8s
   annotations:
 {{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
   labels:

--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/linux-dashboards.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/linux-dashboards.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Values.grafana.defaultDashboards.namespace }}
-  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) "linux" | trunc 63 | trimSuffix "-" }}
+  name: rancher-default-dashboards-linux
   annotations:
 {{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
   labels:

--- a/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/windows-dashboards.yaml
+++ b/packages/rancher-monitoring/generated-changes/overlay/templates/rancher-monitoring/dashboards/rancher/windows-dashboards.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   namespace: {{ .Values.grafana.defaultDashboards.namespace }}
-  name: {{ printf "%s-%s" (include "kube-prometheus-stack.fullname" $) "windows" | trunc 63 | trimSuffix "-" }}
+  name: rancher-default-dashboards-windows
   annotations:
 {{ toYaml .Values.grafana.sidecar.dashboards.annotations | indent 4 }}
   labels:

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -2,7 +2,7 @@ url: https://github.com/prometheus-community/helm-charts.git
 subdirectory: charts/kube-prometheus-stack
 commit: 3ca6ba66032a1efce0500f9ad6f83351ad0604b8
 packageVersion: 00
-releaseCandidateVersion: 06
+releaseCandidateVersion: 07
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Currently, we prefix dashboards based on logic similar to `{{ .Chart.Name }}-<dashboard>`.

However, when Grafana has a default dashboard with the same name as Rancher, the name becomes the same, which results in a conflict, re: https://github.com/rancher/rancher/issues/32024#issuecomment-818312832

While one solution for this would be to just ensure there is no overlap between the dashboard ConfigMap names chosen by Rancher and Grafana, an easier fix seems to be just to change the naming prefix of dashboards that are deployed by default by Rancher instead.

Therefore, we can have a `rancher-monitoring-etcd` deployed by default with Grafana as well as a `rancher-default-dashboards-etcd` to keep the name etcd but avoid conflict.

Related Issue: https://github.com/rancher/rancher/issues/32024