### PR TITLE
Fix units to bytes, not kb

### DIFF
--- a/packages/rancher-monitoring/generated-changes/overlay/files/rancher/k8s/rancher-etcd-nodes.json
+++ b/packages/rancher-monitoring/generated-changes/overlay/files/rancher/k8s/rancher-etcd-nodes.json
@@ -98,7 +98,7 @@
       "yaxes": [
         {
           "decimals": null,
-          "format": "Kbits",
+          "format": "Bps",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/packages/rancher-monitoring/generated-changes/overlay/files/rancher/k8s/rancher-etcd.json
+++ b/packages/rancher-monitoring/generated-changes/overlay/files/rancher/k8s/rancher-etcd.json
@@ -96,7 +96,7 @@
       "yaxes": [
         {
           "decimals": null,
-          "format": "Kbits",
+          "format": "Bps",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/packages/rancher-monitoring/generated-changes/overlay/files/rancher/pods/rancher-pod-containers.json
+++ b/packages/rancher-monitoring/generated-changes/overlay/files/rancher/pods/rancher-pod-containers.json
@@ -206,7 +206,7 @@
       "yaxes": [
         {
           "decimals": 1,
-          "format": "kbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/packages/rancher-monitoring/generated-changes/overlay/files/rancher/pods/rancher-pod.json
+++ b/packages/rancher-monitoring/generated-changes/overlay/files/rancher/pods/rancher-pod.json
@@ -206,7 +206,7 @@
       "yaxes": [
         {
           "decimals": 1,
-          "format": "kbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/packages/rancher-monitoring/generated-changes/overlay/files/rancher/workloads/rancher-workload-pods.json
+++ b/packages/rancher-monitoring/generated-changes/overlay/files/rancher/workloads/rancher-workload-pods.json
@@ -206,7 +206,7 @@
       "yaxes": [
         {
           "decimals": 1,
-          "format": "kbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/packages/rancher-monitoring/generated-changes/overlay/files/rancher/workloads/rancher-workload.json
+++ b/packages/rancher-monitoring/generated-changes/overlay/files/rancher/workloads/rancher-workload.json
@@ -206,7 +206,7 @@
       "yaxes": [
         {
           "decimals": 1,
-          "format": "kbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -2,7 +2,7 @@ url: https://github.com/prometheus-community/helm-charts.git
 subdirectory: charts/kube-prometheus-stack
 commit: 3ca6ba66032a1efce0500f9ad6f83351ad0604b8
 packageVersion: 00
-releaseCandidateVersion: 10
+releaseCandidateVersion: 11
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Quick fix to change units to since all of the PromQL metrics are based on bytes, not kilobytes.

For future, we can use https://github.com/grafana/grafana/blob/master/packages/grafana-data/src/valueFormats/categories.ts to identify the key value pairs that are tied to certain units showing up on the Grafana dashboard.

Related Issue: https://github.com/rancher/rancher/issues/32357