### PR TITLE
changes in rancher-sachet: add the link to the upstream example

### DIFF
--- a/packages/rancher-alerting-drivers/package.yaml
+++ b/packages/rancher-alerting-drivers/package.yaml
@@ -1,3 +1,3 @@
 packageVersion: 00
-releaseCandidateVersion: 03
+releaseCandidateVersion: 04
 url: local

--- a/packages/rancher-sachet/charts/templates/configmap-pre-install.yaml
+++ b/packages/rancher-sachet/charts/templates/configmap-pre-install.yaml
@@ -12,6 +12,19 @@ metadata:
     "helm.sh/resource-policy": keep
 data:
   config.yaml: |-
+    {{- if and (not .Values.sachet.providers) (not .Values.sachet.receivers) }}
+    # please refer to the upstream documentation for configuration options:
+    #   https://github.com/messagebird/sachet
+    #
+    # providers:
+    #   aliyun:
+    #     region_id:
+    #     ...
+    # receivers:
+    #   - name: 'team-sms'
+    #     provider: 'aliyu'
+    #     ...
+    {{- end }}
     {{- with .Values.sachet.providers }}
     providers: {{ toYaml . | nindent 6 }}
     {{- end }}

--- a/packages/rancher-sachet/package.yaml
+++ b/packages/rancher-sachet/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 03
+releaseCandidateVersion: 04


### PR DESCRIPTION
issue https://github.com/rancher/rancher/issues/32296


Note:

Because the change is only in `rancher-sachet`, so bump the versions of `rancher-sachet` and `rancher-alerting-drivers`, NOT `rancher-prom2teams`.