### PR TITLE
The defaults are too low

### DIFF
--- a/charts/rancher-monitoring/values.yaml
+++ b/charts/rancher-monitoring/values.yaml
@@ -2280,10 +2280,10 @@ prometheus:
     ##
     resources:
       limits:
-        memory: 1500Mi
+        memory: 2500Mi
         cpu: 1000m
       requests:
-        memory: 750Mi
+        memory: 1750Mi
         cpu: 750m
 
     ## Prometheus StorageSpec for persistent data


### PR DESCRIPTION
We are still seeing high severity tickets with Monitoring crashing due to WAL compaction exceeding the default limits in place.  I noticed the limits in Monitoring by default are lower than any of the recommended.

I've updated the default to reflect that suggested in the table here: https://rancher.com/docs/rancher/v2.5/en/monitoring-alerting/#setting-resource-limits-and-requests
I've also created a PR to add best practice of tuning defaults to the docs here: https://github.com/rancher/docs/pull/3436

It's odd to me that, in the docs, there is a "known issue" to increase the Prometheus memory limits to those noted in the table above...