### PR TITLE
[2.5]  run fluentbit as a privileged container

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
@@ -20,6 +20,7 @@ spec:
           image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}:{{ .Values.images.fluentbit.tag }}"
           {{- if .Values.global.seLinux.enabled }}
           securityContext:
+            privileged: true
             seLinuxOptions:
               type: rke_logreader_t
           {{- end }}

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.4.tgz
 packageVersion: 00
-releaseCandidateVersion: 04
+releaseCandidateVersion: 05
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/31309

PROBLEM:
fluentbit did not display any errors when deployed on a centos cluster.  The systemd logs would never be delivered to the output.

SOLUTION:
run the fluentbit container as a privileged container.

TESTING:
I modified the running qa instance that discovered the bug and systemd logs were immediately delivered after the change was applied.