### PR TITLE
Small updates for Windows support

### DIFF
--- a/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -281,7 +281,7 @@
  
  ## Provide a k8s version to auto dashboard import script example: kubeTargetVersionOverride: 1.16.6
  ##
-@@ -89,8 +354,30 @@
+@@ -89,8 +354,32 @@
  
  ##
  global:
@@ -289,11 +289,13 @@
 +    systemDefaultRegistry: ""
 +    ## Windows Monitoring
 +    ## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-windows-exporter
-+    ## Runs https://github.com/prometheus-community/windows_exporter as a DaemonSet
-+    ## Relies on the existence of a wins server of version v0.1.0+ on every Windows host to allow 
-+    ## windows_exporter to run as a host process that can publish host metrics to a port on the Pod
-+    windows:
-+      enabled: false
++    ##
++    ## Deploys a DaemonSet of Prometheus exporters based on https://github.com/prometheus-community/windows_exporter.
++    ## Every Windows host must have a wins version of 0.1.0+ to use this chart (default as of Rancher 2.5.8).
++    ## To upgrade wins versions on Windows hosts, see https://github.com/rancher/wins/tree/master/charts/rancher-wins-upgrader.
++    ##
++    # windows:
++    #   enabled: false
 +  kubectl:
 +     repository: rancher/kubectl
 +     tag: v1.20.2
@@ -312,7 +314,7 @@
      pspEnabled: true
      pspAnnotations: {}
        ## Specify pod annotations
-@@ -143,6 +430,22 @@
+@@ -143,6 +432,22 @@
    ## ref: https://prometheus.io/docs/alerting/configuration/#configuration-file
    ##      https://prometheus.io/webtools/alerting/routing-tree-editor/
    ##
@@ -335,7 +337,7 @@
    config:
      global:
        resolve_timeout: 5m
-@@ -179,25 +482,76 @@
+@@ -179,25 +484,76 @@
    ## ref: https://prometheus.io/docs/alerting/notifications/
    ##      https://prometheus.io/docs/alerting/notification_examples/
    ##
@@ -431,7 +433,7 @@
  
    ingress:
      enabled: false
-@@ -235,6 +589,25 @@
+@@ -235,6 +591,25 @@
    ## Configuration for Alertmanager secret
    ##
    secret:
@@ -457,7 +459,7 @@
      annotations: {}
  
    ## Configuration for creating an Ingress that will map to each Alertmanager replica service
-@@ -352,7 +725,7 @@
+@@ -352,7 +727,7 @@
      ## Of type: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
      tlsConfig: {}
  
@@ -466,7 +468,7 @@
  
      ## 	metric relabel configs to apply to samples before ingestion.
      ##
-@@ -383,7 +756,7 @@
+@@ -383,7 +758,7 @@
      ## Image of Alertmanager
      ##
      image:
@@ -475,7 +477,7 @@
        tag: v0.21.0
        sha: ""
  
-@@ -495,9 +868,13 @@
+@@ -495,9 +870,13 @@
      ## Define resources requests and limits for single Pods.
      ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
      ##
@@ -492,7 +494,7 @@
  
      ## Pod anti-affinity can prevent the scheduler from placing Prometheus replicas on the same node.
      ## The default value "soft" means that the scheduler should *prefer* to not schedule two replica pods onto the same node but no guarantee is provided.
-@@ -601,10 +978,46 @@
+@@ -601,10 +980,46 @@
    enabled: true
    namespaceOverride: ""
  
@@ -539,7 +541,7 @@
    adminPassword: prom-operator
  
    ingress:
-@@ -644,6 +1057,7 @@
+@@ -644,6 +1059,7 @@
      dashboards:
        enabled: true
        label: grafana_dashboard
@@ -547,7 +549,7 @@
  
        ## Annotations for Grafana dashboard configmaps
        ##
-@@ -692,7 +1106,60 @@
+@@ -692,7 +1108,60 @@
    ## Passed to grafana subchart and used by servicemonitor below
    ##
    service:
@@ -609,7 +611,7 @@
  
    ## If true, create a serviceMonitor for grafana
    ##
