### PR TITLE
Fix/issue 3917

### DIFF
--- a/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/_helpers.tpl
+++ b/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/_helpers.tpl
@@ -121,3 +121,28 @@ Set kube-audit file name based on distribution
 {{ required "Filename of the kube-audit log is required" .Values.additionalLoggingSources.kubeAudit.auditFilename }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+A shared list of custom parsers for the vairous fluentbit pods rancher creates
+*/}}
+{{- define "logging-operator.parsers" -}}
+[PARSER]
+    Name              klog
+    Format            regex
+    Regex             ^(?<level>[IWEF])(?<timestamp>\d{4} \d{2}:\d{2}:\d{2}).\d{6} +?(?<thread_id>\d+) (?<filename>.+):(?<linenumber>\d+)] (?<message>.+)
+    Time_Key          timestamp
+    Time_Format       %m%d %T
+
+[PARSER]
+    Name              rancher
+    Format            regex
+    Regex             ^time="(?<timestamp>.+)" level=(?<level>.+) msg="(?<msg>.+)"$
+    Time_Key          timestamp
+    Time_Format       %FT%TZ
+
+[PARSER]
+    Name              etcd
+    Format            json
+    Time_Key          ts
+    Time_Format       %FT%TZ
+{{- end -}}

--- a/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/loggings/k3s/configmap.yaml
+++ b/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/loggings/k3s/configmap.yaml
@@ -13,6 +13,7 @@ data:
         Daemon            Off
         Log_Level         info
         Coro_Stack_Size   24576
+        Parsers_File      parsers.conf
 
     [INPUT]
         Name              systemd
@@ -22,6 +23,28 @@ data:
         {{- if .Values.additionalLoggingSources.k3s.stripUnderscores }}
         Strip_Underscores On
         {{- end }}
+        Systemd_Filter    _SYSTEMD_UNIT=k3s-agent.service
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            klog
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            rancher
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            etcd
+        Reserve_Data      On
 
     [OUTPUT]
         Name              forward
