### PR TITLE
Fixed WordPress Username label typo

### DIFF
--- a/charts/wordpress/v1.0.5/questions.yml
+++ b/charts/wordpress/v1.0.5/questions.yml
@@ -36,7 +36,7 @@ questions:
   description: "User of the application"
   type: string
   required: true
-  label: WordPress Usernname
+  label: WordPress Username
   group: "WordPress Settings"
 - variable: wordpressPassword
   default: ""

--- a/charts/wordpress/v2.1.10/questions.yml
+++ b/charts/wordpress/v2.1.10/questions.yml
@@ -36,7 +36,7 @@ questions:
   description: "User of the application"
   type: string
   required: true
-  label: WordPress Usernname
+  label: WordPress Username
   group: "WordPress Settings"
 - variable: wordpressPassword
   default: ""

--- a/charts/wordpress/v2.1.11/questions.yml
+++ b/charts/wordpress/v2.1.11/questions.yml
@@ -36,7 +36,7 @@ questions:
   description: "User of the application"
   type: string
   required: true
-  label: WordPress Usernname
+  label: WordPress Username
   group: "WordPress Settings"
 - variable: wordpressPassword
   default: ""

--- a/charts/wordpress/v2.1.12/questions.yml
+++ b/charts/wordpress/v2.1.12/questions.yml
@@ -36,7 +36,7 @@ questions:
   description: "User of the application"
   type: string
   required: true
-  label: WordPress Usernname
+  label: WordPress Username
   group: "WordPress Settings"
 - variable: wordpressPassword
   default: ""

--- a/charts/wordpress/v7.3.8/questions.yml
+++ b/charts/wordpress/v7.3.8/questions.yml
@@ -38,7 +38,7 @@ questions:
   description: "User of the application"
   type: string
   required: true
-  label: WordPress Usernname
+  label: WordPress Username
   group: "WordPress Settings"
 - variable: wordpressPassword
   default: ""

--- a/charts/wordpress/v9.0.3/questions.yml
+++ b/charts/wordpress/v9.0.3/questions.yml
@@ -38,7 +38,7 @@ questions:
   description: "User of the application"
   type: string
   required: true
-  label: WordPress Usernname
+  label: WordPress Username
   group: "WordPress Settings"
 - variable: wordpressPassword
   default: ""


### PR DESCRIPTION
Noticed during recent Rancher Rodeo - WordPress Username label had a typo (Usernname). Corrected for all versions.