### PR TITLE
Put binary in prefixPath within container

### DIFF
--- a/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -294,8 +294,8 @@
 +    ## Every Windows host must have a wins version of 0.1.0+ to use this chart (default as of Rancher 2.5.8).
 +    ## To upgrade wins versions on Windows hosts, see https://github.com/rancher/wins/tree/master/charts/rancher-wins-upgrader.
 +    ##
-+    # windows:
-+    #   enabled: false
++    windows:
++      enabled: false
 +  kubectl:
 +     repository: rancher/kubectl
 +     tag: v1.20.2

--- a/packages/rancher-monitoring/package.yaml
+++ b/packages/rancher-monitoring/package.yaml
@@ -2,7 +2,7 @@ url: https://github.com/prometheus-community/helm-charts.git
 subdirectory: charts/kube-prometheus-stack
 commit: 3ca6ba66032a1efce0500f9ad6f83351ad0604b8
 packageVersion: 00
-releaseCandidateVersion: 16
+releaseCandidateVersion: 17
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-windows-exporter/charts/templates/configmap.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.clients }}{{ if .Values.clients.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -6,3 +7,4 @@ metadata:
   labels: {{ include "windowsExporter.labels" . | nindent 4 }}
 data:
 {{ (.Files.Glob "scripts/*").AsConfig | indent 2 }}
+{{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       - name: exporter-node-proxy
         image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
-        command: ["pwsh", "-f", "c:/scripts/proxy-entry.ps1"]
+        command: ["pwsh", "-f", "C:/scripts/proxy-entry.ps1"]
         ports:
         - name: http
           containerPort: {{ required "Need .Values.clients.port to figure out where to get metrics from" .Values.clients.port }}
@@ -31,14 +31,16 @@ spec:
         - name: wins-pipe-proxy
           mountPath: \\.\pipe\rancher_wins_proxy
         - name: exporter-scripts
-          mountPath: c:/scripts/
+          mountPath: C:/scripts/
       - name: exporter-node
         image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
-        command: ["pwsh", "-f", "c:/scripts/run.ps1"]
+        command: ["pwsh", "-f", "C:/scripts/run.ps1"]
 {{- if .Values.clients.args }}
         args: {{ .Values.clients.args }}
 {{- end }}
-        env: {{ include "windowsExporter.client.env" . | nindent 10 }}
+        env: {{ include "windowsExporter.client.env" . | nindent 8 }}
+        - name: CATTLE_PREFIX_PATH
+          value: {{ default "C:\\" .Values.global.cattle.rkeWindowsPathPrefix | replace "/" "\\" }}
 {{- if .Values.resources }}
         resources: {{ toYaml .Values.clients.resources | nindent 10 }}
 {{- end }}
@@ -48,16 +50,16 @@ spec:
         - name: binary-host-path
           mountPath: C:/host/etc/windows-exporter
         - name: exporter-scripts
-          mountPath: c:/scripts/
+          mountPath: C:/scripts/
       initContainers:
       - name: check-wins-version
         image: {{ template "system_default_registry" . }}{{ .Values.clients.image.repository }}:{{ .Values.clients.image.tag }}
-        command: ["pwsh", "-f", "c:/scripts/check-wins-version.ps1"]
+        command: ["pwsh", "-f", "C:/scripts/check-wins-version.ps1"]
         volumeMounts:
         - name: wins-pipe
           mountPath: \\.\pipe\rancher_wins
         - name: exporter-scripts
-          mountPath: c:/scripts/
+          mountPath: C:/scripts/
       volumes:
       - name: wins-pipe
         hostPath:

--- a/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/daemonset.yaml
@@ -1,5 +1,5 @@
-{{ include "windowsExporter.validatePathPrefix" . }}
 {{- if .Values.clients }}{{ if .Values.clients.enabled }}
+{{ include "windowsExporter.validatePathPrefix" . }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/packages/rancher-windows-exporter/charts/templates/rbac.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/rbac.yaml
@@ -74,5 +74,5 @@ spec:
   allowedHostPaths:
   - pathPrefix: \\.\pipe\rancher_wins
   - pathPrefix: \\.\pipe\rancher_wins_proxy
-  - pathPrefix: c:/etc/windows-exporter
+  - pathPrefix: C:/etc/windows-exporter
 {{- end }}{{- end }}

--- a/packages/rancher-windows-exporter/charts/templates/service.yaml
+++ b/packages/rancher-windows-exporter/charts/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.serviceMonitor .Values.clients }}{{- if and .Values.serviceMonitor.enabled .Values.clients.enabled }}
+{{- if and .Values.clients }}{{- if and .Values.clients.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/packages/rancher-windows-exporter/package.yaml
+++ b/packages/rancher-windows-exporter/package.yaml
@@ -1,3 +1,3 @@
 url: local
 packageVersion: 00
-releaseCandidateVersion: 09
+releaseCandidateVersion: 10

--- a/packages/rancher-wins-upgrader/package.yaml
+++ b/packages/rancher-wins-upgrader/package.yaml
@@ -1,5 +1,5 @@
 url: https://github.com/rancher/wins.git
 subdirectory: charts/rancher-wins-upgrader
-commit: 7dfa09add333ddea480850cdd5596012178797d5
+commit: 3edd5ddfd1df3d0d8d0ab1d3398259ab712f8f44
 packageVersion: 00
-releaseCandidateVersion: 05
+releaseCandidateVersion: 06


### PR DESCRIPTION
The reason why this change is necessary is that wins performs a checksum on the exact same path that must exist in the container and must exist on the host. Therefore, even though there is no need for the container to have knowledge of the CATTLE_PREFIX_PATH, it must for wins to be able to checksum correctly.

Related Issue: https://github.com/rancher/rancher/issues/32194, https://github.com/rancher/rancher/issues/32530

Wins PR: https://github.com/rancher/wins/pull/39