### PR TITLE
support install rancher-alerting-drivers in hardened cluster

### DIFF
--- a/packages/rancher-alerting-drivers/charts/templates/_helpers.tpl
+++ b/packages/rancher-alerting-drivers/charts/templates/_helpers.tpl
@@ -1,3 +1,29 @@
+{{- define "system_default_registry" -}}
+{{- if .Values.global.cattle.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Windows cluster will add default taint for linux nodes,
+add below linux tolerations to workloads could be scheduled to those linux nodes
+*/}}
+
+{{- define "linux-node-tolerations" -}}
+- key: "cattle.io/os"
+  value: "linux"
+  effect: "NoSchedule"
+  operator: "Equal"
+{{- end -}}
+
+{{- define "linux-node-selector" -}}
+{{- if semverCompare "<1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+beta.kubernetes.io/os: linux
+{{- else -}}
+kubernetes.io/os: linux
+{{- end -}}
+{{- end -}}
+
 {{/*
 Expand the name of the chart.
 */}}

--- a/packages/rancher-alerting-drivers/charts/templates/hardened.yaml
+++ b/packages/rancher-alerting-drivers/charts/templates/hardened.yaml
@@ -1,0 +1,116 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "drivers.fullname" . }}-patch-sa
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "drivers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      serviceAccountName: {{ include "drivers.fullname" . }}-patch-sa
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      restartPolicy: Never
+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
+      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
+      containers:
+        - name: {{ include "drivers.fullname" . }}-patch-sa
+          image: "{{ include "system_default_registry" . }}{{ .Values.global.kubectl.repository }}:{{ .Values.global.kubectl.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["kubectl", "-n", {{ .Release.Namespace | quote }}, "patch", "serviceaccount", "default", "-p", "{\"automountServiceAccountToken\": false}"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "drivers.fullname" . }}-patch-sa
+  namespace: {{ .Release.Namespace }}
+  labels: {{ include "drivers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "drivers.fullname" . }}-patch-sa
+  labels: {{ include "drivers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+rules:
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs:     ["use"]
+    resourceNames:
+      - {{ include "drivers.fullname" . }}-patch-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "drivers.fullname" . }}-patch-sa
+  labels: {{ include "drivers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "drivers.fullname" . }}-patch-sa
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "drivers.fullname" . }}-patch-sa
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "drivers.fullname" . }}-patch-sa
+  labels: {{ include "drivers.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install, post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
+spec:
+  privileged: false
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+  volumes:
+    - 'secret'
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-allow-all
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector: {}
+  ingress:
+    - {}
+  egress:
+    - {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/packages/rancher-alerting-drivers/charts/values.yaml
+++ b/packages/rancher-alerting-drivers/charts/values.yaml
@@ -6,9 +6,9 @@ global:
   cattle:
     # the registry where all images will be pulled from
     systemDefaultRegistry: ""
-  # set this value if you want the sub-charts to be installed into
-  # a namespace rather than where this chart is installed
-  namespaceOverride: ""
+  kubectl:
+    repository: rancher/kubectl
+    tag: v1.20.2
 
 prom2teams:
   enabled: false

--- a/packages/rancher-alerting-drivers/package.yaml
+++ b/packages/rancher-alerting-drivers/package.yaml
@@ -1,3 +1,3 @@
-packageVersion: 00
-releaseCandidateVersion: 04
+packageVersion: 01
+releaseCandidateVersion: 01
 url: local

--- a/packages/rancher-prom2teams/generated-changes/overlay/templates/psp.yaml
+++ b/packages/rancher-prom2teams/generated-changes/overlay/templates/psp.yaml
@@ -26,3 +26,4 @@ spec:
   readOnlyRootFilesystem: false
   volumes:
     - 'configMap'
+    - 'secret'

--- a/packages/rancher-prom2teams/package.yaml
+++ b/packages/rancher-prom2teams/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/idealista/prom2teams.git
 subdirectory: helm
 commit: 29710102acb7748dc93cc1e827d2f5b8aa506206 # the commit points to the tag 3.2.1
-packageVersion: 00
-releaseCandidateVersion: 03
+packageVersion: 01
+releaseCandidateVersion: 01

--- a/packages/rancher-sachet/charts/templates/psp.yaml
+++ b/packages/rancher-sachet/charts/templates/psp.yaml
@@ -26,3 +26,4 @@ spec:
   readOnlyRootFilesystem: false
   volumes:
     - 'configMap'
+    - 'secret'

--- a/packages/rancher-sachet/package.yaml
+++ b/packages/rancher-sachet/package.yaml
@@ -1,3 +1,3 @@
 url: local
-packageVersion: 00
-releaseCandidateVersion: 04
+packageVersion: 01
+releaseCandidateVersion: 01


### PR DESCRIPTION
Issues:
https://github.com/rancher/rancher/issues/32358
https://github.com/rancher/rancher/issues/32665

Notes about the PR:
- The chart is tested on a custom hardened cluster under the [CIS 1.6 Benchmark](https://rancher.com/docs/rancher/v2.x/en/security/rancher-2.5/1.6-hardening-2.5/). 
- The app is installed into the hardened cluster successfully.
- After the app is installed, pass the CIS scan with the profile `rke-profile-hardened-1.6`
