### PR TITLE
Disable pushprox-client internal metrics by default

### DIFF
--- a/packages/rancher-pushprox/charts/README.md
+++ b/packages/rancher-pushprox/charts/README.md
@@ -30,7 +30,6 @@ The following tables list the configurable parameters of the rancher-pushprox ch
 | ----- | ----------- | ------ |
 | `serviceMonitor.enabled` | Deploys a [Prometheus Operator](https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#servicemonitor) ServiceMonitor CR that is configured to scrape metrics on the hosts that the clients are deployed on via the proxy. Also deploys a Service that points to all pods with the expected client name that exposes the `metricsPort` selected | `true` |
 | `clients.enabled` | Deploys a DaemonSet of clients that are each capable of scraping endpoints on the hostNetwork it is deployed on | `true` |
-| `clients.port` |  The port where the client will publish PushProx client-specific metrics. If deploying multiple clients onto the same node, the clients should not have conflicting ports | `9369` |
 | `clients.proxyUrl` | Overrides the default proxyUrl setting of `http://pushprox-{{ .Values.component }}-proxy.{{ . Release.Namespace }}.svc.cluster.local:{{ .Values.proxy.port }}"` with the `proxyUrl` specified | `""` |
 | `clients.useLocalhost` | Sets a flag on each client deployment to redirect scrapes directed to `HOST_IP` to `127.0.0.1` | `false` |
 | `clients.https.enabled` | Enables scraping metrics via HTTPS using the provided TLS certs that exist on each host | `false` |
@@ -43,6 +42,8 @@ The following tables list the configurable parameters of the rancher-pushprox ch
 | `clients.resources` | Set resource limits and requests for the client container | `{}` |
 | `clients.nodeSelector` | Select which nodes to deploy the clients on | `{}` |
 | `clients.tolerations` | Specify tolerations for clients | `[]` |
+| `clients.metrics` |  Enable PushProx client-specific metrics, listens on the host network namespace | `false` |
+| `clients.metrics.port` |  The port where the client will publish PushProx client-specific metrics. If deploying multiple clients onto the same node, the clients should not have conflicting ports | `9369` |
 | `proxy.enabled` | Deploys the proxy that each client will register with | `true` |
 | `proxy.port` | The port exposed by the proxy that each client will register with to allow metrics to be scraped from the host | `8080` |
 | `proxy.resources` | Set resource limits and requests for the proxy container | `{}` |

--- a/packages/rancher-pushprox/charts/templates/pushprox-clients.yaml
+++ b/packages/rancher-pushprox/charts/templates/pushprox-clients.yaml
@@ -32,7 +32,9 @@ spec:
         args:
         - --fqdn=$(HOST_IP)
         - --proxy-url=$(PROXY_URL)
+        {{- if .Values.clients.metrics.enabled -}}
         - --metrics-addr=$(PORT)
+        {{- end }}
         - --allow-port={{ required "Need .Values.metricsPort to configure client to be allowed to scrape metrics at port" .Values.metricsPort}}
         {{- if .Values.clients.useLocalhost }}
         - --use-localhost
@@ -55,8 +57,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        {{- if .Values.clients.metrics.enabled -}}
         - name: PORT
-          value: :{{ .Values.clients.port }}
+          value: :{{ .Values.clients.metrics.port }}
+        {{- end }}
         - name: PROXY_URL
           value: {{ template "pushProxy.proxyUrl" . }}
         securityContext:

--- a/packages/rancher-pushprox/charts/values.yaml
+++ b/packages/rancher-pushprox/charts/values.yaml
@@ -28,8 +28,11 @@ serviceMonitor:
 
 clients:
   enabled: true
-  # The port which the PushProx client will post PushProx metrics to
-  port: 9369
+  metrics:
+    # Enable scrape metrics from the PushProx client itself. When enabled, listens on the host network namespace
+    enabled: false
+    # The port which the PushProx client will provide it's internal metrics
+    port: 9369
   # If unset, this will default to the URL for the proxy service: http://pushprox-{{component}}-proxy.{{namepsace}}.svc.cluster.local:{{proxy.port}}
   # Should be modified if the clients are being deployed outside the cluster where the proxy rests, otherwise leave it null
   proxyUrl: ""


### PR DESCRIPTION
To avoid concerns during pen-testing and scans, adjust the listening port for pushprox client metrics, these metrics are not currently used, this PR addresses the clients listening on the host network namespace by disabling the internal metrics port by default:

Example of before/after:
```
# netstat -plant | grep -i 10014
tcp6       0      0 :::10014                :::*                    LISTEN      33815/pushprox-clie
```

```
# netstat -plant | grep -i 10014
#
```