### PR TITLE
Update pushprox-clients to bind on localhost

### DIFF
--- a/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/hardenedKubelet/templates/pushprox-clients.yaml
+++ b/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/hardenedKubelet/templates/pushprox-clients.yaml
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: localhost:{{ .Values.clients.port }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:

--- a/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeControllerManager/templates/pushprox-clients.yaml
+++ b/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeControllerManager/templates/pushprox-clients.yaml
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: localhost:{{ .Values.clients.port }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:

--- a/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeEtcd/templates/pushprox-clients.yaml
+++ b/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeEtcd/templates/pushprox-clients.yaml
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: localhost:{{ .Values.clients.port }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:

--- a/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeIngressNginx/templates/pushprox-clients.yaml
+++ b/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeIngressNginx/templates/pushprox-clients.yaml
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: localhost:{{ .Values.clients.port }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:

--- a/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeProxy/templates/pushprox-clients.yaml
+++ b/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeProxy/templates/pushprox-clients.yaml
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: localhost:{{ .Values.clients.port }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:

--- a/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeScheduler/templates/pushprox-clients.yaml
+++ b/charts/rancher-monitoring/rancher-monitoring/100.0.0+up16.6.0/charts/rkeScheduler/templates/pushprox-clients.yaml
@@ -68,7 +68,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: localhost:{{ .Values.clients.port }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:


### PR DESCRIPTION
To avoid concerns during pen-testing and scans, adjust the listening port for pushprox clients to listen only on localhost:

Before:
```
tcp6       0      0 :::10011                :::*                    LISTEN      27772/pushprox-clie
tcp6       0      0 :::10012                :::*                    LISTEN      3503825/pushprox-cl
tcp6       0      0 :::10013                :::*                    LISTEN      3504218/pushprox-cl
tcp6       0      0 :::10014                :::*                    LISTEN      28088/pushprox-clie
```
After:
```
tcp        0      0 127.0.0.1:10011         0.0.0.0:*               LISTEN      3627993/pushprox-cl
tcp        0      0 127.0.0.1:10012         0.0.0.0:*               LISTEN      3626976/pushprox-cl
tcp        0      0 127.0.0.1:10013         0.0.0.0:*               LISTEN      3612416/pushprox-cl
tcp        0      0 127.0.0.1:10014         0.0.0.0:*               LISTEN      3610968/pushprox-cl
```

While running on `hostNetwork`, the pushprox clients can reach the k8s components without binding the port on all host interfaces. Happy to adjust this for k3s/RKE2 if desired.