### PR TITLE
Revert change to helper function name

### DIFF
--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -2,7 +2,7 @@ url: https://github.com/prometheus-community/helm-charts.git
 subdirectory: charts/kube-prometheus-stack
 commit: 3ca6ba66032a1efce0500f9ad6f83351ad0604b8
 packageVersion: 00
-releaseCandidateVersion: 13
+releaseCandidateVersion: 14
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-windows-exporter/charts/templates/_helpers.tpl
+++ b/packages/rancher-windows-exporter/charts/templates/_helpers.tpl
@@ -63,7 +63,7 @@ kubernetes.io/os: windows
 {{- end }}
 {{- end -}}
 
-{{- define "winsUpgrader.validatePathPrefix" -}}
+{{- define "windowsExporter.validatePathPrefix" -}}
 {{- $pathPrefix := (default "C:/" .Values.global.cattle.rkeWindowsPathPrefix) -}}
 {{- if (contains "\\" $pathPrefix) -}}
 {{- fail ".Values.global.cattle.rkeWindowsPathPrefix must not contain backslashes" -}}

--- a/packages/rancher-windows-exporter/package.yaml
+++ b/packages/rancher-windows-exporter/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 07
+releaseCandidateVersion: 08


### PR DESCRIPTION
Reverts change that was accidentally introduced in https://github.com/rancher/charts/pull/1172 to modify the helper template name:

https://github.com/rancher/charts/pull/1172/files#diff-2b0747e6ecba415652b5430ad7ae97c9d55f752c6de682d8cd2f23443e56f1d4R66

Related Issue: https://github.com/rancher/rancher/issues/32194