### PR TITLE
bump rancher-backup to 1.0.5-rc1

### DIFF
--- a/packages/rancher-backup-crd/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-backup-crd/generated-changes/patch/Chart.yaml.patch
@@ -4,10 +4,10 @@
    catalog.cattle.io/namespace: cattle-resources-system
    catalog.cattle.io/release-name: rancher-backup-crd
  apiVersion: v2
--appVersion: 1.0.4-rc4
-+appVersion: 1.0.4
+-appVersion: 1.0.5-rc1
++appVersion: 1.0.5
  description: Installs the CRDs for rancher-backup.
  name: rancher-backup-crd
  type: application
--version: 1.0.4-rc4
-+version: 1.0.4
+-version: 1.0.5-rc1
++version: 1.0.5

--- a/packages/rancher-backup-crd/package.yaml
+++ b/packages/rancher-backup-crd/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/rancher/backup-restore-operator/releases/download/v1.0.4-rc4/rancher-backup-crd-1.0.4-rc4.tgz
+url: https://github.com/rancher/backup-restore-operator/releases/download/v1.0.5-rc1/rancher-backup-crd-1.0.5-rc1.tgz
 packageVersion: 00
-releaseCandidateVersion: 04
+releaseCandidateVersion: 01

--- a/packages/rancher-backup/generated-changes/patch/Chart.yaml.patch
+++ b/packages/rancher-backup/generated-changes/patch/Chart.yaml.patch
@@ -4,13 +4,13 @@
    catalog.cattle.io/scope: management
    catalog.cattle.io/ui-component: rancher-backup
  apiVersion: v2
--appVersion: 1.0.4-rc4
-+appVersion: 1.0.4
+-appVersion: 1.0.5-rc1
++appVersion: 1.0.5
  description: Provides ability to back up and restore the Rancher application running on any Kubernetes cluster
  icon: https://charts.rancher.io/assets/logos/backup-restore.svg
  keywords:
  - applications
  - infrastructure
  name: rancher-backup
--version: 1.0.4-rc4
-+version: 1.0.4
+-version: 1.0.5-rc1
++version: 1.0.5

--- a/packages/rancher-backup/package.yaml
+++ b/packages/rancher-backup/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/rancher/backup-restore-operator/releases/download/v1.0.4-rc4/rancher-backup-1.0.4-rc4.tgz
+url: https://github.com/rancher/backup-restore-operator/releases/download/v1.0.5-rc1/rancher-backup-1.0.5-rc1.tgz
 packageVersion: 00
-releaseCandidateVersion: 04
+releaseCandidateVersion: 01


### PR DESCRIPTION

cut a new Chart version 1.0.5 which contains the fix for the following issues: 
https://github.com/rancher/backup-restore-operator/issues/81
https://github.com/rancher/backup-restore-operator/issues/90
https://github.com/rancher/backup-restore-operator/issues/104
