### PR TITLE
Fixed phpBB Username label typo

### DIFF
--- a/charts/phpbb/v2.0.0/questions.yaml
+++ b/charts/phpbb/v2.0.0/questions.yaml
@@ -34,7 +34,7 @@ questions:
   description: "Username of the phpBB"
   type: string
   required: true
-  label: phpUser Usernname
+  label: phpUser Username
   group: "phpBB Settings"
 - variable: phpbbPassword
   default: ""

--- a/charts/phpbb/v6.0.1/questions.yaml
+++ b/charts/phpbb/v6.0.1/questions.yaml
@@ -35,7 +35,7 @@ questions:
   description: "Username of the phpBB"
   type: string
   required: true
-  label: phpUser Usernname
+  label: phpUser Username
   group: "phpBB Settings"
 - variable: phpbbPassword
   default: ""


### PR DESCRIPTION
After fixing for WordPress (#1376) I checked for other Usernname typos and found phpBB also has. Corrected for both versions.