### PR TITLE
fix the issue where the configmap is missing when upgrading rancher-alerting-drives to enable a new driver

### DIFF
--- a/packages/rancher-alerting-drivers/package.yaml
+++ b/packages/rancher-alerting-drivers/package.yaml
@@ -1,3 +1,3 @@
 packageVersion: 00
-releaseCandidateVersion: 02
+releaseCandidateVersion: 03
 url: local

--- a/packages/rancher-prom2teams/generated-changes/patch/templates/configmap.yaml.patch
+++ b/packages/rancher-prom2teams/generated-changes/patch/templates/configmap.yaml.patch
@@ -20,7 +20,7 @@
 +  name: {{ include "prom2teams.fullname" . }}
 +  labels: {{ include "prom2teams.labels" . | nindent 4 }}
 +  annotations:
-+    "helm.sh/hook": pre-install
++    "helm.sh/hook": pre-install, pre-upgrade
 +    "helm.sh/hook-weight": "3"
 +    "helm.sh/resource-policy": keep
  data:

--- a/packages/rancher-prom2teams/package.yaml
+++ b/packages/rancher-prom2teams/package.yaml
@@ -2,4 +2,4 @@ url: https://github.com/idealista/prom2teams.git
 subdirectory: helm
 commit: 29710102acb7748dc93cc1e827d2f5b8aa506206 # the commit points to the tag 3.2.1
 packageVersion: 00
-releaseCandidateVersion: 02
+releaseCandidateVersion: 03

--- a/packages/rancher-sachet/charts/templates/configmap-pre-install.yaml
+++ b/packages/rancher-sachet/charts/templates/configmap-pre-install.yaml
@@ -7,7 +7,7 @@ metadata:
   name: {{ include "sachet.fullname" . }}
   labels: {{ include "sachet.labels" . | nindent 4 }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install, pre-upgrade
     "helm.sh/hook-weight": "3"
     "helm.sh/resource-policy": keep
 data:

--- a/packages/rancher-sachet/package.yaml
+++ b/packages/rancher-sachet/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 02
+releaseCandidateVersion: 03


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/32249


Problem:
If we enable a new driver when doing a helm upgrade, the new configMap will not be created because configmaps are created only when a `helm install` happens. 

Fix:
Create the configmaps if it is missing when a `helm upgrade` happens. 