### PR TITLE
Updating CIS chart image tags to use non-rc tags to release 1.0.400

### DIFF
--- a/packages/rancher-cis-benchmark/charts/values.yaml
+++ b/packages/rancher-cis-benchmark/charts/values.yaml
@@ -5,10 +5,10 @@
 image:
   cisoperator:
     repository: rancher/cis-operator
-    tag: v1.0.4-rc5
+    tag: v1.0.4
   securityScan:
     repository: rancher/security-scan
-    tag: v0.2.3-rc6
+    tag: v0.2.3
   sonobuoy:
     repository: rancher/mirrored-sonobuoy-sonobuoy
     tag: v0.16.3

--- a/packages/rancher-cis-benchmark/package.yaml
+++ b/packages/rancher-cis-benchmark/package.yaml
@@ -1,6 +1,6 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 06
+releaseCandidateVersion: 07
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
Updating with non-rc tags for rancher-cis-benchmark