### PR TITLE
Match backup crd version to primary chart with 1.0.4-rc3

### DIFF
--- a/packages/rancher-backup-crd/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-backup-crd/generated-changes/patch/Chart.yaml.patch
@@ -4,10 +4,10 @@
    catalog.cattle.io/namespace: cattle-resources-system
    catalog.cattle.io/release-name: rancher-backup-crd
  apiVersion: v2
--appVersion: 1.0.4-rc2
+-appVersion: 1.0.4-rc3
 +appVersion: 1.0.4
  description: Installs the CRDs for rancher-backup.
  name: rancher-backup-crd
  type: application
--version: 1.0.4-rc2
+-version: 1.0.4-rc3
 +version: 1.0.4

--- a/packages/rancher-backup-crd/package.yaml
+++ b/packages/rancher-backup-crd/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/rancher/backup-restore-operator/releases/download/v1.0.4-rc2/rancher-backup-crd-1.0.4-rc2.tgz
+url: https://github.com/rancher/backup-restore-operator/releases/download/v1.0.4-rc3/rancher-backup-crd-1.0.4-rc3.tgz
 packageVersion: 00
-releaseCandidateVersion: 02
+releaseCandidateVersion: 03


### PR DESCRIPTION
Relevant issue: https://github.com/rancher/rancher/issues/32152

Appears that we accidentally missed the CRD chart here: https://github.com/rancher/charts/pull/1082