-@@ -722,6 +1189,14 @@
+@@ -722,6 +1191,14 @@
      #   targetLabel: nodename
      #   replacement: $1
      #   action: replace
@@ -624,7 +626,7 @@
  
  ## Component scraping the kube api server
  ##
-@@ -879,7 +1354,7 @@
+@@ -879,7 +1356,7 @@
  ## Component scraping the kube controller manager
  ##
  kubeControllerManager:
@@ -633,7 +635,7 @@
  
    ## If your kube controller manager is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1014,7 +1489,7 @@
+@@ -1014,7 +1491,7 @@
  ## Component scraping etcd
  ##
  kubeEtcd:
@@ -642,7 +644,7 @@
  
    ## If your etcd is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1076,7 +1551,7 @@
+@@ -1076,7 +1553,7 @@
  ## Component scraping kube scheduler
  ##
  kubeScheduler:
@@ -651,7 +653,7 @@
  
    ## If your kube scheduler is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1131,7 +1606,7 @@
+@@ -1131,7 +1608,7 @@
  ## Component scraping kube proxy
  ##
  kubeProxy:
@@ -660,7 +662,7 @@
  
    ## If your kube proxy is not deployed as a pod, specify IPs it can be found on
    ##
-@@ -1210,6 +1685,13 @@
+@@ -1210,6 +1687,13 @@
      create: true
    podSecurityPolicy:
      enabled: true
@@ -674,7 +676,7 @@
  
  ## Deploy node exporter as a daemonset to all nodes
  ##
-@@ -1259,6 +1741,16 @@
+@@ -1259,6 +1743,16 @@
    extraArgs:
      - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
      - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs)$
@@ -691,7 +693,7 @@
  
  ## Manages Prometheus and Alertmanager components
  ##
-@@ -1289,7 +1781,7 @@
+@@ -1289,7 +1783,7 @@
      patch:
        enabled: true
        image:
@@ -700,7 +702,7 @@
          tag: v1.5.0
          sha: ""
          pullPolicy: IfNotPresent
-@@ -1428,13 +1920,13 @@
+@@ -1428,13 +1922,13 @@
  
    ## Resource limits & requests
    ##
@@ -721,7 +723,7 @@
  
    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom CNI (such as calico),
    # because control-plane managed by AWS cannot communicate with pods' IP CIDR and admission webhooks are not working
-@@ -1487,7 +1979,7 @@
+@@ -1487,7 +1981,7 @@
    ## Prometheus-operator image
    ##
    image:
@@ -730,7 +732,7 @@
      tag: v0.46.0
      sha: ""
      pullPolicy: IfNotPresent
-@@ -1503,7 +1995,7 @@
+@@ -1503,7 +1997,7 @@
    ## Prometheus-config-reloader image to use for config and rule reloading
    ##
    prometheusConfigReloaderImage:
@@ -739,7 +741,7 @@
      tag: v0.46.0
      sha: ""
  
-@@ -1558,6 +2050,14 @@
+@@ -1558,6 +2052,14 @@
      ##
      nodePort: 30901
  
@@ -754,7 +756,7 @@
    ## Configuration for Prometheus service
    ##
    service:
-@@ -1570,7 +2070,7 @@
+@@ -1570,7 +2072,7 @@
      port: 9090
  
      ## To be used with a proxy extraContainer port
@@ -763,7 +765,7 @@
  
      ## List of IP addresses at which the Prometheus server service is available
      ## Ref: https://kubernetes.io/docs/user-guide/services/#external-ips
-@@ -1822,7 +2322,7 @@
+@@ -1822,7 +2324,7 @@
      ## Image of Prometheus.
      ##
      image:
@@ -772,7 +774,7 @@
        tag: v2.24.0
        sha: ""
  
-@@ -1885,6 +2385,11 @@
+@@ -1885,6 +2387,11 @@
      ##
      externalUrl: ""
  
@@ -784,7 +786,7 @@
      ## Define which Nodes the Pods are scheduled on.
      ## ref: https://kubernetes.io/docs/user-guide/node-selection/
      ##
