### PR TITLE
[rancher-alerting-drivers] configmap-reloader and PSP

### DIFF
--- a/packages/rancher-alerting-drivers/charts/Chart.yaml
+++ b/packages/rancher-alerting-drivers/charts/Chart.yaml
@@ -2,7 +2,7 @@ name: rancher-alerting-drivers
 home: ""
 sources: []
 version: 1.0.1
-description: The manager for third-party webhook receivers used in the Alertmanger
+description: The manager for third-party webhook receivers used in Prometheus Alertmanager
 keywords:
 - monitoring
 - alertmanger

--- a/packages/rancher-alerting-drivers/package.yaml
+++ b/packages/rancher-alerting-drivers/package.yaml
@@ -1,3 +1,3 @@
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02
 url: local

--- a/packages/rancher-prom2teams/generated-changes/overlay/templates/psp.yaml
+++ b/packages/rancher-prom2teams/generated-changes/overlay/templates/psp.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "prom2teams.fullname" . }}-psp
+  labels: {{ include "prom2teams.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'configMap'

--- a/packages/rancher-prom2teams/generated-changes/overlay/templates/role.yaml
+++ b/packages/rancher-prom2teams/generated-changes/overlay/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "prom2teams.fullname" . }}-psp
+  namespace: {{ include "prom2teams.namespace" . }}
+  labels: {{ include "prom2teams.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - {{ include "prom2teams.fullname" . }}-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/packages/rancher-prom2teams/generated-changes/overlay/templates/rolebinding.yaml
+++ b/packages/rancher-prom2teams/generated-changes/overlay/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "prom2teams.fullname" . }}-psp
+  namespace: {{ include "prom2teams.namespace" . }}
+  labels: {{ include "prom2teams.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prom2teams.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prom2teams.fullname" . }}

--- a/packages/rancher-prom2teams/package.yaml
+++ b/packages/rancher-prom2teams/package.yaml
@@ -2,4 +2,4 @@ url: https://github.com/idealista/prom2teams.git
 subdirectory: helm
 commit: 29710102acb7748dc93cc1e827d2f5b8aa506206 # the commit points to the tag 3.2.1
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02

--- a/packages/rancher-sachet/charts/templates/deployment.yaml
+++ b/packages/rancher-sachet/charts/templates/deployment.yaml
@@ -56,6 +56,18 @@ spec:
           {{- with .Values.resources }}
           resources: {{ toYaml .Values.resources | nindent 12 }}
           {{- end }}
+        - name: config-reloader
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
+          image: {{ include "system_default_registry" . }}{{ .Values.configReloader.repository }}:{{ .Values.configReloader.tag }}
+          imagePullPolicy: {{ .Values.configReloader.pullPolicy }}
+          args:
+            - -volume-dir=/watch-config
+            - -webhook-method=POST
+            - -webhook-status-code=200
+            - -webhook-url=http://127.0.0.1:{{ .Values.service.port }}/-/reload
+          volumeMounts:
+            - mountPath: /watch-config
+              name: config-volume
       volumes:
         - name: config-volume
           configMap:

--- a/packages/rancher-sachet/charts/templates/psp.yaml
+++ b/packages/rancher-sachet/charts/templates/psp.yaml
@@ -1,0 +1,28 @@
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "sachet.fullname" . }}-psp
+  labels: {{ include "sachet.labels" . | nindent 4 }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'configMap'

--- a/packages/rancher-sachet/charts/templates/role.yaml
+++ b/packages/rancher-sachet/charts/templates/role.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "sachet.fullname" . }}-psp
+  namespace: {{ include "sachet.namespace" . }}
+  labels: {{ include "sachet.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - policy
+    resourceNames:
+      - {{ include "sachet.fullname" . }}-psp
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use

--- a/packages/rancher-sachet/charts/templates/rolebinding.yaml
+++ b/packages/rancher-sachet/charts/templates/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "sachet.fullname" . }}-psp
+  namespace: {{ include "sachet.namespace" . }}
+  labels: {{ include "sachet.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "sachet.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "sachet.fullname" . }}

--- a/packages/rancher-sachet/charts/values.yaml
+++ b/packages/rancher-sachet/charts/values.yaml
@@ -10,6 +10,11 @@ global:
 nameOverride: "sachet"
 fullnameOverride: ""
 
+configReloader:
+  repository: rancher/mirrored-jimmidyson-configmap-reload
+  pullPolicy: IfNotPresent
+  tag: v0.4.0
+
 sachet:
   # reference: https://github.com/messagebird/sachet/blob/master/examples/config.yaml
   providers: {}

--- a/packages/rancher-sachet/package.yaml
+++ b/packages/rancher-sachet/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02


### PR DESCRIPTION
This PR contains the following changes:
- add supports for reloading the configMap in rancher-sachet
- add supports for pod security policy in rancher-sachet and rancher-prom2teams

related PR: https://github.com/rancher/charts/pull/1085
related issue: https://github.com/rancher/rancher/issues/29951