@@ -29,4 +52,6 @@ data:
         Host              {{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc
         Port              24240
         Retry_Limit       False
+  parsers.conf: |
+{{ include "logging-operator.parsers" . | indent 4 }}
 {{- end }}

--- a/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/loggings/rke2/configmap.yaml
+++ b/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/loggings/rke2/configmap.yaml
@@ -13,16 +13,38 @@ data:
         Daemon            Off
         Log_Level         info
         Coro_Stack_Size   24576
+        Parsers_File      parsers.conf
 
     [INPUT]
         Name              systemd
         Tag               rke2
-        Path              {{ .Values.systemdLogPath | default "/var/log/journal" }}
+        Path              {{ .Values.systemdLogPath | default "/var/run/journal" }}
         Systemd_Filter    _SYSTEMD_UNIT=rke2-server.service
         Systemd_Filter    _SYSTEMD_UNIT=rke2-agent.service
         {{- if .Values.additionalLoggingSources.rke2.stripUnderscores }}
         Strip_Underscores On
         {{- end }}
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            klog
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            rancher
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            etcd
+        Reserve_Data      On
 
     [OUTPUT]
         Name              forward
@@ -30,4 +52,6 @@ data:
         Host              {{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc
         Port              24240
         Retry_Limit       False
+  parsers.conf: |
+{{ include "logging-operator.parsers" . | indent 4 }}
 {{- end }}

--- a/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/loggings/rke2/daemonset.yaml
+++ b/charts/rancher-logging/rancher-logging/100.0.0+up3.10.0/templates/loggings/rke2/daemonset.yaml
@@ -10,13 +10,15 @@ spec:
       name: {{ .Release.Name }}-rke2-journald-aggregator
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/loggings/rke2/configmap.yaml") . | sha256sum }}
       name: "{{ .Release.Name }}-rke2-journald-aggregator"
       namespace: "{{ .Release.Namespace }}"
       labels:
         name: {{ .Release.Name }}-rke2-journald-aggregator
     spec:
       containers:
-        - name: fluentd
+        - name: fluentbit
           image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}:{{ .Values.images.fluentbit.tag }}"
           {{- if .Values.global.seLinux.enabled }}
           securityContext:

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/configmap.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/k3s/configmap.yaml
@@ -13,6 +13,7 @@ data:
         Daemon            Off
         Log_Level         info
         Coro_Stack_Size   24576
+        Parsers_File      parsers.conf
 
     [INPUT]
         Name              systemd
@@ -22,6 +23,28 @@ data:
         {{- if .Values.additionalLoggingSources.k3s.stripUnderscores }}
         Strip_Underscores On
         {{- end }}
+        Systemd_Filter    _SYSTEMD_UNIT=k3s-agent.service
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            klog
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            rancher
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            etcd
+        Reserve_Data      On
 
     [OUTPUT]
         Name              forward
@@ -29,4 +52,6 @@ data:
         Host              {{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc
         Port              24240
         Retry_Limit       False
+  parsers.conf: |
+{{ include "logging-operator.parsers" . | indent 4 }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/configmap.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/configmap.yaml
@@ -13,16 +13,38 @@ data:
         Daemon            Off
         Log_Level         info
         Coro_Stack_Size   24576
+        Parsers_File      parsers.conf
 
     [INPUT]
         Name              systemd
         Tag               rke2
-        Path              {{ .Values.systemdLogPath | default "/var/log/journal" }}
+        Path              {{ .Values.systemdLogPath | default "/var/run/journal" }}
         Systemd_Filter    _SYSTEMD_UNIT=rke2-server.service
         Systemd_Filter    _SYSTEMD_UNIT=rke2-agent.service
         {{- if .Values.additionalLoggingSources.rke2.stripUnderscores }}
         Strip_Underscores On
         {{- end }}
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            klog
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            rancher
+        Reserve_Data      On
+
+    [FILTER]
+        Name              parser
+        Match             *
+        Key_Name          MESSAGE
+        Parser            etcd
+        Reserve_Data      On
 
     [OUTPUT]
         Name              forward
@@ -30,4 +52,6 @@ data:
         Host              {{ .Release.Name }}-fluentd.{{ .Release.Namespace }}.svc
         Port              24240
         Retry_Limit       False
+  parsers.conf: |
+{{ include "logging-operator.parsers" . | indent 4 }}
 {{- end }}

--- a/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/loggings/rke2/daemonset.yaml
@@ -10,13 +10,15 @@ spec:
       name: {{ .Release.Name }}-rke2-journald-aggregator
   template:
     metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/loggings/rke2/configmap.yaml") . | sha256sum }}
       name: "{{ .Release.Name }}-rke2-journald-aggregator"
       namespace: "{{ .Release.Namespace }}"
       labels:
         name: {{ .Release.Name }}-rke2-journald-aggregator
     spec:
       containers:
-        - name: fluentd
+        - name: fluentbit
           image: "{{ template "system_default_registry" . }}{{ .Values.images.fluentbit.repository }}:{{ .Values.images.fluentbit.tag }}"
           {{- if .Values.global.seLinux.enabled }}
           securityContext:

--- a/packages/rancher-logging/generated-changes/patch/templates/_helpers.tpl.patch
+++ b/packages/rancher-logging/generated-changes/patch/templates/_helpers.tpl.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/_helpers.tpl
 +++ charts/templates/_helpers.tpl
-@@ -56,3 +56,68 @@
+@@ -56,3 +56,93 @@
  {{- end }}
  app.kubernetes.io/managed-by: {{ .Release.Service }}
  {{- end -}}
@@ -68,5 +68,30 @@
 +{{- else -}}
 +{{ required "Filename of the kube-audit log is required" .Values.additionalLoggingSources.kubeAudit.auditFilename }}
 +{{- end -}}
++{{- end -}}
++
++{{/*
++A shared list of custom parsers for the vairous fluentbit pods rancher creates
++*/}}
++{{- define "logging-operator.parsers" -}}
++[PARSER]
++    Name              klog
++    Format            regex
++    Regex             ^(?<level>[IWEF])(?<timestamp>\d{4} \d{2}:\d{2}:\d{2}).\d{6} +?(?<thread_id>\d+) (?<filename>.+):(?<linenumber>\d+)] (?<message>.+)
++    Time_Key          timestamp
++    Time_Format       %m%d %T
++
++[PARSER]
++    Name              rancher
++    Format            regex
++    Regex             ^time="(?<timestamp>.+)" level=(?<level>.+) msg="(?<msg>.+)"$
++    Time_Key          timestamp
++    Time_Format       %FT%TZ
++
++[PARSER]
++    Name              etcd
++    Format            json
++    Time_Key          ts
++    Time_Format       %FT%TZ
 +{{- end -}}
 \ No newline at end of file


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/32917
https://github.com/rancher/rancher/issues/33046
https://github.com/rancher/rancher/issues/33328

# Problem
Rancher logging gets all of the metadata for the control plane logs of k3s and rke2 from journald.  Due to limitations of journald this makes it difficult to search these logs and timestamps are recorded as when fluent bit collected the log, not when the event actually occurred.  

# Solution
By adding custom parsers for most of the log formats generated by k3s and rke2 we can gather richer logs with accurate timestamps.

# Testing
We should test on k3s HA setups and rke2 HA setups.  I have tested on single node clusters of k3s and rke2 and observed rich logs from both.