-@@ -1917,7 +2422,7 @@
+@@ -1917,7 +2424,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the PrometheusRule resources created
      ##
@@ -793,7 +795,7 @@
  
      ## PrometheusRules to be selected for target discovery.
      ## If {}, select all PrometheusRules
-@@ -1942,7 +2447,7 @@
+@@ -1942,7 +2449,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the servicemonitors created
      ##
@@ -802,7 +804,7 @@
  
      ## ServiceMonitors to be selected for target discovery.
      ## If {}, select all ServiceMonitors
-@@ -1965,7 +2470,7 @@
+@@ -1965,7 +2472,7 @@
      ## prometheus resource to be created with selectors based on values in the helm deployment,
      ## which will also match the podmonitors created
      ##
@@ -811,7 +813,7 @@
  
      ## PodMonitors to be selected for target discovery.
      ## If {}, select all PodMonitors
-@@ -2092,9 +2597,13 @@
+@@ -2092,9 +2599,13 @@
  
      ## Resource limits & requests
      ##
@@ -828,7 +830,7 @@
  
      ## Prometheus StorageSpec for persistent data
      ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/user-guides/storage.md
-@@ -2117,7 +2626,13 @@
+@@ -2117,7 +2628,13 @@
      #    medium: Memory
  
      # Additional volumes on the output StatefulSet definition.
@@ -843,7 +845,7 @@
  
      # Additional VolumeMounts on the output StatefulSet definition.
      volumeMounts: []
-@@ -2224,9 +2739,34 @@
+@@ -2224,9 +2741,34 @@
      ##
      thanos: {}
  
@@ -879,7 +881,7 @@
  
      ## InitContainers allows injecting additional initContainers. This is meant to allow doing some changes
      ## (permissions, dir tree) on mounted volumes before starting prometheus
-@@ -2234,7 +2774,7 @@
+@@ -2234,7 +2776,7 @@
  
      ## PortName to use for Prometheus.
      ##

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -2,7 +2,7 @@ url: https://github.com/prometheus-community/helm-charts.git
 subdirectory: charts/kube-prometheus-stack
 commit: 3ca6ba66032a1efce0500f9ad6f83351ad0604b8
 packageVersion: 00
-releaseCandidateVersion: 09
+releaseCandidateVersion: 10
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-windows-exporter/charts/values.yaml
+++ b/packages/rancher-windows-exporter/charts/values.yaml
@@ -21,6 +21,7 @@ clients:
   image:
     repository: rancher/windows_exporter-package
     tag: v0.0.1
+    os: "windows"
 
   # Specify the IP addresses of nodes that you want to collect metrics from
   endpoints: []

--- a/packages/rancher-windows-exporter/package.yaml
+++ b/packages/rancher-windows-exporter/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 04
+releaseCandidateVersion: 05

--- a/packages/rancher-wins-upgrader/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-wins-upgrader/generated-changes/patch/values.yaml.patch
@@ -1,0 +1,10 @@
+--- charts-original/values.yaml
++++ charts/values.yaml
+@@ -20,6 +20,7 @@
+     # TODO(aiyengar2): replace with an image that just contains wins
+     repository: rancher/wins
+     tag: v0.1.0
++    os: "windows"
+   config: |
+     debug: false
+     listen: rancher_wins

--- a/packages/rancher-wins-upgrader/package.yaml
+++ b/packages/rancher-wins-upgrader/package.yaml
@@ -1,3 +1,3 @@
 url: https://github.com/rancher/wins/releases/download/v0.1.0/dist.rancher-wins-upgrader-0.0.1.tgz
 packageVersion: 00
-releaseCandidateVersion: 01
+releaseCandidateVersion: 02


### PR DESCRIPTION
Comments out global.cattle.windows.enabled so that users can set it to false in Rancher Dashboard UI.

Adds dummy `os` values to support marking images as Windows images for private registry script.

Related Issues: https://github.com/rancher/rancher/issues/32274, https://github.com/rancher/rancher/issues/32265, https://github.com/rancher/rancher/issues/32280