### PR TITLE
Allow rancher-wins-upgrader and rancher-windows-exporter to default to c:/ if rkeWindowsPathPrefix is ""

### DIFF
--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -2,7 +2,7 @@ url: https://github.com/prometheus-community/helm-charts.git
 subdirectory: charts/kube-prometheus-stack
 commit: 3ca6ba66032a1efce0500f9ad6f83351ad0604b8
 packageVersion: 00
-releaseCandidateVersion: 12
+releaseCandidateVersion: 13
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-windows-exporter/charts/templates/_helpers.tpl
+++ b/packages/rancher-windows-exporter/charts/templates/_helpers.tpl
@@ -63,8 +63,8 @@ kubernetes.io/os: windows
 {{- end }}
 {{- end -}}
 
-{{- define "windowsExporter.validatePathPrefix" -}}
-{{- $pathPrefix := (required "Must provide value for .Values.global.cattle.rkeWindowsPathPrefix" .Values.global.cattle.rkeWindowsPathPrefix) -}}
+{{- define "winsUpgrader.validatePathPrefix" -}}
+{{- $pathPrefix := (default "C:/" .Values.global.cattle.rkeWindowsPathPrefix) -}}
 {{- if (contains "\\" $pathPrefix) -}}
 {{- fail ".Values.global.cattle.rkeWindowsPathPrefix must not contain backslashes" -}}
 {{- else if (not (hasSuffix "/" $pathPrefix)) -}}

--- a/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
@@ -67,7 +67,7 @@ spec:
           path: \\.\pipe\rancher_wins_proxy
       - name: binary-host-path
         hostPath:
-          path: {{ .Values.global.cattle.rkeWindowsPathPrefix }}etc/windows-exporter
+          path: {{ default "C:/" .Values.global.cattle.rkeWindowsPathPrefix }}etc/windows-exporter
           type: DirectoryOrCreate
       - name: exporter-scripts
         configMap:

--- a/packages/rancher-windows-exporter/package.yaml
+++ b/packages/rancher-windows-exporter/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 06
+releaseCandidateVersion: 07

--- a/packages/rancher-wins-upgrader/package.yaml
+++ b/packages/rancher-wins-upgrader/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/rancher/wins.git
 subdirectory: charts/rancher-wins-upgrader
-commit: 4bf76f4ecbc0ea7b835a4080d36705737a41559a
+commit: 3d12d657f7c7e471260e1a105c63604112ad9828
 packageVersion: 00
-releaseCandidateVersion: 03
+releaseCandidateVersion: 04


### PR DESCRIPTION
Wins PR: https://github.com/rancher/wins/pull/36

Related Issue: https://github.com/rancher/rancher/issues/32194