### PR TITLE
Change the tracing url for kiali

### DIFF
--- a/packages/rancher-istio-1.8/charts/README.md
+++ b/packages/rancher-istio-1.8/charts/README.md
@@ -20,7 +20,7 @@ If you remove dependent CRD charts prior to removing rancher-istio, you may enco
 
 Kiali allows you to view and manage your istio-based service mesh through an easy to use dashboard.
 
-####  Dependencies
+###  Dependencies
 - rancher-monitoring chart or other Prometheus installation
 
 This dependecy installs the required CRDs for installing Kiali. Since Kiali is bundled in with Istio in this chart, if you do not have these dependencies installed, your Istio installation will fail. If you do not plan on using Kiali, set `kiali.enabled=false` when installing Istio for a succesful installation.
@@ -34,7 +34,7 @@ To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreN
 1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
 1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
 
-####  External Services
+###  External Kiali Services
 
 ##### Prometheus
 The `kiali.external_services.prometheus` url is set in the values.yaml:
@@ -51,11 +51,20 @@ http://{{ .Values.nameOverride }}-grafana.{{ .Values.namespaceOverride }}.svc:{{
 The url depends on the default values for `nameOverride`, `namespaceOverride`, and `grafana.service.port` being set in your rancher-monitoring or other monitoring instance.
 
 ##### Tracing
-The `kiali.external_services.tracing` url and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml:
+The `kiali.external_services.tracing.url`, `kiali.external_services.tracing.in_cluster_url` and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml. 
+
+To ensure traces work for your services in the Kiali dashboard, you must set `kiali.external_services.tracing.url` and `kiali.external_services.tracing.in_cluster_url` key value using the complete external url to your tracing instance.
 ```
-http://tracing.{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+https://<your domain>/k8s/clusters/<cluster id>/api/v1/namespaces/{{ .Values.namespaceOverride }}/services/http:{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+```
+An example with all the values filled in:
+```
+https://111.222.333.44/k8s/clusters/c-zbpdp/api/v1/namespaces/istio-system/services/http:tracing:16686/proxy/jaeger
 ```
 The url depends on the default values for `namespaceOverride`, and `.Values.service.externalPort` being set in your rancher-tracing or other tracing instance.
+
+> **Note:** If you are having a hard time determining the complete url value, deploy Istio with Kiali and Tracing enabled.
+Navigate to the Jaeger dashboard and copy the url from the browser up to the {{ .Values.tracing.contextPath }} context path to use as your complete url value. The context path is `/jaeger` by default.
 
 ## Jaeger
 

--- a/packages/rancher-istio-1.8/charts/app-readme.md
+++ b/packages/rancher-istio-1.8/charts/app-readme.md
@@ -35,11 +35,13 @@ http://{{ .Values.nameOverride }}-grafana.{{ .Values.namespaceOverride }}.svc:{{
 ```
 **Custom Tracing Installation with Kiali**
 
-To use a custom Tracing installation, set the `kiali.external_services.tracing` url and update the `.Values.tracing.contextPath` in the rancher-istio values.yaml.
+The `kiali.external_services.tracing.url`, `kiali.external_services.tracing.in_cluster_url` and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml.
 
-This url depends on the values for `namespaceOverride`, and `.Values.service.externalPort` in your rancher-tracing or other tracing instance.:
+To ensure traces work for your services in the Kiali dashboard, you must set `kiali.external_services.tracing.url` and `kiali.external_services.tracing.in_cluster_url` key value using the complete external url to your tracing instance.
 ```
-http://tracing.{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+https://<your domain>/k8s/clusters/<cluster id>/api/v1/namespaces/{{ .Values.namespaceOverride }}/services/http:{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
 ```
+
+The url depends on the default values for `namespaceOverride`, and `.Values.service.externalPort` being set in your rancher-tracing or other tracing instance.
 
 For more information on how to use the feature, refer to our [docs](https://rancher.com/docs/rancher/v2.x/en/istio/v2.5/).

--- a/packages/rancher-istio-1.8/charts/values.yaml
+++ b/packages/rancher-istio-1.8/charts/values.yaml
@@ -82,7 +82,11 @@ kiali:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
       url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
     tracing:
-      in_cluster_url: "http://tracing.istio-system.svc:16686/jaeger"
+      auth:
+        insecure_skip_verify: true
+      # set the in_cluser_url & url to match your current full url path to jaeger
+      in_cluster_url: ""
+      url: ""
     grafana:
       in_cluster_url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"
       url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"

--- a/packages/rancher-istio-1.8/package.yaml
+++ b/packages/rancher-istio-1.8/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02

--- a/packages/rancher-istio-1.9/charts/README.md
+++ b/packages/rancher-istio-1.9/charts/README.md
@@ -20,7 +20,7 @@ If you remove dependent CRD charts prior to removing rancher-istio, you may enco
 
 Kiali allows you to view and manage your istio-based service mesh through an easy to use dashboard.
 
-####  Dependencies
+###  Dependencies
 - rancher-monitoring chart or other Prometheus installation
 
 This dependecy installs the required CRDs for installing Kiali. Since Kiali is bundled in with Istio in this chart, if you do not have these dependencies installed, your Istio installation will fail. If you do not plan on using Kiali, set `kiali.enabled=false` when installing Istio for a succesful installation.
@@ -34,7 +34,7 @@ To limit scraping to specific namespaces, set `prometheus.prometheusSpec.ignoreN
 1. Add a Service Monitor or Pod Monitor in the namespace with the targets you want to scrape.
 1. Add an additionalScrapeConfig to your rancher-monitoring instance to scrape all targets in all namespaces.
 
