### PR TITLE
Add sriov chart

### DIFF
--- a/packages/rancher-sriov/charts/Chart.yaml
+++ b/packages/rancher-sriov/charts/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: sriov
+description: Install SR-IOV operator, cni and device plugin.
+version: v1.0.0-build20210429
+appVersion: v1.0.0
+home: https://github.com/k8snetworkplumbingwg/sriov-network-operator
+keywords:
+  - sr-iov
+  - Networking
+sources:
+  - https://github.com/rancher/charts
+maintainers:
+  - name: Rancher Labs
+    email: charts@rancher.com
+annotations:
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/experimental: true
+  catalog.cattle.io/namespace: cattle-sriov-system
+  catalog.cattle.io/release-name: sriov
+  catalog.cattle.io/os: linux
+  catalog.cattle.io/auto-install: sriov-crd=match

--- a/packages/rancher-sriov/charts/app-README.md
+++ b/packages/rancher-sriov/charts/app-README.md
@@ -1,0 +1,13 @@
+This chart is based on the upstream [k8snetworkplumbingwg/sriov-network-operator](https://github.com/k8snetworkplumbingwg/sriov-network-operator) project. The chart deploys the SR-IOV Operator and its CRDs. It allows users to deploy SR-IOV CNI, which can be used, together with Multus, to provide high performing extra network interfaces to pods.
+
+
+The chart installs the following components:
+
+    SR-IOV Operator - The operator helps provision and configure SR-IOV CNI plugin and Device plugin. It requires Multus to operate correctly.
+    SR-IOV Network Config Daemon - Deployed by the operator, this daemon is responsible for discovering the SR-IOV NICs on each node
+
+Note that SR-IOV requires NICs that support SR-IOV and the activation of specific configuration options in the operating system. Nodes that fultill these requirements should be labeled with:
+
+`feature.node.kubernetes.io/network-sriov.capable=true`
+
+The SR-IOV Network Config Daemon will be deployed on such capable nodes. For more information on how to use this feature, refer to our RKE2 networking docs.

--- a/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovibnetworks_crd.yaml
+++ b/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovibnetworks_crd.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: sriovibnetworks.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovIBNetwork
+    listKind: SriovIBNetworkList
+    plural: sriovibnetworks
+    singular: sriovibnetwork
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovIBNetwork is the Schema for the sriovibnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovIBNetworkSpec defines the desired state of SriovIBNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
+                  supported: (infinibandGUID), e.g. ''{"infinibandGUID": true}'''
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovIBNetworkStatus defines the observed state of SriovIBNetwork
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+

--- a/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovnetwork_crd.yaml
+++ b/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovnetwork_crd.yaml
@@ -1,0 +1,110 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: sriovnetworks.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovNetwork
+    listKind: SriovNetworkList
+    plural: sriovnetworks
+    singular: sriovnetwork
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetwork is the Schema for the sriovnetworks API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkSpec defines the desired state of SriovNetwork
+            properties:
+              capabilities:
+                description: 'Capabilities to be configured for this network. Capabilities
+                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                type: string
+              ipam:
+                description: IPAM configuration to be used for this network.
+                type: string
+              linkState:
+                description: VF link state (enable|disable|auto)
+                enum:
+                - auto
+                - enable
+                - disable
+                type: string
+              maxTxRate:
+                description: Maximum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting)
+                minimum: 0
+                type: integer
+              metaPlugins:
+                description: MetaPluginsConfig configuration to be used in order to
+                  chain metaplugins to the sriov interface returned by the operator.
+                type: string
+              minTxRate:
+                description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no
+                  rate limiting). min_tx_rate should be <= max_tx_rate.
+                minimum: 0
+                type: integer
+              networkNamespace:
+                description: Namespace of the NetworkAttachmentDefinition custom resource
+                type: string
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+              spoofChk:
+                description: VF spoof check, (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              trust:
+                description: VF trust mode (on|off)
+                enum:
+                - "on"
+                - "off"
+                type: string
+              vlan:
+                description: VLAN ID to assign for the VF. Defaults to 0.
+                maximum: 4096
+                minimum: 0
+                type: integer
+              vlanQoS:
+                description: VLAN QoS ID to assign for the VF. Defaults to 0.
+                maximum: 7
+                minimum: 0
+                type: integer
+            required:
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkStatus defines the observed state of SriovNetwork
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+

--- a/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovnetworknodepolicy_crd.yaml
+++ b/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovnetworknodepolicy_crd.yaml
@@ -1,0 +1,132 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: sriovnetworknodepolicies.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovNetworkNodePolicy
+    listKind: SriovNetworkNodePolicyList
+    plural: sriovnetworknodepolicies
+    singular: sriovnetworknodepolicy
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodePolicy is the Schema for the sriovnetworknodepolicies
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
+            properties:
+              deviceType:
+                description: The driver type for configured VFs. Allowed value "netdevice",
+                  "vfio-pci". Defaults to netdevice.
+                enum:
+                - netdevice
+                - vfio-pci
+                type: string
+              eSwitchMode:
+                description: NIC Device Mode. Allowed value "legacy","switchdev".
+                enum:
+                - legacy
+                - switchdev
+                type: string
+              isRdma:
+                description: RDMA mode. Defaults to false.
+                type: boolean
+              linkType:
+                description: NIC Link Type. Allowed value "eth", "ETH", "ib", and
+                  "IB".
+                enum:
+                - eth
+                - ETH
+                - ib
+                - IB
+                type: string
+              mtu:
+                description: MTU of VF
+                minimum: 1
+                type: integer
+              nicSelector:
+                description: NicSelector selects the NICs to be configured
+                properties:
+                  deviceID:
+                    description: The device hex code of SR-IoV device. Allowed value
+                      "0d58", "1572", "158b", "1013", "1015", "1017", "101b".
+                    type: string
+                  netFilter:
+                    description: Infrastructure Networking selection filter. Allowed
+                      value "openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                    type: string
+                  pfNames:
+                    description: Name of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  rootDevices:
+                    description: PCI address of SR-IoV PF.
+                    items:
+                      type: string
+                    type: array
+                  vendor:
+                    description: The vendor hex code of SR-IoV device. Allowed value
+                      "8086", "15b3".
+                    type: string
+                type: object
+              nodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              numVfs:
+                description: Number of VFs for each PF
+                minimum: 0
+                type: integer
+              priority:
+                description: Priority of the policy, higher priority policies can
+                  override lower ones.
+                maximum: 99
+                minimum: 0
+                type: integer
+              resourceName:
+                description: SRIOV Network device plugin endpoint resource name
+                type: string
+            required:
+            - nicSelector
+            - nodeSelector
+            - numVfs
+            - resourceName
+            type: object
+          status:
+            description: SriovNetworkNodePolicyStatus defines the observed state of
+              SriovNetworkNodePolicy
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+

--- a/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovnetworknodestate_crd.yaml
+++ b/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovnetworknodestate_crd.yaml
@@ -1,0 +1,154 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: sriovnetworknodestates.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovNetworkNodeState
+    listKind: SriovNetworkNodeStateList
+    plural: sriovnetworknodestates
+    singular: sriovnetworknodestate
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovNetworkNodeStateSpec defines the desired state of SriovNetworkNodeState
+            properties:
+              dpConfigVersion:
+                type: string
+              interfaces:
+                items:
+                  properties:
+                    eSwitchMode:
+                      type: string
+                    linkType:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    vfGroups:
+                      items:
+                        properties:
+                          deviceType:
+                            type: string
+                          policyName:
+                            type: string
+                          resourceName:
+                            type: string
+                          vfRange:
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+            type: object
+          status:
+            description: SriovNetworkNodeStateStatus defines the observed state of
+              SriovNetworkNodeState
+            properties:
+              interfaces:
+                items:
+                  properties:
+                    Vfs:
+                      items:
+                        properties:
+                          Vlan:
+                            type: integer
+                          assigned:
+                            type: string
+                          deviceID:
+                            type: string
+                          driver:
+                            type: string
+                          mac:
+                            type: string
+                          mtu:
+                            type: integer
+                          name:
+                            type: string
+                          pciAddress:
+                            type: string
+                          vendor:
+                            type: string
+                          vfID:
+                            type: integer
+                        required:
+                        - pciAddress
+                        - vfID
+                        type: object
+                      type: array
+                    deviceID:
+                      type: string
+                    driver:
+                      type: string
+                    eSwitchMode:
+                      type: string
+                    linkSpeed:
+                      type: string
+                    linkType:
+                      type: string
+                    mac:
+                      type: string
+                    mtu:
+                      type: integer
+                    name:
+                      type: string
+                    netFilter:
+                      type: string
+                    numVfs:
+                      type: integer
+                    pciAddress:
+                      type: string
+                    totalvfs:
+                      type: integer
+                    vendor:
+                      type: string
+                  required:
+                  - pciAddress
+                  type: object
+                type: array
+              lastSyncError:
+                type: string
+              syncStatus:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+

--- a/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovoperatorconfig_crd.yaml
+++ b/packages/rancher-sriov/charts/crds/sriov-network-operator-sriovoperatorconfig_crd.yaml
@@ -1,0 +1,80 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sriovoperatorconfigs.sriovnetwork.openshift.io
+spec:
+  group: sriovnetwork.openshift.io
+  names:
+    kind: SriovOperatorConfig
+    listKind: SriovOperatorConfigList
+    plural: sriovoperatorconfigs
+    singular: sriovoperatorconfig
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: SriovOperatorConfig is the Schema for the sriovoperatorconfigs
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SriovOperatorConfigSpec defines the desired state of SriovOperatorConfig
+            properties:
+              configDaemonNodeSelector:
+                additionalProperties:
+                  type: string
+                description: NodeSelector selects the nodes to be configured
+                type: object
+              disableDrain:
+                description: Flag to disable nodes drain during debugging
+                type: boolean
+              enableInjector:
+                description: Flag to control whether the network resource injector
+                  webhook shall be deployed
+                type: boolean
+              enableOperatorWebhook:
+                description: Flag to control whether the operator admission controller
+                  webhook shall be deployed
+                type: boolean
+              enableOvsOffload:
+                description: Flag to enable OVS hardware offload. Set to 'true' to
+                  provision switchdev-configuration.service and enable OpenvSwitch
+                  hw-offload on nodes.
+                type: boolean
+              logLevel:
+                description: Flag to control the log verbose level of the operator.
+                  Set to '0' to show only the basic logs. And set to '2' to show all
+                  the available logs.
+                maximum: 2
+                minimum: 0
+                type: integer
+            type: object
+          status:
+            description: SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig
+            properties:
+              injector:
+                description: Show the runtime status of the network resource injector
+                  webhook
+                type: string
+              operatorWebhook:
+                description: Show the runtime status of the operator admission controller
+                  webhook
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/packages/rancher-sriov/charts/templates/NOTES.txt
+++ b/packages/rancher-sriov/charts/templates/NOTES.txt
@@ -1,0 +1,10 @@
+{{- if or (.Values.webhook.enable) (.Values.injector.enable) }}
+{{- if not .Values.cert_manager }}
+Thank you for installing {{ .Chart.Name }}.
+
+WARNING! Self signed certificates have been generated for webhooks.
+These certificates have a one-year validity and will not be rotated
+automatically. This should not be a production cluster. Please deploy
+and use cert-manager for production clusters.
+{{- end }}
+{{- end }}

--- a/packages/rancher-sriov/charts/templates/_helpers.tpl
+++ b/packages/rancher-sriov/charts/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "system_default_registry" -}}
+{{- if .Values.global.systemDefaultRegistry -}}
+{{- printf "%s/" .Values.global.cattle.systemDefaultRegistry -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end -}}

--- a/packages/rancher-sriov/charts/templates/_webhook-certs.tpl
+++ b/packages/rancher-sriov/charts/templates/_webhook-certs.tpl
@@ -1,0 +1,31 @@
+{{/*
+Generate TLS certificates for webhooks.
+Note: these 2 lines, that are repeated several times below, are a trick to
+ensure the CA certs are generated only once:
+    $ca := .ca | default (genCA "sriov-network-operator.k8s.cni.cncf.io" 365)
+    $_ := set . "ca" $ca -
+Please, don't try to "simplify" them as without this trick, every generated
+certificate would be signed by a different CA.
+*/}}
+{{- define "sriov_operator_ca_cert" }}
+{{- $ca := .ca | default (genCA "sriov-network-operator.k8s.cni.cncf.io" 365) -}}
+{{- $_ := set . "ca" $ca -}}
+{{- printf "%s" $ca.Cert | b64enc -}}
+{{- end }}
+{{- define "sriov_operator_cert" }}
+{{- $ca := .ca | default (genCA "sriov-network-operator.k8s.cni.cncf.io" 365) -}}
+{{- $_ := set . "ca" $ca -}}
+{{- $cn := printf "operator-webhook-service.%s.svc" .Release.Namespace -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end }}
+{{- define "sriov_resource_injector_cert" }}
+{{- $ca := .ca | default (genCA "sriov-network-operator.k8s.cni.cncf.io" 365) -}}
+{{- $_ := set . "ca" $ca -}}
+{{- $cn := printf "network-resources-injector-service.%s.svc" .Release.Namespace -}}
+{{- $cert := genSignedCert $cn nil (list $cn) 365 $ca -}}
+tls.crt: {{ $cert.Cert | b64enc }}
+tls.key: {{ $cert.Key | b64enc }}
+{{- end }}
+

--- a/packages/rancher-sriov/charts/templates/admin-role.yaml
+++ b/packages/rancher-sriov/charts/templates/admin-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-admin
+rules:
+- apiGroups:
+  - sriovnetwork.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/packages/rancher-sriov/charts/templates/certmanagercerts.yaml
+++ b/packages/rancher-sriov/charts/templates/certmanagercerts.yaml
@@ -1,0 +1,43 @@
+{{- if or .Values.webhook.enable .Values.injector.enable -}}
+{{- if .Values.cert_manager -}}
+{{- if not (.Capabilities.APIVersions.Has "cert-manager.io/v1") -}}
+{{- required "cert-manager is required but not found!" "" -}}
+{{- end -}}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: sriov-network-operator-selfsigned-issuer
+  namespace: {{ .Release.Namespace }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: operator-webhook-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: operator-webhook-service
+  dnsNames:
+  - operator-webhook-service.{{ .Release.Namespace }}.svc
+  issuerRef:
+    name: sriov-network-operator-selfsigned-issuer
+  privateKey:
+    rotationPolicy: Always
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: network-resources-injector-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: network-resources-injector-secret
+  dnsNames:
+  - network-resources-injector-service.{{ .Release.Namespace }}.svc
+  issuerRef:
+    name: sriov-network-operator-selfsigned-issuer
+  privateKey:
+    rotationPolicy: Always
+{{- end -}}
+{{- end -}}
+

--- a/packages/rancher-sriov/charts/templates/clusterrole.yaml
+++ b/packages/rancher-sriov/charts/templates/clusterrole.yaml
@@ -1,0 +1,47 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-network-operator
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["namespaces", "serviceaccounts"]
+  verbs: ["*"]
+- apiGroups: ["k8s.cni.cncf.io"]
+  resources: ["network-attachment-definitions"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["clusterroles", "clusterrolebindings"]
+  verbs: ["*"]
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+  verbs: ["*"]
+- apiGroups: ["sriovnetwork.openshift.io"]
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-network-config-daemon
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get", "list", "watch", "patch", "update"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods/eviction"]
+  verbs: ["create"]

--- a/packages/rancher-sriov/charts/templates/clusterrolebinding.yaml
+++ b/packages/rancher-sriov/charts/templates/clusterrolebinding.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sriov-network-operator
+roleRef:
+  kind: ClusterRole
+  name: sriov-network-operator
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: sriov-network-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: sriov-network-config-daemon
+roleRef:
+  kind: ClusterRole
+  name: sriov-network-config-daemon
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+  name: sriov-network-config-daemon

--- a/packages/rancher-sriov/charts/templates/deployment.yaml
+++ b/packages/rancher-sriov/charts/templates/deployment.yaml
@@ -1,0 +1,90 @@
+{{- if not (.Capabilities.APIVersions.Has "k8s.cni.cncf.io/v1/NetworkAttachmentDefinition") -}}
+{{- required "rke2-multus is required but not found!" "" -}}
+{{- end -}}
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: {{ .Release.Namespace }}
+spec:
+  # Add fields here
+  enableInjector: {{ .Values.injector.enable }}
+  enableOperatorWebhook: {{ .Values.webhook.enable }}
+  configDaemonNodeSelector: {feature.node.kubernetes.io/network-sriov.capable: "true"}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sriov-network-operator
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: sriov-network-operator
+  template:
+    metadata:
+      labels:
+        name: sriov-network-operator
+    spec:
+      nodeSelector:
+        node-role.kubernetes.io/master: "true"
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoSchedule
+        key: cattle.io/os
+        operator: Equal
+        value: linux
+      serviceAccountName: sriov-network-operator
+      containers:
+        - name: sriov-network-operator
+          # Replace this with the built image name
+          image: {{ include "system_default_registry" . }}{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}
+          command:
+          - sriov-network-operator
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SRIOV_CNI_IMAGE
+              value: {{ include "system_default_registry" . }}{{ .Values.cni.image.repository }}:{{ .Values.cni.image.tag }}
+            - name: SRIOV_INFINIBAND_CNI_IMAGE
+              value: {{ include "system_default_registry" . }}{{ .Values.cni_infiniband.image.repository }}:{{ .Values.cni_infiniband.image.tag }}
+            - name: SRIOV_DEVICE_PLUGIN_IMAGE
+              value: {{ include "system_default_registry" . }}{{ .Values.device_plugin.image.repository }}:{{ .Values.device_plugin.image.tag }}
+            - name: NETWORK_RESOURCES_INJECTOR_IMAGE
+              value: {{ include "system_default_registry" . }}{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}
+            - name: OPERATOR_NAME
+              value: sriov-network-operator
+            - name: SRIOV_NETWORK_CONFIG_DAEMON_IMAGE
+              value: {{ include "system_default_registry" . }}{{ .Values.config_daemon.image.repository }}:{{ .Values.config_daemon.image.tag }}
+            - name: SRIOV_NETWORK_WEBHOOK_IMAGE
+              value: {{ include "system_default_registry" . }}{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag }}
+            - name: RESOURCE_PREFIX
+              value: rancher.io
+            - name: ENABLE_ADMISSION_CONTROLLER
+              value: "false"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: RELEASE_VERSION
+              value: {{ .Values.operator.image.tag }}
+            - name: SRIOV_CNI_BIN_PATH
+              value: /opt/cni/bin
+            - name: CLUSTER_TYPE
+              value: "kubernetes"
+            {{- if or .Values.webhook.enable .Values.injector.enable }}
+            {{- if not .Values.cert_manager }}
+            - name: WEBHOOK_CA_BUNDLE
+              value: "{{ include "sriov_operator_ca_cert" . }}"
+            {{- end }}
+            {{- end }}

--- a/packages/rancher-sriov/charts/templates/edit-role.yaml
+++ b/packages/rancher-sriov/charts/templates/edit-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-edit
+rules:
+- apiGroups:
+  - sriovnetwork.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/packages/rancher-sriov/charts/templates/role.yaml
+++ b/packages/rancher-sriov/charts/templates/role.yaml
@@ -1,0 +1,96 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sriov-network-operator
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - apps
+  resourceNames:
+  - sriov-network-operator
+  resources:
+  - deployments/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - serviceaccounts
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - '*'
+- apiGroups:
+  - sriovnetwork.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operator-webhook-sa
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  

--- a/packages/rancher-sriov/charts/templates/rolebinding.yaml
+++ b/packages/rancher-sriov/charts/templates/rolebinding.yaml
@@ -1,0 +1,38 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sriov-network-operator
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: sriov-network-operator
+roleRef:
+  kind: Role
+  name: sriov-network-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: sriov-network-config-daemon
+roleRef:
+  kind: Role
+  name: sriov-network-config-daemon
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operator-webhook-sa
+  namespace: {{ .Release.Namespace }}
+subjects:
+- kind: ServiceAccount
+  name: operator-webhook-sa
+roleRef:
+  kind: Role
+  name: operator-webhook-sa
+  apiGroup: rbac.authorization.k8s.io

--- a/packages/rancher-sriov/charts/templates/secrets.yaml
+++ b/packages/rancher-sriov/charts/templates/secrets.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.cert_manager -}}
+{{- if .Values.webhook.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: operator-webhook-service
+  namespace: {{ .Release.Namespace }}
+data:
+{{ include "sriov_operator_cert" . | indent 2 }}
+{{- end }}
+---
+{{- if .Values.injector.enable }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: network-resources-injector-secret
+  namespace: {{ .Release.Namespace }}
+data:
+{{ include "sriov_resource_injector_cert" . | indent 2 }}
+{{- end }}
+{{- end }}

--- a/packages/rancher-sriov/charts/templates/serviceaccount.yaml
+++ b/packages/rancher-sriov/charts/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-network-operator
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sriov-network-config-daemon
+  namespace: {{ .Release.Namespace }}

--- a/packages/rancher-sriov/charts/templates/view-role.yaml
+++ b/packages/rancher-sriov/charts/templates/view-role.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: sriov-view
+rules:
+- apiGroups:
+  - sriovnetwork.openshift.io
+  resources:
+  - '*'
+  verbs:
+  - ["get", "watch", "list"]

--- a/packages/rancher-sriov/charts/values.yaml
+++ b/packages/rancher-sriov/charts/values.yaml
@@ -1,0 +1,46 @@
+operator:
+  image:
+    repository: rancher/hardened-sriov-network-operator
+    tag: v1.0.0-build20210429
+
+cni:
+  image:
+    repository: rancher/hardened-sriov-cni
+    tag: v2.6-build20210310
+
+cni_infiniband:
+  image:
+    repository: rancher/hardened-ib-sriov-cni
+    tag: v1.0.0-build20210310
+
+device_plugin:
+  image:
+    repository: rancher/hardened-sriov-network-device-plugin
+    tag: v3.3.1-build20210310
+
+injector:
+  image:
+    repository: rancher/hardened-sriov-network-resources-injector
+    tag: v1-build20210310
+  enable: false
+
+config_daemon:
+  image:
+    repository: rancher/hardened-sriov-network-config-daemon
+    tag: v1.0.0-build20210429
+
+webhook:
+  image:
+    repository: rancher/hardened-sriov-network-webhook
+    tag: v1.0.0-build20210429
+  enable: false
+
+# cert_manager enables integration with cert-manager to generate
+# certificates for the operator webhooks. Otherwise the chart will
+# generate ad-hoc certificates with no automated renewal at expiration,
+# not recommended for production clusters.
+cert_manager: true
+
+global:
+  cattle:
+    systemDefaultRegistry: ""

--- a/packages/rancher-sriov/package.yaml
+++ b/packages/rancher-sriov/package.yaml
@@ -1,0 +1,9 @@
+url: local
+packageVersion: 01
+releaseCandidateVersion: 00
+additionalCharts:
+  - workingDir: charts-crd
+    crdOptions:
+      templateDirectory: crd-template
+      crdDirectory: templates
+      addCRDValidationToMainChart: true

--- a/packages/rancher-sriov/templates/crd-template/Chart.yaml
+++ b/packages/rancher-sriov/templates/crd-template/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+version: v1.0.0
+description: Installs the CRDs for rke2-sriov.
+name: sriov-crd
+type: application
+annotations:
+  catalog.cattle.io/experimental: "true"
+  catalog.cattle.io/release-name: sriov-crd
+  catalog.cattle.io/namespace: cattle-sriov-system
+  catalog.cattle.io/certified: rancher
+  catalog.cattle.io/hidden: "true"


### PR DESCRIPTION
SRIOV is a dataplane acceleration technique. In Kubernetes, it is used in pods that require high packet throughput. The way to deploy it is by configuring the sriov-cni as a secondary CNI-plugin in Multus. That way, the sriov-cni will manage the extra network interface that the pod requests.

This is a feature for rke2 but we want to put it in rancher charts rather than rke2-charts. The reason is that using it is a very advanced use case and for tech preview we wont be able to integrate it directly into rke2. User will have to deploy their primary CNI and then deploy sri-ov separately via helm after the fact. We cant put it into rke2-charts because that helm repo is really intended for producing charts that can be embedded directly into rke2. we dont want to push it as a helm repo you should configure to use directly from helm

Signed-off-by: Manuel Buil <mbuil@suse.com>