### PR TITLE
Removed istiocoredns from 1.9

### DIFF
--- a/packages/rancher-istio-1.8/charts/values.yaml
+++ b/packages/rancher-istio-1.8/charts/values.yaml
@@ -7,7 +7,7 @@ installer:
   repository: rancher/istio-installer
   tag: 1.8.5-rancher1
 
-##Deprecated as of 1.8, native support provided by enabling `dns.enabled=true`
+##Deprecated as of 1.8 and unsupported in 1.9, native support provided by enabling `dns.enabled=true`
 istiocoredns:
   enabled: false
   image:

--- a/packages/rancher-istio-1.8/package.yaml
+++ b/packages/rancher-istio-1.8/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 03

--- a/packages/rancher-istio-1.9/charts/configs/istio-base.yaml
+++ b/packages/rancher-istio-1.9/charts/configs/istio-base.yaml
@@ -1,9 +1,6 @@
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
 spec:
-  addonComponents:
-    istiocoredns:
-      enabled: {{ .Values.istiocoredns.enabled }}
   components:
     base:
       enabled: {{ .Values.base.enabled }}
@@ -68,10 +65,6 @@ spec:
       defaultPodDisruptionBudget:
         enabled: {{ .Values.global.defaultPodDisruptionBudget.enabled }}
       {{- end }}
-    istiocoredns:
-      coreDNSImage: {{ template "system_default_registry" . }}{{ .Values.istiocoredns.image.repository }}
-      coreDNSPluginImage: {{ template "system_default_registry" . }}{{ .Values.istiocoredns.pluginImage.repository }}:{{ .Values.istiocoredns.pluginImage.tag }}
-      coreDNSTag: {{ .Values.istiocoredns.image.tag }}
     {{- if .Values.pilot.enabled }}
     pilot:
       image: {{ template "system_default_registry" . }}{{ .Values.pilot.repository }}:{{ .Values.pilot.tag }}

--- a/packages/rancher-istio-1.9/charts/values.yaml
+++ b/packages/rancher-istio-1.9/charts/values.yaml
@@ -5,17 +5,7 @@ forceInstall: false
 
 installer:
   repository: rancher/istio-installer
-  tag: 1.9.3-rancher1
-
-##Deprecated as of 1.8, native support provided by enabling `dns.enabled=true`
-istiocoredns:
-  enabled: false
-  image:
-    repository: rancher/mirrored-coredns-coredns
-    tag: 1.6.2
-  pluginImage:
-    repository: rancher/mirrored-istio-coredns-plugin
-    tag: 0.2-istio-1.1
+  tag: 1.9.3-rancher2
 
 ##Native support for dns added in 1.8
 dns:

--- a/packages/rancher-istio-1.9/package.yaml
+++ b/packages/rancher-istio-1.9/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 03


### PR DESCRIPTION
**Problem**
istiocoredns is not longer supported in the IstioOperator file
istio-installer is not catching errors for istioctl install and upgrade commands so helm is reporting a successful install even when not true. 

**Solution**
Remove istiocoredns from the IstioOperator base-config map. Updated the 1.8 values.yaml to indicate that it will be unsupported in 1.9. 
Use new istio-intaller image that catches errors for istioctl commands 

**Issue**
https://github.com/rancher/rancher/issues/32252

Dependent: https://github.com/rancher/istio-installer/pull/23