-####  External Services
+###  External Kiali Services
 
 ##### Prometheus
 The `kiali.external_services.prometheus` url is set in the values.yaml:
@@ -51,11 +51,20 @@ http://{{ .Values.nameOverride }}-grafana.{{ .Values.namespaceOverride }}.svc:{{
 The url depends on the default values for `nameOverride`, `namespaceOverride`, and `grafana.service.port` being set in your rancher-monitoring or other monitoring instance.
 
 ##### Tracing
-The `kiali.external_services.tracing` url and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml:
+The `kiali.external_services.tracing.url`, `kiali.external_services.tracing.in_cluster_url` and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml. 
+
+To ensure traces work for your services in the Kiali dashboard, you must set `kiali.external_services.tracing.url` and `kiali.external_services.tracing.in_cluster_url` key value using the complete external url to your tracing instance.
 ```
-http://tracing.{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+https://<your domain>/k8s/clusters/<cluster id>/api/v1/namespaces/{{ .Values.namespaceOverride }}/services/http:{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+```
+An example with all the values filled in:
+```
+https://111.222.333.44/k8s/clusters/c-zbpdp/api/v1/namespaces/istio-system/services/http:tracing:16686/proxy/jaeger
 ```
 The url depends on the default values for `namespaceOverride`, and `.Values.service.externalPort` being set in your rancher-tracing or other tracing instance.
+
+> **Note:** If you are having a hard time determining the complete url value, deploy Istio with Kiali and Tracing enabled.
+Navigate to the Jaeger dashboard and copy the url from the browser up to the {{ .Values.tracing.contextPath }} context path to use as your complete url value. The context path is `/jaeger` by default.
 
 ## Jaeger
 

--- a/packages/rancher-istio-1.9/charts/app-readme.md
+++ b/packages/rancher-istio-1.9/charts/app-readme.md
@@ -35,11 +35,13 @@ http://{{ .Values.nameOverride }}-grafana.{{ .Values.namespaceOverride }}.svc:{{
 ```
 **Custom Tracing Installation with Kiali**
 
-To use a custom Tracing installation, set the `kiali.external_services.tracing` url and update the `.Values.tracing.contextPath` in the rancher-istio values.yaml.
+The `kiali.external_services.tracing.url`, `kiali.external_services.tracing.in_cluster_url` and `.Values.tracing.contextPath` is set in the rancher-istio values.yaml.
 
-This url depends on the values for `namespaceOverride`, and `.Values.service.externalPort` in your rancher-tracing or other tracing instance.:
+To ensure traces work for your services in the Kiali dashboard, you must set `kiali.external_services.tracing.url` and `kiali.external_services.tracing.in_cluster_url` key value using the complete external url to your tracing instance.
 ```
-http://tracing.{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
+https://<your domain>/k8s/clusters/<cluster id>/api/v1/namespaces/{{ .Values.namespaceOverride }}/services/http:{{ .Values.namespaceOverride }}.svc:{{ .Values.service.externalPort }}/{{ .Values.tracing.contextPath }}
 ```
+
+The url depends on the default values for `namespaceOverride`, and `.Values.service.externalPort` being set in your rancher-tracing or other tracing instance.
 
 For more information on how to use the feature, refer to our [docs](https://rancher.com/docs/rancher/v2.x/en/istio/v2.5/).

--- a/packages/rancher-istio-1.9/charts/values.yaml
+++ b/packages/rancher-istio-1.9/charts/values.yaml
@@ -82,7 +82,11 @@ kiali:
       custom_metrics_url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
       url: "http://rancher-monitoring-prometheus.cattle-monitoring-system.svc:9090"
     tracing:
-      in_cluster_url: "http://tracing.istio-system.svc:16686/jaeger"
+      auth:
+        insecure_skip_verify: true
+      # set the in_cluser_url & url to match your current full url path to jaeger
+      in_cluster_url: ""
+      url: ""
     grafana:
       in_cluster_url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"
       url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"

--- a/packages/rancher-istio-1.9/package.yaml
+++ b/packages/rancher-istio-1.9/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02


### PR DESCRIPTION
**Problem**
When attempting to look at traces for services in Kiali, if you change the filter options, an error occurs `Cannot not parse minDuration: time: missing unit in duration "1703875"' and the display button does not work after that. Additional error is seen when Kiali attempts to make a call to Tracing and is unable to reach the service using the provided url. 

**Solution**
Use the full URL value for `in_cluster_url` and `url` to ensure the Kiali service is able to reach the tracing service. Added the same notes to the readme and the app-readme for both 1.8 and 1.9 to cover how to properly set this value. 

**Issue** 
https://github.com/rancher/rancher/issues/31979

**Notes**
From various notes I found on different issues, it would appear that even though tracing has the option for an `in_cluster_url`, it still needs to be an external facing url. If it is not accessible externally, it will result in an error. A different way to resolve this issue would've been to proxy the in_cluster_url so that it is accessible externally. Because the call is being made to an "external" service, the authorization has to be set to insecure_skip_verify. 