### PR TITLE
Add rancher-logging to 2.6 among multiple changes

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/app-readme.md
+++ b/packages/rancher-logging/generated-changes/overlay/app-readme.md
@@ -1,0 +1,22 @@
+# Rancher Logging
+
+This chart is based off of the upstream [Banzai Logging Operator](https://banzaicloud.com/docs/one-eye/logging-operator/) chart. The chart deploys a logging operator and CRDs, which allows users to configure complex logging pipelines with a few simple custom resources. There are two levels of logging, which allow you to collect all logs in a cluster or from a single namespace.
+
+For more information on how to use the feature, refer to our [docs](https://rancher.com/docs/rancher/v2.x/en/logging/v2.5/).
+
+## Namespace-level logging
+
+To collect logs from a single namespace, users create flows and these flows are connected to outputs or cluster outputs.
+
+## Cluster-level logging
+
+To collect logs from an entire cluster, users create cluster flows and cluster outputs.
+
+## CRDs
+
+- [Cluster Flow](https://banzaicloud.com/docs/one-eye/logging-operator/crds/v1beta1/clusterflow_types/) - A cluster flow is a CRD (`ClusterFlow`) that defines what logs to collect from the entire cluster. The cluster flow must be deployed in the same namespace as the logging operator.
+- [Cluster Output](https://banzaicloud.com/docs/one-eye/logging-operator/crds/v1beta1/clusteroutput_types/) - A cluster output is a CRD (`ClusterOutput`) that defines how to connect to logging providers so they can start collecting logs. The cluster output must be deployed in the same namespace as the logging operator. The convenience of using a cluster output is that either a cluster flow or flow can send logs to those providers without needing to define specific outputs in each namespace for each flow.
+- [Flow](https://banzaicloud.com/docs/one-eye/logging-operator/crds/v1beta1/flow_types/) - A flow is a CRD (`Flow`) that defines what logs to collect from the namespace that it is deployed in.
+- [Output](https://banzaicloud.com/docs/one-eye/logging-operator/crds/v1beta1/output_types/) - An output is a CRD (`Output`) that defines how to connect to logging providers so logs can be sent to the provider.
+
+For more information on how to configure the Helm chart, refer to the Helm README.

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.additionalLoggingSources.aks.enabled }}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}-aks
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    inputTail:
+      Tag: "aks"
+      Path: "/var/log/azure/kubelet-status.log"
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/aks/logging.yaml
@@ -15,21 +15,43 @@ spec:
     inputTail:
       Tag: "aks"
       Path: "/var/log/azure/kubelet-status.log"
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
     tolerations: {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
     nodeSelector: {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
     resources: {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -37,16 +59,25 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.additionalLoggingSources.eks.enabled }}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}-eks
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    inputTail:
+      Tag: "eks"
+      Path: "/var/log/messages"
+      Parser: "syslog"
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/eks/logging.yaml
@@ -16,21 +16,43 @@ spec:
       Tag: "eks"
       Path: "/var/log/messages"
       Parser: "syslog"
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
     tolerations: {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
     nodeSelector: {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
     resources: {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -38,16 +60,25 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.additionalLoggingSources.gke.enabled }}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}-gke
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    inputTail:
+      Tag: "gke"
+      Path: "/var/log/kube-proxy.log"
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/gke/logging.yaml
@@ -15,21 +15,43 @@ spec:
     inputTail:
       Tag: "gke"
       Path: "/var/log/kube-proxy.log"
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
     tolerations: {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
     nodeSelector: {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
     resources: {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -37,16 +59,25 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
     nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.additionalLoggingSources.k3s.enabled (eq .Values.additionalLoggingSources.k3s.container_engine "openrc")}}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}-k3s
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    inputTail:
+      Tag: "k3s"
+      Path: "/var/log/k3s.log"
+    extraVolumeMounts:
+      - source: "/var/log/"
+        destination: "/var/log"
+        readOnly: true
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-openrc.yaml
@@ -15,28 +15,47 @@ spec:
     inputTail:
       Tag: "k3s"
       Path: "/var/log/k3s.log"
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
     extraVolumeMounts:
       - source: "/var/log/"
         destination: "/var/log"
         readOnly: true
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -44,23 +63,29 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
+    tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
+    resources: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.additionalLoggingSources.k3s.enabled (eq .Values.additionalLoggingSources.k3s.container_engine "systemd")}}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}-k3s
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    inputTail:
+      Tag: "k3s"
+      Path: "/var/log/syslog"
+    extraVolumeMounts:
+      - source: "/var/log/"
+        destination: "/var/log"
+        readOnly: true
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/logging-k3s-systemd.yaml
@@ -15,28 +15,47 @@ spec:
     inputTail:
       Tag: "k3s"
       Path: "/var/log/syslog"
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
     extraVolumeMounts:
       - source: "/var/log/"
         destination: "/var/log"
         readOnly: true
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -44,23 +63,29 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
+    tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
+    resources: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/configmap.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/configmap.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.additionalLoggingSources.rke.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-rke
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Log_Level         {{ .Values.additionalLoggingSources.rke.fluentbit.log_level }}
+        Parsers_File      parsers.conf
+
+    [INPUT]
+        Tag               rke
+        Name              tail
+        Path_Key          filename
+        Parser            docker
+        DB                /tail-db/tail-containers-state.db
+        Mem_Buf_Limit     {{ .Values.additionalLoggingSources.rke.fluentbit.mem_buffer_limit }}
+        Path              /var/lib/rancher/rke/log/*.log
+
+    [OUTPUT]
+        Name              forward
+        Match             *
+        Host              {{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc
+        Port              24240
+        Retry_Limit       False
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.additionalLoggingSources.rke.enabled }}
+{{- $containers := printf "%s/containers/" (default "/var/lib/docker" .Values.global.dockerRootDirectory) }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-rke-aggregator
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-rke-aggregator"
+      namespace: "{{ .Release.Namespace }}"
+      labels:
+        name: {{ .Release.Name }}-rke-aggregator
+    spec:
+      containers:
+        - name: fluentbit
+          image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}:{{ .Values.images.fluentbit.tag }}"
+          volumeMounts:
+            - mountPath: /var/lib/rancher/rke/log/
+              name: indir
+            - mountPath: {{ $containers }}
+              name: containers
+            - mountPath: /tail-db
+              name: positiondb
+            - mountPath: /fluent-bit/etc/fluent-bit.conf
+              name: config
+              subPath: fluent-bit.conf
+          {{- if .Values.global.seLinux.enabled }}
+          securityContext:
+            seLinuxOptions:
+              type: rke_logreader_t
+          {{- end }}
+      volumes:
+        - name: indir
+          hostPath:
+            path: /var/lib/rancher/rke/log/
+            type: DirectoryOrCreate
+        - name: containers
+          hostPath:
+            path: {{ $containers }}
+            type: DirectoryOrCreate
+        - name: positiondb
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: "{{ .Release.Name }}-rke"
+      serviceAccountName: "{{ .Release.Name }}-rke-aggregator"
+      {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+      {{- with $total_tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+{{- if .Values.global.psp.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+rules:
+  - apiGroups:
+    - policy
+    resourceNames:
+    - "{{ .Release.Name }}-rke-aggregator"
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ .Release.Name }}-rke-aggregator"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ .Release.Name }}-rke-aggregator"
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ .Release.Name }}-rke-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  allowPrivilegeEscalation: false
+  allowedHostPaths:
+  - pathPrefix: {{ $containers }}
+    readOnly: false
+  - pathPrefix: /var/lib/rancher/rke/log/
+    readOnly: false
+  - pathPrefix: /var/lib/rancher/logging/
+    readOnly: false
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - secret
+  - hostPath
+{{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke/daemonset.yaml
@@ -51,12 +51,10 @@ spec:
       serviceAccountName: "{{ .Release.Name }}-rke-aggregator"
       {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
       {{- with $total_tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
+      tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
 ---
 apiVersion: v1

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/configmap.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.additionalLoggingSources.rke2.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-rke2
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+data:
+  fluent-bit.conf: |
+    [INPUT]
+        Name              systemd
+        Tag               rke2
+        Path              {{ .Values.systemdLogPath | default "/var/log/journal" }}
+        Systemd_Filter    _SYSTEMD_UNIT=rke2-server.service
+
+    [OUTPUT]
+        Name              forward
+        Match             *
+        Host              {{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc
+        Port              24240
+        Retry_Limit       False
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.additionalLoggingSources.rke2.enabled }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Release.Name }}-rke2-journald-aggregator
+  template:
+    metadata:
+      name: "{{ .Release.Name }}-rke2-journald-aggregator"
+      namespace: "{{ .Release.Namespace }}"
+      labels:
+        name: {{ .Release.Name }}-rke2-journald-aggregator
+    spec:
+      containers:
+        - name: fluentd
+          image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}:{{ .Values.images.fluentbit.tag }}"
+          {{- if .Values.global.seLinux.enabled }}
+          securityContext:
+            seLinuxOptions:
+              type: rke_logreader_t
+          {{- end }}
+          volumeMounts:
+            - mountPath: /fluent-bit/etc/
+              name: config
+            - mountPath: {{ .Values.systemdLogPath | default "/var/log/journal" }}
+              name: journal
+              readOnly: true
+            - mountPath: /etc/machine-id
+              name: machine-id
+              readOnly: true
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: "{{ .Release.Name }}-rke2-journald-aggregator"
+      volumes:
+        - name: config
+          configMap:
+            name: "{{ .Release.Name }}-rke2"
+        - name: journal
+          hostPath:
+            path: {{ .Values.systemdLogPath | default "/var/log/journal" }}
+        - name: machine-id
+          hostPath:
+            path: /etc/machine-id
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+{{- if .Values.global.psp.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+rules:
+  - apiGroups:
+    - policy
+    resourceNames:
+    - "{{ .Release.Name }}-rke2-journald-aggregator"
+    resources:
+    - podsecuritypolicies
+    verbs:
+    - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+subjects:
+  - kind: ServiceAccount
+    name: "{{ .Release.Name }}-rke2-journald-aggregator"
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: "{{ .Release.Name }}-rke2-journald-aggregator"
+  namespace: "{{ .Release.Namespace }}"
+spec:
+  allowPrivilegeEscalation: false
+  fsGroup:
+    rule: RunAsAny
+  readOnlyRootFilesystem: true
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+  - configMap
+  - emptyDir
+  - secret
+  - hostPath
+{{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
@@ -33,12 +33,10 @@ spec:
               name: machine-id
               readOnly: true
       {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
+      tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: "{{ .Release.Name }}-rke2-journald-aggregator"
       volumes:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.additionalLoggingSources.rke2.enabled }}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}-rke2-containers
+  namespace: {{ .Release.Namespace }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    inputTail:
+      Tag: "rke2"
+      Path: "/var/log/containers/*rke*.log"
+    extraVolumeMounts:
+      - source: "/var/log/containers/"
+        destination: "/var/log/containers/"
+        readOnly: true
+    {{- if or .Values.global.psp.enabled .Values.global.seLinux.enabled }}
+    security:
+    {{- end }}
+    {{- if or .Values.global.psp.enabled }}
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- if .Values.global.seLinux.enabled }}
+      securityContext:
+        seLinuxOptions:
+          type: rke_logreader_t
+    {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}
+{{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/logging-rke2-containers.yaml
@@ -13,10 +13,33 @@ spec:
     inputTail:
       Tag: "rke2"
       Path: "/var/log/containers/*rke*.log"
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
     extraVolumeMounts:
       - source: "/var/log/containers/"
         destination: "/var/log/containers/"
         readOnly: true
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if or .Values.global.psp.enabled .Values.global.seLinux.enabled }}
     security:
     {{- end }}
@@ -29,19 +52,15 @@ spec:
         seLinuxOptions:
           type: rke_logreader_t
     {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -49,23 +68,29 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
+    tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
+    resources: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
@@ -1,0 +1,111 @@
+{{- $containers := printf "%s/containers/" (default "/var/lib/docker" .Values.global.dockerRootDirectory) }}
+apiVersion: logging.banzaicloud.io/v1beta1
+kind: Logging
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "logging-operator.labels" . | indent 4 }}
+spec:
+  controlNamespace: {{ .Release.Namespace }}
+  {{- if (include "windowsEnabled" .) }}
+  nodeAgents:
+    - name: win-agent
+      profile: windows
+      nodeAgentFluentbit:
+        daemonSet:
+          spec:
+            template:
+              spec:
+                containers:
+                - image: "{{ template "system_default_registry" . }}{{ .Values.images.nodeagent_fluentbit.repository }}:{{ .Values.images.nodeagent_fluentbit.tag }}"
+                  name: fluent-bit
+        tls:
+          enabled: {{ .Values.nodeAgents.tls.enabled | default false }}
+    {{- if .Values.additionalLoggingSources.rke.enabled }}
+    - name: win-agent-rke
+      profile: windows
+      nodeAgentFluentbit:
+        filterKubernetes:
+          Kube_Tag_Prefix: "kuberentes.C.var.lib.rancher.rke.log."
+        inputTail:
+          Path: "C:\\var\\lib\\rancher\\rke\\log"
+        extraVolumeMounts:
+        - source: "/var/lib/rancher/rke/log"
+          destination: "/var/lib/rancher/rke/log"
+          readOnly: true
+        daemonSet:
+          spec:
+            template:
+              spec:
+                containers:
+                - image: "{{ template "system_default_registry" . }}{{ .Values.images.nodeagent_fluentbit.repository }}:{{ .Values.images.nodeagent_fluentbit.tag }}"
+                  name: fluent-bit
+        tls:
+          enabled: {{ .Values.nodeAgents.tls.enabled | default false }}
+    {{- end }}
+  {{- end }}
+  fluentbit:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
+      tag: {{ .Values.images.fluentbit.tag }}
+    {{- if or .Values.global.psp.enabled .Values.global.seLinux.enabled }}
+    security:
+    {{- end }}
+    {{- if .Values.global.psp.enabled }}
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- if .Values.global.seLinux.enabled }}
+      securityContext:
+        seLinuxOptions:
+          type: rke_logreader_t
+    {{- end }}
+  {{- if .Values.global.dockerRootDirectory }}
+    mountPath: {{ $containers }}
+    extraVolumeMounts:
+      - source: {{ $containers }}
+        destination: {{ $containers }}
+        readOnly: true
+  {{- end }}
+  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
+  {{- with $total_tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  fluentd:
+    image:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
+      tag: {{ .Values.images.fluentd.tag }}
+    configReloaderImage:
+      repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
+      tag: {{ .Values.images.config_reloader.tag }}
+    disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.global.psp.enabled }}
+    security:
+      podSecurityPolicyCreate: true
+      roleBasedAccessControlCreate: true
+    {{- end }}
+    {{- with .Values.tolerations }}
+    tolerations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentd.livenessProbe }}
+    livenessProbe: {{- toYaml . | nindent 6 }}
+    {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/root/logging.yaml
@@ -29,10 +29,25 @@ spec:
         filterKubernetes:
           Kube_Tag_Prefix: "kuberentes.C.var.lib.rancher.rke.log."
         inputTail:
-          Path: "C:\\var\\lib\\rancher\\rke\\log"
+          Path: "{{ template "windowsPathPrefix" . }}/var/lib/rancher/rke/log"
+          {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+          Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+          {{- end }}
+          {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+          Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+          {{- end }}
+          {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+          Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+          {{- end }}
+          {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+          Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+          {{- end }}
+          {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+          Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+          {{- end }}
         extraVolumeMounts:
-        - source: "/var/lib/rancher/rke/log"
-          destination: "/var/lib/rancher/rke/log"
+        - source: "c:/var/lib/rancher/rke/log"
+          destination: "c:/var/lib/rancher/rke/log"
           readOnly: true
         daemonSet:
           spec:
@@ -49,6 +64,32 @@ spec:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}
       tag: {{ .Values.images.fluentbit.tag }}
+    {{- if or .Values.fluentbit.inputTail.Buffer_Chunk_Size .Values.fluentbit.inputTail.Buffer_Max_Size .Values.fluentbit.inputTail.Mem_Buf_Limit .Values.fluentbit.inputTail.Multiline_Flush .Values.fluentbit.inputTail.Skip_Long_Lines }}
+    inputTail:
+      {{- if .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      Buffer_Chunk_Size: {{ .Values.fluentbit.inputTail.Buffer_Chunk_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      Buffer_Max_Size: {{ .Values.fluentbit.inputTail.Buffer_Max_Size }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      Mem_Buf_Limit: {{ .Values.fluentbit.inputTail.Mem_Buf_Limit }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Multiline_Flush }}
+      Multiline_Flush: {{ .Values.fluentbit.inputTail.Multiline_Flush }}
+      {{- end }}
+      {{- if .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      Skip_Long_Lines: {{ .Values.fluentbit.inputTail.Skip_Long_Lines }}
+      {{- end }}
+    {{- end }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentbit.bufferStorage }}
+    bufferStorage: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     {{- if or .Values.global.psp.enabled .Values.global.seLinux.enabled }}
     security:
     {{- end }}
@@ -61,26 +102,22 @@ spec:
         seLinuxOptions:
           type: rke_logreader_t
     {{- end }}
-  {{- if .Values.global.dockerRootDirectory }}
+    {{- if .Values.global.dockerRootDirectory }}
     mountPath: {{ $containers }}
     extraVolumeMounts:
       - source: {{ $containers }}
         destination: {{ $containers }}
         readOnly: true
-  {{- end }}
-  {{- $total_tolerations := concat (.Values.tolerations) (.Values.fluentbit.tolerations) }}
-  {{- with $total_tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
-  {{- with .Values.fluentbit.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
-  {{- end }}
+    {{- end }}
+    {{- with (concat (.Values.tolerations) (.Values.fluentbit.tolerations)) }}
+    tolerations: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.nodeSelector }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.resources }}
+    resources: {{- toYaml . | nindent 6 }}
+    {{- end }}
   fluentd:
     image:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.fluentd.repository }}
@@ -88,23 +125,29 @@ spec:
     configReloaderImage:
       repository: {{ template "system_default_registry" . }}{{ .Values.images.config_reloader.repository }}
       tag: {{ .Values.images.config_reloader.tag }}
+    {{- if not .Values.disablePvc }}
+    {{- with .Values.fluentd.bufferStorageVolume }}
+    bufferStorageVolume: {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- end }}
     disablePvc: {{ .Values.disablePvc }}
+    {{- if .Values.fluentd.replicas }}
+    scaling:
+      replicas: {{ .Values.fluentd.replicas }}
+    {{- end }}
     {{- if .Values.global.psp.enabled }}
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
     {{- end }}
-    {{- with .Values.tolerations }}
-    tolerations:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
+    tolerations: {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with .Values.nodeSelector }}
-    nodeSelector:
-      {{- toYaml . | nindent 6 }}
+    {{- with (default .Values.nodeSelector .Values.fluentd.nodeSelector) }}
+    nodeSelector: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.resources }}
-    resources:
-      {{- toYaml . | nindent 6 }}
+    resources: {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/userroles.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/userroles.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "logging-admin"
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups:
+      - "logging.banzaicloud.io"
+    resources:
+      - flows
+      - outputs
+    verbs:
+      - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "logging-view"
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+  - apiGroups:
+      - "logging.banzaicloud.io"
+    resources:
+      - flows
+      - outputs
+      - clusterflows
+      - clusteroutputs
+    verbs:
+      - get
+      - list
+      - watch

--- a/packages/rancher-logging/generated-changes/overlay/templates/validate-install.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/validate-install.yaml
@@ -1,0 +1,5 @@
+#{{- if .Values.global.dockerRootDirectory }}
+#{{- if or (hasSuffix "/containers" .Values.global.dockerRootDirectory) (hasSuffix "/" .Values.global.dockerRootDirectory) }}
+#{{- required "global.dockerRootDirectory must not end with suffix: '/' or '/containers'" "" -}}
+#{{- end }}
+#{{- end }}

--- a/packages/rancher-logging/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/Chart.yaml.patch
@@ -1,0 +1,23 @@
+--- charts-original/Chart.yaml
++++ charts/Chart.yaml
+@@ -1,5 +1,18 @@
+ apiVersion: v1
+ appVersion: 3.9.4
+-description: A Helm chart to install Banzai Cloud logging-operator
+-name: logging-operator
++description: Collects and filter logs using highly configurable CRDs. Powered by Banzai Cloud Logging Operator.
++name: rancher-logging
+ version: 3.9.4
++icon: https://charts.rancher.io/assets/logos/logging.svg
++keywords:
++  - logging
++  - monitoring
++  - security
++annotations:
++  catalog.cattle.io/certified: rancher
++  catalog.cattle.io/namespace: cattle-logging-system
++  catalog.cattle.io/release-name: rancher-logging
++  catalog.cattle.io/ui-component: logging
++  catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
++  catalog.cattle.io/display-name: "Logging"
++  catalog.cattle.io/auto-install: rancher-logging-crd=match

--- a/packages/rancher-logging/generated-changes/patch/README.md.patch
+++ b/packages/rancher-logging/generated-changes/patch/README.md.patch
@@ -1,0 +1,10 @@
+--- charts-original/README.md
++++ charts/README.md
+@@ -68,6 +68,7 @@
+ | `securityContext`                                   | Container SecurityContext for Logging operator. [More info](https://kubernetes.io/docs/concepts/policy/security-context/) | `{"allowPrivilegeEscalation": false, "readOnlyRootFilesystem": true}` |
+ | `createCustomResource`                              | Create CRDs. | `true` |
+ | `monitoring.serviceMonitor.enabled`                 | Create Prometheus Operator servicemonitor. | `false` |
++| `global.seLinux.enabled`                            | Add seLinuxOptions to Logging resources, requires the [rke2-selinux RPM](https://github.com/rancher/rke2-selinux/releases) | `false` |
+ 
+ Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example:
+ 

--- a/packages/rancher-logging/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rancher-logging/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -56,3 +56,21 @@
+@@ -56,3 +56,30 @@
  {{- end }}
  app.kubernetes.io/managed-by: {{ .Release.Service }}
  {{- end -}}
@@ -14,11 +14,20 @@
 +{{- end -}}
 +
 +{{- define "windowsEnabled" }}
-+  {{- if not (kindIs "invalid" .Values.global.cattle.windows) }}
-+  {{- if not (kindIs "invalid" .Values.global.cattle.windows.enabled) }}
-+  {{- if .Values.global.cattle.windows.enabled }}
++{{- if not (kindIs "invalid" .Values.global.cattle.windows) }}
++{{- if not (kindIs "invalid" .Values.global.cattle.windows.enabled) }}
++{{- if .Values.global.cattle.windows.enabled }}
 +true
-+  {{- end }}
-+  {{- end }}
-+  {{- end }}
++{{- end }}
++{{- end }}
++{{- end }}
++{{- end }}
++
++{{- define "windowsPathPrefix" }}
++{{- $temp := (default "c:\\" .Values.global.cattle.rkeWindowsPathPrefix | replace "\\" "/" | replace "//" "/") }}
++{{- if (hasSuffix "/" $temp) }}
++{{- trimSuffix "/" $temp }}
++{{- else }}
++{{- $temp }}
++{{- end }}
 +{{- end }}

--- a/packages/rancher-logging/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rancher-logging/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,0 +1,24 @@
+--- charts-original/templates/_helpers.tpl
++++ charts/templates/_helpers.tpl
+@@ -56,3 +56,21 @@
+ {{- end }}
+ app.kubernetes.io/managed-by: {{ .Release.Service }}
+ {{- end -}}
++
++{{- define "system_default_registry" -}}
++{{- if .Values.global.cattle.systemDefaultRegistry -}}
++{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
++{{- else -}}
++{{- "" -}}
++{{- end -}}
++{{- end -}}
++
++{{- define "windowsEnabled" }}
++  {{- if not (kindIs "invalid" .Values.global.cattle.windows) }}
++  {{- if not (kindIs "invalid" .Values.global.cattle.windows.enabled) }}
++  {{- if .Values.global.cattle.windows.enabled }}
++true
++  {{- end }}
++  {{- end }}
++  {{- end }}
++{{- end }}

--- a/packages/rancher-logging/generated-changes/patch/templates/deployment.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/templates/deployment.yaml.patch
@@ -1,0 +1,24 @@
+--- charts-original/templates/deployment.yaml
++++ charts/templates/deployment.yaml
+@@ -33,7 +33,7 @@
+     {{- end }}
+       containers:
+         - name: {{ .Chart.Name }}
+-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
++          image: "{{ template "system_default_registry" . }}{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+           args: {{ range .Values.extraArgs }}
+             - {{ . -}}
+             {{ end }}
+@@ -51,10 +51,10 @@
+       securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
+     {{- end }}
+ 
+-      {{- with .Values.nodeSelector }}
++    {{- with .Values.nodeSelector }}
+       nodeSelector:
+         {{- toYaml . | nindent 8 }}
+-      {{- end }}
++    {{- end }}
+     {{- with .Values.affinity }}
+       affinity:
+         {{- toYaml . | nindent 8 }}

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -1,0 +1,123 @@
+--- charts-original/values.yaml
++++ charts/values.yaml
+@@ -5,7 +5,7 @@
+ replicaCount: 1
+ 
+ image:
+-  repository: ghcr.io/banzaicloud/logging-operator
++  repository: rancher/mirrored-banzaicloud-logging-operator
+   tag: 3.9.4
+   pullPolicy: IfNotPresent
+ 
+@@ -37,9 +37,14 @@
+   #   cpu: 100m
+   #   memory: 128Mi
+ 
+-nodeSelector: {}
++nodeSelector:
++  kubernetes.io/os: linux
+ 
+-tolerations: []
++tolerations:
++  - key: cattle.io/os
++    operator: "Equal"
++    value: "linux"
++    effect: NoSchedule
+ 
+ affinity: {}
+ 
+@@ -55,6 +60,9 @@
+     # Labels to query http service
+     labels: {}
+ 
++# These "rbac" settings match the upstream defaults. For only using psp in the overlay files, which
++# include the default Logging CRs created, see the "global.psp" setting. To enable psp for the entire
++# chart, enable both "rbac.psp" and "global.psp" (this may require further changes to the chart).
+ rbac:
+   enabled: true
+   psp:
+@@ -85,3 +93,84 @@
+     additionalLabels: {}
+     metricRelabelings: []
+     relabelings: []
++
++disablePvc: true
++
++systemdLogPath: "/run/log/journal"
++
++additionalLoggingSources:
++  rke:
++    enabled: false
++    fluentbit:
++      log_level: "info"
++      mem_buffer_limit: "5MB"
++  rke2:
++    enabled: false
++  k3s:
++    enabled: false
++    container_engine: "systemd"
++  aks:
++    enabled: false
++  eks:
++    enabled: false
++  gke:
++    enabled: false
++
++images:
++  config_reloader:
++    repository: rancher/mirrored-jimmidyson-configmap-reload
++    tag: v0.4.0
++  fluentbit:
++    repository: rancher/mirrored-fluent-fluent-bit
++    tag: 1.6.10
++  fluentbit_debug:
++    repository: rancher/mirrored-fluent-fluent-bit
++    tag: 1.6.10-debug
++  fluentd:
++    repository: rancher/mirrored-banzaicloud-fluentd
++    tag: v1.11.5-alpine-12
++  nodeagent_fluentbit:
++    os: "windows,linux"
++    repository: rancher/fluent-bit
++    tag: 1.6.10
++
++# These settings apply to every Logging CR, including vendor Logging CRs enabled in "additionalLoggingSources".
++# Changing these affects every Logging CR installed.
++nodeAgents:
++  tls:
++    enabled: false
++fluentd:
++  resources: {}
++  livenessProbe:
++    tcpSocket:
++      port: 24240
++    initialDelaySeconds: 30
++    periodSeconds: 15
++fluentbit:
++  resources: {}
++  tolerations:
++    - key: node-role.kubernetes.io/controlplane
++      value: "true"
++      effect: NoSchedule
++    - key: node-role.kubernetes.io/etcd
++      value: "true"
++      effect: NoExecute
++
++global:
++  cattle:
++    systemDefaultRegistry: ""
++    # Uncomment the below two lines to either enable or disable Windows logging. If this chart is
++    # installed via the Rancher UI, it will set this value to "true" if the cluster is a Windows
++    # cluster. In that scenario, if you would like to disable Windows logging on Windows clusters,
++    # set the value below to "false".
++    # windows:
++    #   enabled: true
++  # Change the "dockerRootDirectory" if the default Docker directory has changed.
++  dockerRootDirectory: ""
++  # This psp setting differs from the upstream "rbac.psp" by only enabling psp settings for the
++  # overlay files, which include the Logging CRs created, whereas the upstream "rbac.psp" affects the
++  # logging operator.
++  psp:
++    enabled: true
++  seLinux:
++    enabled: false

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,7 @@
  rbac:
    enabled: true
    psp:
-@@ -85,3 +93,84 @@
+@@ -85,3 +93,94 @@
      additionalLabels: {}
      metricRelabelings: []
      relabelings: []
@@ -87,13 +87,22 @@
 +  tls:
 +    enabled: false
 +fluentd:
-+  resources: {}
++  bufferStorageVolume: {}
 +  livenessProbe:
 +    tcpSocket:
 +      port: 24240
 +    initialDelaySeconds: 30
 +    periodSeconds: 15
++  nodeSelector: {}
++  resources: {}
++  tolerations: {}
 +fluentbit:
++  inputTail:
++    Buffer_Chunk_Size: ""
++    Buffer_Max_Size: ""
++    Mem_Buf_Limit: ""
++    Multiline_Flush: ""
++    Skip_Long_Lines: ""
 +  resources: {}
 +  tolerations:
 +    - key: node-role.kubernetes.io/controlplane
@@ -119,5 +128,6 @@
 +  # logging operator.
 +  psp:
 +    enabled: true
++  rkeWindowsPathPrefix: "c:\\"
 +  seLinux:
 +    enabled: false

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,6 +1,6 @@
 url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.4.tgz
-packageVersion: 00
-releaseCandidateVersion: 08
+packageVersion: 01
+releaseCandidateVersion: 00
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,0 +1,9 @@
+url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.9.4.tgz
+packageVersion: 00
+releaseCandidateVersion: 08
+additionalCharts:
+  - workingDir: charts-crd
+    crdOptions:
+      templateDirectory: crd-template
+      crdDirectory: templates
+      addCRDValidationToMainChart: true

--- a/packages/rancher-logging/templates/crd-template/Chart.yaml
+++ b/packages/rancher-logging/templates/crd-template/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+version: 3.9.4
+description: Installs the CRDs for rancher-logging.
+name: rancher-logging-crd
+type: application
+annotations:
+  catalog.cattle.io/hidden: "true"
+  catalog.cattle.io/release-name: rancher-logging-crd
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/namespace: cattle-logging-system

--- a/packages/rancher-logging/templates/crd-template/README.md
+++ b/packages/rancher-logging/templates/crd-template/README.md
@@ -1,0 +1,2 @@
+# rancher-logging-crd
+A Rancher chart that installs the CRDs used by rancher-logging.


### PR DESCRIPTION
## Description
This PR is split into two commits: a copy commit, similar to PRs in [rancher/system-charts](https://github.com/rancher/system-charts), and a commit with the desired changes.

## Objectives
- Add the `rancher-logging` package from `dev-v2.5-source` with no changes
- Add RKE Windows PathPrefix and standardize Windows paths within the logging chart (continuation of #1169)
- Add buffer configuration for `fluent-bit` for logging (continuation of #1121)
- Add `fluentd` options from frequent requests (originally from @dbason; continuation of #1112)
- Tidy the Logging CRs in the chart for style consistency and general cleanup (it also addresses: https://github.com/rancher/charts/pull/1182#commitcomment-50398194)

## Why are these changes in one PR rather than multiple?
1. All continuations of PRs were already approved and reviewed
1. Given the slated timing for 2.6 release, QA may not be able to test individual RCs for each commit (making the split for separate PRs less effective)
1. All major changes are unrelated to one another, so if regressions occur, they will be isolated

## Relevant issues
- https://github.com/rancher/rancher/issues/28401
- https://github.com/rancher/rancher/issues/31807
- https://github.com/rancher/rancher/issues/32268
- https://github.com/rancher/rancher/issues/32541