### PR TITLE
fix the index.yaml file

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -12,13 +12,13 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.7
-    created: "2021-09-29T22:20:49.286746-04:00"
+    created: "2021-09-30T12:30:02.133338-07:00"
     dependencies:
     - condition: gitops.enabled
       name: gitjob
       repository: file://./charts/gitjob
     description: Fleet Manager - GitOps at Scale
-    digest: fdef3fd15c2dd26e8c7b6ebad8012f13bff6ba9f3441d7f64fbc4eddbe82e58b
+    digest: 60cce943a53d723a9c05d35adbb0162443956fe20e80f183883395c46ca80fda
     icon: https://charts.rancher.io/assets/logos/fleet.svg
     name: fleet
     urls:
@@ -35,7 +35,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.6
-    created: "2021-08-27T15:44:45.879883-04:00"
+    created: "2021-09-30T12:30:02.081889-07:00"
     dependencies:
     - condition: gitops.enabled
       name: gitjob
@@ -58,7 +58,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.5
-    created: "2021-08-25T15:50:58.45749519-07:00"
+    created: "2021-09-30T12:30:02.080647-07:00"
     description: Fleet Manager - GitOps at Scale
     digest: b2d52dd2c2815be26d1eabedd0ca230e7709073bfc7a9b15018f1aa4d29d814e
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -77,7 +77,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.4
-    created: "2021-08-25T15:50:58.456123205-07:00"
+    created: "2021-09-30T12:30:02.079682-07:00"
     description: Fleet Manager - GitOps at Scale
     digest: 3dc07290740992da2a36c0d0cf2ef3592bcb1e2c5482a37a49336794795944f0
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -96,7 +96,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.3
-    created: "2021-08-25T15:50:58.454730039-07:00"
+    created: "2021-09-30T12:30:02.078521-07:00"
     description: Fleet Manager - GitOps at Scale
     digest: f33de3f1deb1cdfe0ff8af7cde8919bbe3e594b30e423735caddfcf3117d3224
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -115,7 +115,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.2
-    created: "2021-08-25T15:50:58.453503132-07:00"
+    created: "2021-09-30T12:30:02.077533-07:00"
     description: Fleet Manager - GitOps at Scale
     digest: 7604d7eb2a6ef5b119b0ee102ea528e63db77caff3441bd47c116964ac530887
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -134,7 +134,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.1
-    created: "2021-08-25T15:50:58.452285759-07:00"
+    created: "2021-09-30T12:30:02.076577-07:00"
     description: Fleet Manager - GitOps at Scale
     digest: 2b05e7779f54c0bd853594b798662be27043d401ee4df1ef2393d25ae4ebbdb8
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -153,7 +153,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.0
-    created: "2021-08-25T15:50:58.451057391-07:00"
+    created: "2021-09-30T12:30:02.075533-07:00"
     description: Fleet Manager - GitOps at Scale
     digest: 80ebb76232c4d9c17199901ccce179c86d78202872266fdec29c417c78ee1a9d
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -170,7 +170,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.7
-    created: "2021-09-29T22:21:03.633644-04:00"
+    created: "2021-09-30T12:30:02.146527-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 7987910c8dd050d84e7a5bc20bc323652e85be1026507f507f626389712e4077
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -186,7 +186,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.6
-    created: "2021-08-27T15:44:53.812812-04:00"
+    created: "2021-09-30T12:30:02.144603-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 547e6663ef2b3bebff4f09e4bae7cc702838ba0513740cd8d4db8693cd587f94
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -202,7 +202,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.5
-    created: "2021-08-25T15:50:58.462357043-07:00"
+    created: "2021-09-30T12:30:02.142621-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 7d41b4ee8f0103d2200cd9347aa08a94df5598a5be047b3e283787b86724a5e6
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -218,7 +218,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.4
-    created: "2021-08-25T15:50:58.461678815-07:00"
+    created: "2021-09-30T12:30:02.140439-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 59fb278112c907eaf12dd963ded1aa6ae03be09bb795d2129fd35b6888fbd31c
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -234,7 +234,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.3
-    created: "2021-08-25T15:50:58.461038956-07:00"
+    created: "2021-09-30T12:30:02.138313-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: f92cbe28d99ae754a590e3de5a3226109704c7a69376e1b824b5eb01e3997df3
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -250,7 +250,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.2
-    created: "2021-08-25T15:50:58.460456473-07:00"
+    created: "2021-09-30T12:30:02.136639-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 2be8d753ca9d2ddc9f0c152a81021b146838223796a497841850486bc26f6457
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -266,7 +266,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.1
-    created: "2021-08-25T15:50:58.459825938-07:00"
+    created: "2021-09-30T12:30:02.135376-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 1913e45bcda723490e3c1c1613f99a328b6414c472f9f7c490c087d7697563f1
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -282,7 +282,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.0
-    created: "2021-08-25T15:50:58.459267107-07:00"
+    created: "2021-09-30T12:30:02.134331-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 8b517f7d18f2aa1e34e5ac475684752dc8ff46f050cfd2b2d91fd343cab8cf50
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -299,7 +299,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.7
-    created: "2021-09-29T22:21:16.860005-04:00"
+    created: "2021-09-30T12:30:02.165537-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: fd052765600dae535ce53e13567dd528c5b143f948afc89a78f3483f051775c5
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -315,7 +315,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.6
-    created: "2021-08-27T15:44:58.775864-04:00"
+    created: "2021-09-30T12:30:02.162447-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 560aac95a80d2fb343ed79590752672f627c3984d4be54e75b94b781f4da45db
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -331,7 +331,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.5
-    created: "2021-08-25T15:50:58.470520149-07:00"
+    created: "2021-09-30T12:30:02.158444-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: cab5177c5c69ef4d35a3b9efd60ce9d07d6313c30aa76bc0062f26087b44a828
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -347,7 +347,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.4
-    created: "2021-08-25T15:50:58.469813947-07:00"
+    created: "2021-09-30T12:30:02.156515-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 36c8f232f6d3f2698d0e43d7a95359555f0e8852cfb2c41d901eb09f807d291f
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -363,7 +363,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.3
-    created: "2021-08-25T15:50:58.469030284-07:00"
+    created: "2021-09-30T12:30:02.154625-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 35bbfc8e2276379965d8671b752530b4b3603cacab9106dad64f37839b2f1342
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -379,7 +379,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.2
-    created: "2021-08-25T15:50:58.468069039-07:00"
+    created: "2021-09-30T12:30:02.152985-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 025f0b2ee6f8b709c19ed2676faecba9579c9a14d526d9e16573eb8b98d5bc52
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -394,7 +394,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.1
-    created: "2021-08-25T15:50:58.466761524-07:00"
+    created: "2021-09-30T12:30:02.15136-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: f47abbbcd5b2ca28dcb8303e01a5562da698ec78423c0dc4aa249e6f6b3b7eb4
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -409,7 +409,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.0
-    created: "2021-08-25T15:50:58.464563892-07:00"
+    created: "2021-09-30T12:30:02.148306-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 08e3af78da30602b47b60ebfb8e509703dbedc5b312f6aa3a9e9b0275adca75a
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -431,7 +431,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.2.0
-    created: "2021-09-18T00:16:44.728785643+08:00"
+    created: "2021-09-30T12:30:02.191358-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: ccb1eddfedf12d839dfed1e8fd6de68e7284bcf3c4b2a76ac3d7c65982ae08ef
     home: https://github.com/longhorn/longhorn
@@ -473,7 +473,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.2
-    created: "2021-08-25T15:50:58.486087084-07:00"
+    created: "2021-09-30T12:30:02.178531-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 6a2ce555892a327c3ea0b22c0ceed32125b60fc482fef8efd59cf4c94c24322e
     home: https://github.com/longhorn/longhorn
@@ -511,13 +511,14 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: longhorn.io/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: longhorn
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.1
-    created: "2021-08-25T15:50:58.482637471-07:00"
+    created: "2021-09-30T12:30:02.17663-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
-    digest: bf329bb6f2429e47489851d7355e474c72b590a0123b90fb3ea6eaed5d6d449b
+    digest: 59485d7ff4e0fa36c29930ce3d1fb1996189d3fff841ce5cb3919b41d04066ff
     home: https://github.com/longhorn/longhorn
     icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.png
     keywords:
@@ -552,13 +553,14 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: longhorn.io/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: longhorn
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.0
-    created: "2021-08-25T15:50:58.47911867-07:00"
+    created: "2021-09-30T12:30:02.1747-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
-    digest: 98b46706eb8c7b6261c1aa03f5081429867076f8f8f28ff0e4fb2f7389d66ef3
+    digest: 6f552a95ecfdad686750d8446ed4322a8d5d87a4ec394542e8d9fc85386c8e69
     home: https://github.com/longhorn/longhorn
     icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.svg?sanitize=true
     keywords:
@@ -593,13 +595,14 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: longhorn.io/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: longhorn
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.0
-    created: "2021-08-25T15:50:58.47575538-07:00"
+    created: "2021-09-30T12:30:02.172621-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
-    digest: aba8166911b39cfe44529c1ff3fd910e437ade64e72f39edc20957442605f619
+    digest: 6dd88e8250e3776569b46a534269ecefa1804a3d85e5bf244b81987f5e70a8be
     home: https://github.com/longhorn/longhorn
     icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.svg
     keywords:
@@ -634,13 +637,14 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: longhorn.io/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: longhorn
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-08-25T15:50:58.47434851-07:00"
+    created: "2021-09-30T12:30:02.170225-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
-    digest: b18eda4e4b1170b7e9f488782fb6409da084b5beaa9945a3a3babe39f031e320
+    digest: 327b75f1d0a5bdfcbe9eadc9e8a2ff0c5c68f7b40d15f70b4c556cd2f0fc132f
     home: https://github.com/longhorn/longhorn
     icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.svg
     keywords:
@@ -673,13 +677,14 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: longhorn.io/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: longhorn
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-08-25T15:50:58.473125348-07:00"
+    created: "2021-09-30T12:30:02.16839-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
-    digest: 66189346fc24f5407f7a11a41faf9913144801a72472151702e28f808d557073
+    digest: fe67a68e6ddb15c8746bd630dd12a47885aad49d44305eb84e170d8900e1fc58
     home: https://github.com/longhorn/longhorn
     icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/longhorn/icon/color/longhorn-icon-color.svg
     keywords:
@@ -713,7 +718,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-18T00:16:44.728953473+08:00"
+    created: "2021-09-30T12:30:02.192252-07:00"
     description: Installs the CRDs for longhorn.
     digest: 50b1f96c695a816816e5a9c8b2daf1d18f0e1689d33c10b3b84d8e1a79b7747a
     name: longhorn-crd
@@ -727,7 +732,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.488175028-07:00"
+    created: "2021-09-30T12:30:02.183571-07:00"
     description: Installs the CRDs for longhorn.
     digest: b11d2d8ed60e7a4767c0411324e84f9825290f346bb9532df92ea16a78a12722
     name: longhorn-crd
@@ -741,7 +746,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.487884147-07:00"
+    created: "2021-09-30T12:30:02.182729-07:00"
     description: Installs the CRDs for longhorn.
     digest: eec1b37ef0f12930cac4b8dc812e0c08af32ec5af8afb37114f3932e333bb5b6
     name: longhorn-crd
@@ -755,7 +760,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.487602715-07:00"
+    created: "2021-09-30T12:30:02.181978-07:00"
     description: Installs the CRDs for longhorn.
     digest: 305196027ef02e1f01519b99302321fbb48dd5faca8084751758c5954f83f488
     name: longhorn-crd
@@ -769,7 +774,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.487321099-07:00"
+    created: "2021-09-30T12:30:02.18067-07:00"
     description: Installs the CRDs for longhorn.
     digest: 5d5f3a3493810aa0dfd263757819e00a8a483c5410c5ff4ff61f5d5fee3561b9
     name: longhorn-crd
@@ -783,7 +788,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.486932268-07:00"
+    created: "2021-09-30T12:30:02.17984-07:00"
     description: Installs the CRDs for longhorn.
     digest: 4da0eeeef78a45c8b0111bb66cfca1734088bcd9bb15b8bfd6712b0ab6320ca1
     name: longhorn-crd
@@ -797,7 +802,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.486549861-07:00"
+    created: "2021-09-30T12:30:02.179219-07:00"
     description: Installs the CRDs for longhorn.
     digest: c3fc8df8818d884c9df73999999834cebe41ce6567f60222792c2593ad853d31
     name: longhorn-crd
@@ -818,7 +823,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.0.2
-    created: "2021-09-27T16:09:08.406731052-07:00"
+    created: "2021-09-30T12:30:02.19421-07:00"
     description: A Helm chart for provisioning AKS clusters
     digest: 756963b5366daa89106db55c19e21069361cfd4f166260b8bebae8508464ac5a
     home: https://github.com/rancher/aks-operator
@@ -840,7 +845,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.0.1
-    created: "2021-08-25T15:50:58.488669726-07:00"
+    created: "2021-09-30T12:30:02.193266-07:00"
     description: A Helm chart for provisioning AKS clusters
     digest: f37ff6a67aed0e87ea879d86d4ce318580f693ce2d8d69060425ca99760bb177
     home: https://github.com/rancher/aks-operator
@@ -859,9 +864,9 @@ entries:
       catalog.cattle.io/release-name: rancher-aks-operator-crd
     apiVersion: v2
     appVersion: 1.0.2
-    created: "2021-09-27T16:09:08.407068777-07:00"
+    created: "2021-09-30T12:30:02.195705-07:00"
     description: AKS Operator CustomResourceDefinitions
-    digest: 6b1c1dc25ace06fb856bcbbd1362e592d9044a648e3bd67a5351312e439c11e7
+    digest: 0361a5d82f025056d5b76691fbe158a3f73499b40e3179ef2a75361d9f455f30
     name: rancher-aks-operator-crd
     urls:
     - assets/rancher-aks-operator-crd/rancher-aks-operator-crd-100.0.1+up1.0.2.tgz
@@ -874,7 +879,7 @@ entries:
       catalog.cattle.io/release-name: rancher-aks-operator-crd
     apiVersion: v2
     appVersion: 1.0.1
-    created: "2021-08-25T15:50:58.488932725-07:00"
+    created: "2021-09-30T12:30:02.194967-07:00"
     description: AKS Operator CustomResourceDefinitions
     digest: f3286e4909fb5fa22e88dda79712831aa9d2c5df780d31df0e5c7ef3553984ee
     name: rancher-aks-operator-crd
@@ -890,7 +895,7 @@ entries:
       catalog.cattle.io/type: cluster-tool
     apiVersion: v2
     appVersion: 1.16.0
-    created: "2021-08-25T15:50:58.492533886-07:00"
+    created: "2021-09-30T12:30:02.200818-07:00"
     dependencies:
     - condition: prom2teams.enabled
       name: prom2teams
@@ -914,10 +919,11 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/display-name: Alerting Drivers
       catalog.cattle.io/os: linux
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-alerting-drivers
     apiVersion: v2
     appVersion: 1.16.0
-    created: "2021-08-25T15:50:58.490679782-07:00"
+    created: "2021-09-30T12:30:02.198089-07:00"
     dependencies:
     - condition: prom2teams.enabled
       name: prom2teams
@@ -927,7 +933,7 @@ entries:
       repository: file://./charts/sachet
     description: The manager for third-party webhook receivers used in Prometheus
       Alertmanager
-    digest: 8ca12d79b439d7df90ae8b21cb41db53f5f2ee1b6d8a512b5b817a4677801f6b
+    digest: d874b1759bcd0cc376acef1a86cffb27dc5f5127947109d37fd5c8953dc8e829
     keywords:
     - monitoring
     - alertmanger
@@ -951,7 +957,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v2
     appVersion: 2.0.1
-    created: "2021-09-27T13:19:13.471009-07:00"
+    created: "2021-09-30T12:30:02.211487-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: a4bde8a1e5098ef43a6e4754b7ff066f32389fa5ad9e5df4fbe679caac483e63
@@ -976,7 +982,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v2
     appVersion: 2.0.0
-    created: "2021-08-28T11:30:18.414092-07:00"
+    created: "2021-09-30T12:30:02.209792-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: 0995c2bc4ba1949a10281c3668fc9d12fb155556bff228b7ef92097514fca523
@@ -995,15 +1001,16 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup
       catalog.cattle.io/scope: management
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v2
     appVersion: 1.0.4
-    created: "2021-08-25T15:50:58.496656132-07:00"
+    created: "2021-09-30T12:30:02.208095-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: 905ccec63797a472c268fb4e1bd0b5c2e33d518f4066147275e65e8a2f093c49
+    digest: 2aea8c5bbcd18f68975e129383661c307edafed2f6d399da31fd6b2142065ff1
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -1019,15 +1026,16 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup
       catalog.cattle.io/scope: management
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-08-25T15:50:58.49579894-07:00"
+    created: "2021-09-30T12:30:02.2066-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: 21e586d307c78cc6a1321adaa89bef78719f0beca7f181c719cbca27691e6f5a
+    digest: eba830b48b495863c3477f391fbfc9043877c5809d565f6a316964dc31f88066
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -1043,15 +1051,16 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup
       catalog.cattle.io/scope: management
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-08-25T15:50:58.49500635-07:00"
+    created: "2021-09-30T12:30:02.205032-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: 733d4515a014e6c6d99f73db30d3143f7cef04a870b19a3b2f5eef5b09dbfc55
+    digest: 92fc70f5c051d9808bf614624bdf1a0164202a1b14a1996cf26720188ce0826e
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -1067,15 +1076,16 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup
       catalog.cattle.io/scope: management
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-08-25T15:50:58.494188047-07:00"
+    created: "2021-09-30T12:30:02.203553-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: bd39f041d51be323dd59dbbb0bae5c21b7ebbdca5f777972080254eb996595b4
+    digest: cc9946d5f3f06d9d78c0dec481641015d3e71d86e0e1bff246eeba110e37d9f4
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -1090,15 +1100,16 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup
       catalog.cattle.io/scope: management
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-08-25T15:50:58.493306567-07:00"
+    created: "2021-09-30T12:30:02.202222-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: a3a4fcd83c7332bfafe1ee03c17dbdb43765364e97dc19f297884334486196c7
+    digest: b155f48daab42a9a36c7a7e1710da31c160756e7e391d92dffafc976d89114f8
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -1115,7 +1126,7 @@ entries:
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
     appVersion: 2.0.1
-    created: "2021-09-27T13:07:00.368075-07:00"
+    created: "2021-09-30T12:30:02.218859-07:00"
     description: Installs the CRDs for rancher-backup.
     digest: 8eb03a61506b7feb4cd6a8322551868b32422fceea5aba923f2e057cb925810b
     name: rancher-backup-crd
@@ -1130,7 +1141,7 @@ entries:
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
     appVersion: 2.0.0
-    created: "2021-08-28T11:30:33.332456-07:00"
+    created: "2021-09-30T12:30:02.218007-07:00"
     description: Installs the CRDs for rancher-backup.
     digest: 15a2769a275b4b22d160044f60b10c39e7922f59fb2ff627c67208a045133cbc
     name: rancher-backup-crd
@@ -1145,7 +1156,7 @@ entries:
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
     appVersion: 1.0.4
-    created: "2021-08-25T15:50:58.499650376-07:00"
+    created: "2021-09-30T12:30:02.217137-07:00"
     description: Installs the CRDs for rancher-backup.
     digest: 26f7baa1bf1934cf7cfae2720eac74ea1c338dc56aab35a221c688cea6a7ead0
     name: rancher-backup-crd
@@ -1157,11 +1168,12 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"
       catalog.cattle.io/namespace: cattle-resources-system
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.49924307-07:00"
+    created: "2021-09-30T12:30:02.216198-07:00"
     description: Installs the CRDs for rancher-backup.
-    digest: 3dedeb53130cb1050147156b87c770ab40a023be25f4d3342678eb7d8a33362d
+    digest: 52c7d5853d97a3720060cd89c21b560c05780df46b8ae075377fedebbe2fd229
     name: rancher-backup-crd
     type: application
     urls:
@@ -1171,11 +1183,12 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"
       catalog.cattle.io/namespace: cattle-resources-system
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.498839407-07:00"
+    created: "2021-09-30T12:30:02.214249-07:00"
     description: Installs the CRDs for rancher-backup.
-    digest: da8413d2ecc169ba43aa5f6f3cb9da45c297140a1af2e702f11c4645f644c7e4
+    digest: d01a45589bc99ef39000e4e1731921be7ef864bd30b255c5230ca89bbbf05fc8
     name: rancher-backup-crd
     type: application
     urls:
@@ -1185,11 +1198,12 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"
       catalog.cattle.io/namespace: cattle-resources-system
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.498380356-07:00"
+    created: "2021-09-30T12:30:02.213335-07:00"
     description: Installs the CRDs for rancher-backup.
-    digest: b42794ee6663cb35c6f40c1b43ce51f6b82d2f8efe06421c9b2a1cb7cea18503
+    digest: 1a25dccee9394a65915677330d359e89bf56c9bd6c959191755c943eee51b3df
     name: rancher-backup-crd
     type: application
     urls:
@@ -1199,11 +1213,12 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"
       catalog.cattle.io/namespace: cattle-resources-system
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.497828072-07:00"
+    created: "2021-09-30T12:30:02.212426-07:00"
     description: Installs the CRDs for rancher-backup.
-    digest: 4d2cfbd4b413d0a86cd3c94a10a3316c44a668c79730a2a4063933aa0eb6e332
+    digest: 68280009fd6465318c19808dc093de64f492decf1313348fac5e4fd408faef9b
     name: rancher-backup-crd
     type: application
     urls:
@@ -1223,10 +1238,10 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.6
-    created: "2021-09-29T13:30:36.4520631-07:00"
+    created: "2021-09-30T12:30:02.227793-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: a44642335598583cffba01308de3a937dc71eb6a9f8fd6d5cda21e62b72a1377
+    digest: 4168cc0bbd8836fd793f547607a7c3b7dcff91653ad6e167795befe1c44187f9
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1246,10 +1261,10 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.5
-    created: "2021-08-25T15:50:58.504058504-07:00"
+    created: "2021-09-30T12:30:02.226636-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: 646328c0c9fb3c3a5620a2be277dc8b1fd740e38c6e43bb952c00825111aefc0
+    digest: e6445d18c93b85593c1f962115afbfb12af6c4d1786583204f401f5e9ebe058f
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1264,14 +1279,15 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-cis-benchmark
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.4
-    created: "2021-08-25T15:50:58.503338288-07:00"
+    created: "2021-09-30T12:30:02.225428-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: ef7c8837f09bcf669bcb7aef5aec2dca84a27e2c93da5b44194fb0113a1c527d
+    digest: 2425c71f5f5b5958483b7ed1fdba0925840e0a9cd87965000664663c8d9812dd
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1286,14 +1302,15 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-cis-benchmark
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-08-25T15:50:58.502640108-07:00"
+    created: "2021-09-30T12:30:02.224189-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: c548033c5ec3822f2c89f0a1a19e3f4ce063f59a4ee021523642886ec3bf13a2
+    digest: f0bd86f0f0bdbf5f309ab8837a34445d25e0a0c32c054b3fbd2e7e74a9089760
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1308,14 +1325,15 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-cis-benchmark
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-08-25T15:50:58.501989459-07:00"
+    created: "2021-09-30T12:30:02.222359-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: 2cce59f4f78b975edd93b0d707c5282fa44a6fa1f19d702ed4be8c221170c8d1
+    digest: 02c597d8a06b8b36e12bb4881e1de82f0204a2806565cd007a7f6b8d8a872d28
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1330,14 +1348,15 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-cis-benchmark
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-08-25T15:50:58.501279836-07:00"
+    created: "2021-09-30T12:30:02.221046-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: b3a6ce49c5e6918a1658f682fdf25e241d9638fde4b8c046a70562c13228c8c0
+    digest: 91a4efc7f01aa8a1f26e32a3bb8a092fcbc63a7a9c6413a40e7c333dcbb74d10
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1351,14 +1370,15 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-cis-benchmark
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.1
-    created: "2021-08-25T15:50:58.50069264-07:00"
+    created: "2021-09-30T12:30:02.21994-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: 407c19666ce5c083c50d8ef2cbc4fbc26b811106bbfc6b3d25a659a593c0aa3c
+    digest: a18925b456386610da24f29f7a8f34b76b61f2db5d94cd7b398bb51be7a472df
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1373,7 +1393,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-14T15:17:53.675706803-04:00"
+    created: "2021-09-30T12:30:02.231916-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: a07236a3f8c025600416189c5cc60a309be12c00b39b9d3b1f58af8c0b4b36ac
     name: rancher-cis-benchmark-crd
@@ -1387,7 +1407,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.505271318-07:00"
+    created: "2021-09-30T12:30:02.231402-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: 33df5c14654fae5364b074129cae71fdcdb5eaa47aabae3c195906f3d9a37aa5
     name: rancher-cis-benchmark-crd
@@ -1401,7 +1421,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.505068882-07:00"
+    created: "2021-09-30T12:30:02.23086-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: df1bf2270629356a5ad545053da7f18b1782a5441ed98c66d6030c41a3d421d0
     name: rancher-cis-benchmark-crd
@@ -1415,7 +1435,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.504864115-07:00"
+    created: "2021-09-30T12:30:02.230279-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: cabb44716892582bee08bd13c48caa3863c9f53218f2ffa1f1bc123ae7234d5a
     name: rancher-cis-benchmark-crd
@@ -1429,7 +1449,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.504660454-07:00"
+    created: "2021-09-30T12:30:02.229731-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: 20d71a2ae15f77913229f809c4acf5924f988a0cfc09061306d65c45899618ce
     name: rancher-cis-benchmark-crd
@@ -1443,7 +1463,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.504462865-07:00"
+    created: "2021-09-30T12:30:02.229082-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: b12e7bc934602f88087b34540446a2cdc8af5cb30ede6d4d3a48dc29ded1daaa
     name: rancher-cis-benchmark-crd
@@ -1457,7 +1477,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.50426485-07:00"
+    created: "2021-09-30T12:30:02.228364-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: 2be8b1e2aa24e83d8b20439d0b0343851fbd32495306d38d5d20c62d95b0a8b5
     name: rancher-cis-benchmark-crd
@@ -1478,7 +1498,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-08-25T15:50:58.505668041-07:00"
+    created: "2021-09-30T12:30:02.232579-07:00"
     description: A Helm chart for provisioning EKS clusters
     digest: 2a2bf847905a4ff67086e78c7e5009a4f1d113e354a23ccde453611f04712d68
     home: https://github.com/rancher/eks-operator
@@ -1497,7 +1517,7 @@ entries:
       catalog.cattle.io/release-name: rancher-eks-operator-crd
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-08-25T15:50:58.505848859-07:00"
+    created: "2021-09-30T12:30:02.233073-07:00"
     description: EKS Operator CustomResourceDefinitions
     digest: c5de8e1b4058f0329e78e495ebac023a8130ed4e11e9028338368831cbb6b67a
     name: rancher-eks-operator-crd
@@ -1514,7 +1534,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v1.0.0
-    created: "2021-08-27T15:53:23.852232-07:00"
+    created: "2021-09-30T12:30:02.240233-07:00"
     description: |
       Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
     digest: 7183b83b6dee2a781cd862b95b6b0b1898bc2616cb68d2ff65e13646965a1a97
@@ -1538,14 +1558,15 @@ entries:
       catalog.cattle.io/display-name: External IP Webhook
       catalog.cattle.io/namespace: cattle-externalip-system
       catalog.cattle.io/os: linux
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-external-ip-webhook
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v0.1.6
-    created: "2021-08-25T15:50:58.508107689-07:00"
+    created: "2021-09-30T12:30:02.238085-07:00"
     description: |
       Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
-    digest: 14ed8a7f5417a863a325a65d1f9ca1e6a686e36964a1b9bde249abe05d530fad
+    digest: fd85e0a713273e9ef44514fd121037c358fed3d03d35bf1e5cd6d7e0f79dc964
     home: https://github.com/rancher/externalip-webhook
     keywords:
     - cve
@@ -1566,14 +1587,15 @@ entries:
       catalog.cattle.io/display-name: External IP Webhook
       catalog.cattle.io/namespace: cattle-externalip-system
       catalog.cattle.io/os: linux
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-external-ip-webhook
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v0.1.6
-    created: "2021-08-25T15:50:58.507476506-07:00"
+    created: "2021-09-30T12:30:02.236462-07:00"
     description: |
       Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
-    digest: 245d80daa0b7c6316217b2ec9df111060fe6762728a5d9adfb163d7afd02fc9b
+    digest: 4b35561c85c41372f096c5bba85ba2d50171b47158648d645317f1732eb32d35
     home: https://github.com/rancher/externalip-webhook
     keywords:
     - cve
@@ -1594,14 +1616,15 @@ entries:
       catalog.cattle.io/display-name: External IP Webhook
       catalog.cattle.io/namespace: cattle-externalip-system
       catalog.cattle.io/os: linux
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-external-ip-webhook
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v0.1.4
-    created: "2021-08-25T15:50:58.506715089-07:00"
+    created: "2021-09-30T12:30:02.234787-07:00"
     description: |
       Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
-    digest: 7fa93b5a3f3e9bd5ebcf0e8cc670441a5fd63dd611ee0843e08a6521fa315838
+    digest: e44114c31dcedbe8432b287204b07345617cfdce503bfc6525925319a19107e2
     home: https://github.com/rancher/externalip-webhook
     keywords:
     - cve
@@ -1630,7 +1653,7 @@ entries:
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v2
     appVersion: v3.6.0
-    created: "2021-09-24T17:16:30.735871203+05:30"
+    created: "2021-09-30T12:30:02.244448-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 5e869a471a4e29cc17e91d17f6dd2b78edfb37d4f683f9a3bbc8b65d13a35a80
@@ -1657,7 +1680,7 @@ entries:
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v2
     appVersion: v3.5.1
-    created: "2021-08-25T15:50:58.509566312-07:00"
+    created: "2021-09-30T12:30:02.242784-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 51bfa57851f61cdf73d0712b2957a0c75891b79814bdb0a5304ca478971983fc
@@ -1679,14 +1702,15 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-gatekeeper
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v1
     appVersion: v3.3.0
-    created: "2021-08-25T15:50:58.516323781-07:00"
+    created: "2021-09-30T12:30:02.251479-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
-    digest: 5f4530d14b1ede9d9b0c82d3c2dcda473ee45eb87cc5e5140e5a07c381814670
+    digest: 9a44d486245ea45243372ac07e56e180ecf31b51c415a6f090ab34ae2b878869
     home: https://github.com/open-policy-agent/gatekeeper
     icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
     keywords:
@@ -1705,14 +1729,15 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-gatekeeper
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v1
     appVersion: v3.3.0
-    created: "2021-08-25T15:50:58.514390661-07:00"
+    created: "2021-09-30T12:30:02.250158-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
-    digest: cdd2cb75ded06543e55124c5086a12c06e323c0398319e8c8984c73e19dd58bc
+    digest: ba24497df58da6ee771f4d5d4a8f25e94eb86d3b8aa48854bfb4b86ff904f736
     home: https://github.com/open-policy-agent/gatekeeper
     icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
     keywords:
@@ -1732,14 +1757,15 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-gatekeeper
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v1
     appVersion: v3.2.1
-    created: "2021-08-25T15:50:58.512017953-07:00"
+    created: "2021-09-30T12:30:02.248798-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
-    digest: 3d0e961fc109e051f08edacf9e541e5ad1c0c65f046cae72459df0ca4aa22312
+    digest: 703878390aa6c6c70e3c07805312c70e51ef0e657621f870dfab5a69c46d6adc
     home: https://github.com/open-policy-agent/gatekeeper
     icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
     keywords:
@@ -1759,13 +1785,14 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-gatekeeper
     apiVersion: v1
     appVersion: v3.1.1
-    created: "2021-08-25T15:50:58.510640452-07:00"
+    created: "2021-09-30T12:30:02.247484-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
-    digest: 36aebc7718e4afd4d9bb65775276d2288eb0de27192d0d290553a7c7087d7f3f
+    digest: 20f9b2f7d562f0ef13024ad178ebfe4535d1584502d3f90543a4f7d694ab92b1
     home: https://github.com/open-policy-agent/gatekeeper
     icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
     keywords:
@@ -1784,13 +1811,14 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-gatekeeper
     apiVersion: v1
     appVersion: v3.1.1
-    created: "2021-08-25T15:50:58.510086044-07:00"
+    created: "2021-09-30T12:30:02.246185-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
-    digest: 15a4540b7e32c62157c37cfdb9230ce4b11c5837a2f3734378fcd7ec9c824559
+    digest: 074c34d0c2f46236a34e96a7d3c00bdfdad36de1d0e3b6e1a874f69e0b286b49
     home: https://github.com/open-policy-agent/gatekeeper
     icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
     keywords:
@@ -1809,7 +1837,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-24T17:16:30.741425373+05:30"
+    created: "2021-09-30T12:30:02.253873-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 2473133618927588bb5cf2f7829aad41e17dc0743b954025c898683853476ce7
     name: rancher-gatekeeper-crd
@@ -1823,7 +1851,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.517435386-07:00"
+    created: "2021-09-30T12:30:02.252486-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: ec199aafd94d27c19e78c858ff990fe057a31a0240c062b99334e97fbdf7fb46
     name: rancher-gatekeeper-crd
@@ -1837,7 +1865,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.521328824-07:00"
+    created: "2021-09-30T12:30:02.259019-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: d82c0a0eae6ef19cd815fa0f78730403fac042c886c4564af1a0935d9be54d08
     name: rancher-gatekeeper-crd
@@ -1851,7 +1879,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.52019837-07:00"
+    created: "2021-09-30T12:30:02.258285-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 48a03a80fadacabc507fec107dbed749d94fafbef0d26e4eb37e92c974a7c56b
     name: rancher-gatekeeper-crd
@@ -1866,7 +1894,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.519397322-07:00"
+    created: "2021-09-30T12:30:02.25743-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 34f449b69d1b50ff1743ae3b1e81553aec3f0a70c8ac7572c60071a8271b53e2
     name: rancher-gatekeeper-crd
@@ -1881,7 +1909,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.518568876-07:00"
+    created: "2021-09-30T12:30:02.256282-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: e3da4139207bfa07850db780574a028b5e32c66c1ee57b706fb13fdec5311514
     name: rancher-gatekeeper-crd
@@ -1896,7 +1924,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.518045391-07:00"
+    created: "2021-09-30T12:30:02.255296-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 89d80de1bea71d134b19e6092ae123c08173c172a5201d54b4baa6afedea3855
     name: rancher-gatekeeper-crd
@@ -1917,7 +1945,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-08-25T15:50:58.522104682-07:00"
+    created: "2021-09-30T12:30:02.259754-07:00"
     description: A Helm chart for provisioning GKE clusters
     digest: 647914b2fe504d4a06d7de71ff432125d25cd8708ac9d856399097aaaaccffe4
     home: https://github.com/rancher/gke-operator
@@ -1936,9 +1964,9 @@ entries:
       catalog.cattle.io/release-name: rancher-gke-operator-crd
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-08-25T15:50:58.522537772-07:00"
+    created: "2021-09-30T12:30:02.260329-07:00"
     description: GKE Operator CustomResourceDefinitions
-    digest: c85b294e0858d0d4907c43183f6c2c139e3c63a960017452ab3bad3b2d35bec8
+    digest: 2c7fa7ace2acea04dcf5f35e74a206c30a0592a07313b5e2456f5f753e2ebdb0
     name: rancher-gke-operator-crd
     urls:
     - assets/rancher-gke-operator-crd/rancher-gke-operator-crd-100.0.0+up1.1.1.tgz
@@ -1952,7 +1980,7 @@ entries:
       catalog.rancher.io/release-name: rancher-grafana
     apiVersion: v2
     appVersion: 7.5.8
-    created: "2021-08-25T15:50:58.527954631-07:00"
+    created: "2021-09-30T12:30:02.263705-07:00"
     description: The leading tool for querying and visualizing time series and metrics.
     digest: c7e3f13f88da598678e6634a1987271a6fea214d26c266286d40476b2fda7ce8
     home: https://grafana.net
@@ -1984,7 +2012,7 @@ entries:
       catalog.rancher.io/release-name: rancher-grafana
     apiVersion: v2
     appVersion: 7.4.5
-    created: "2021-08-25T15:50:58.531472926-07:00"
+    created: "2021-09-30T12:30:02.267268-07:00"
     description: The leading tool for querying and visualizing time series and metrics.
     digest: 938a0dc18011b95a3db0c94cb37a8db868a22fb41436242724d81391404426d2
     home: https://grafana.net
@@ -2024,7 +2052,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.10.4
-    created: "2021-09-29T21:47:00.972326-07:00"
+    created: "2021-09-30T12:30:02.283479-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2057,7 +2085,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.10.4
-    created: "2021-08-25T15:50:58.558069263-07:00"
+    created: "2021-09-30T12:30:02.280726-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2083,13 +2111,14 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requests-cpu: 710m
       catalog.cattle.io/requests-memory: 2314Mi
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.9.6
-    created: "2021-08-25T15:50:58.58015237-07:00"
+    created: "2021-09-30T12:30:02.29845-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2099,7 +2128,7 @@ entries:
       repository: file://./charts/tracing
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: 8f138c96cdd1f12d91cae4f9443057bc6e6f994e3111ad6b0da69cd42a349ec8
+    digest: 3e88c2c6fb6a42b3246ac479ceb90fefcebb40892dde375509042c7b821264ef
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2115,13 +2144,14 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requests-cpu: 710m
       catalog.cattle.io/requests-memory: 2314Mi
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.9.5
-    created: "2021-08-25T15:50:58.576120803-07:00"
+    created: "2021-09-30T12:30:02.295915-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2131,7 +2161,7 @@ entries:
       repository: file://./charts/tracing
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: 754d6c01062e7853570eb8e53a859136c58914cb36bae6a9d043825e8368498b
+    digest: 02c296a20850b754230aae10f4896d7d4b52d1876b85709bf9d20bb8c89c01ce
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2147,13 +2177,14 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requests-cpu: 710m
       catalog.cattle.io/requests-memory: 2314Mi
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.9.3
-    created: "2021-08-25T15:50:58.57074488-07:00"
+    created: "2021-09-30T12:30:02.293034-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2163,7 +2194,7 @@ entries:
       repository: file://./charts/tracing
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: 4774d1f117a1ce47230e2004dc23609f54ed49c6b45100b2438bf920822f7ca1
+    digest: f0c89f748c6ee29ee29c3a6b758349f23ae797548b69bf1f78db776a6924b1b7
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2179,13 +2210,14 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requests-cpu: 710m
       catalog.cattle.io/requests-memory: 2314Mi
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.8.6
-    created: "2021-08-25T15:50:58.563121642-07:00"
+    created: "2021-09-30T12:30:02.29019-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2195,7 +2227,7 @@ entries:
       repository: file://./charts/tracing
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: d82fc232659cde9e43575d0d99fbb91d90d31fe94ee21712169cb5220022fa00
+    digest: 67822b8e51779cb700e0d9c4fdc044f887d77ad181c30a8a84a87be0870fbfc9
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2211,13 +2243,14 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requests-cpu: 710m
       catalog.cattle.io/requests-memory: 2314Mi
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.8.5
-    created: "2021-08-25T15:50:58.560590007-07:00"
+    created: "2021-09-30T12:30:02.287379-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2227,7 +2260,7 @@ entries:
       repository: file://./charts/tracing
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: efe71af755309576302e421e5becef54cbd291889ccd2372ab765a075075e72e
+    digest: e57041ead3608ee18dd8e859f9c308a1d9ff8338e22f993f3fd3f3b1e7e4552c
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2243,13 +2276,14 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requests-cpu: 710m
       catalog.cattle.io/requests-memory: 2314Mi
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.8.3
-    created: "2021-08-25T15:50:58.553218645-07:00"
+    created: "2021-09-30T12:30:02.278054-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2259,7 +2293,7 @@ entries:
       repository: file://./charts/tracing
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: 3b5fdc7d06c6a3878c47030ff2a9e23ef1ab68ceddcb9fd7290f4e3ef3c99cb0
+    digest: a6bd3b5883379220dc741003427303852b0a5bc8c5d23dfdc874a246332482eb
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2275,11 +2309,12 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.7.3
-    created: "2021-08-25T15:50:58.547208836-07:00"
+    created: "2021-09-30T12:30:02.275087-07:00"
     dependencies:
     - alias: kiali
       condition: kiali.enabled
@@ -2293,7 +2328,7 @@ entries:
       version: 1.20.001
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: ff28763d01f5b7b366ea0373bd052bbe579f17c009955c88e7cbb5eb66802e84
+    digest: 2a3719e42dcb38e0297e63df0d5ff423acf611c5aa606c5bf2b1a747991878fc
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2309,11 +2344,12 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.7.3
-    created: "2021-08-25T15:50:58.538097375-07:00"
+    created: "2021-09-30T12:30:02.271781-07:00"
     dependencies:
     - alias: kiali
       condition: kiali.enabled
@@ -2322,7 +2358,7 @@ entries:
       version: 1.24.0
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: 1e4a14509830e72f8a3d10d6d3ffaf72683dc0243e2cd9d067934844163f9f80
+    digest: 3d8133f45ae905cf311fbd7559082a191dd1674da37f5614b3e70647a7ceafdc
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2337,12 +2373,13 @@ entries:
       catalog.cattle.io/namespace: istio-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: networking.istio.io.virtualservice/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-istio
       catalog.cattle.io/requires-gvr: monitoring.coreos.com.prometheus/v1
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.7.1
-    created: "2021-08-25T15:50:58.53416207-07:00"
+    created: "2021-09-30T12:30:02.269624-07:00"
     dependencies:
     - alias: kiali
       condition: kiali.enabled
@@ -2351,7 +2388,7 @@ entries:
       version: 1.23.0
     description: A basic Istio setup that installs with the istioctl. Refer to https://istio.io/latest/
       for details.
-    digest: 3a7a84aa165a472cf346a4d595ff84ac8190d7f050409b65f2a7168c8307ef28
+    digest: f5d5c689dc7eb17f09c85ef3f6b45e0ffe47e5f8a384628c515ca629d312d394
     icon: https://charts.rancher.io/assets/logos/istio.svg
     keywords:
     - networking
@@ -2371,7 +2408,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.35.0
-    created: "2021-08-25T15:50:58.589223551-07:00"
+    created: "2021-09-30T12:30:02.309035-07:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2406,7 +2443,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.32.0
-    created: "2021-08-25T15:50:58.58805758-07:00"
+    created: "2021-09-30T12:30:02.307443-07:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2441,7 +2478,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.29.0
-    created: "2021-08-25T15:50:58.586681711-07:00"
+    created: "2021-09-30T12:30:02.305181-07:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2476,7 +2513,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.24.0
-    created: "2021-08-25T15:50:58.585007657-07:00"
+    created: "2021-09-30T12:30:02.30323-07:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2511,7 +2548,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.24.0
-    created: "2021-08-25T15:50:58.583416495-07:00"
+    created: "2021-09-30T12:30:02.301503-07:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2546,7 +2583,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.23.0
-    created: "2021-08-25T15:50:58.581821221-07:00"
+    created: "2021-09-30T12:30:02.299928-07:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2575,7 +2612,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-08-25T15:50:58.590044511-07:00"
+    created: "2021-09-30T12:30:02.312765-07:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 04339f84a5ddac166de594dc621534a95360b967cf225933ce686f9c8cb7fb15
     name: rancher-kiali-server-crd
@@ -2586,7 +2623,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-08-25T15:50:58.589914223-07:00"
+    created: "2021-09-30T12:30:02.312128-07:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 20b301ef9430f4d4d3dd75474e96f3ba75bd5adf0f88371970d7c77530f74874
     name: rancher-kiali-server-crd
@@ -2597,7 +2634,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-08-25T15:50:58.589786125-07:00"
+    created: "2021-09-30T12:30:02.311497-07:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 4ddd8248707294cb91fdd1c2fd9994417bf265b7f649312e82a4f1a86b60e9b6
     name: rancher-kiali-server-crd
@@ -2608,7 +2645,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-08-25T15:50:58.589661995-07:00"
+    created: "2021-09-30T12:30:02.311007-07:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: c8635521da746674695c7833a5509ee92c615adabd47e511e1dd7c2617a4bf7b
     name: rancher-kiali-server-crd
@@ -2619,7 +2656,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-08-25T15:50:58.589529589-07:00"
+    created: "2021-09-30T12:30:02.310353-07:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: bd55c5af7c26744e91922c6a9463c10e52ba65ddf0cf148107461f2983a71223
     name: rancher-kiali-server-crd
@@ -2630,7 +2667,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-08-25T15:50:58.589390683-07:00"
+    created: "2021-09-30T12:30:02.309786-07:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 5d5ebb3498ac0b64cf1a73d743b0f3f45fd40c0a9ee3b26d94ae60176e523574
     name: rancher-kiali-server-crd
@@ -2647,7 +2684,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kube-state-metrics
     apiVersion: v2
     appVersion: 2.0.0
-    created: "2021-08-25T15:50:58.592534083-07:00"
+    created: "2021-09-30T12:30:02.314222-07:00"
     description: Install kube-state-metrics to generate and expose cluster-level metrics
     digest: c7a76ad182ca687673327e5ebef5558c9243f876f3241ade6161cd9aa739c0cc
     home: https://github.com/kubernetes/kube-state-metrics/
@@ -2676,7 +2713,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kube-state-metrics
     apiVersion: v1
     appVersion: 1.9.8
-    created: "2021-08-25T15:50:58.594362547-07:00"
+    created: "2021-09-30T12:30:02.315613-07:00"
     description: Install kube-state-metrics to generate and expose cluster-level metrics
     digest: bf852a0682030a0386010427fceb71204d1aedf48c7c4af85dd5e9198fbbcfb0
     home: https://github.com/kubernetes/kube-state-metrics/
@@ -2708,7 +2745,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.12.0
-    created: "2021-08-25T15:50:58.596270546-07:00"
+    created: "2021-09-30T12:30:02.317732-07:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
     digest: 725703ad277825cf79620504a097bbd3cd529e4c33f4fdaa1834409f08b7b297
@@ -2727,14 +2764,15 @@ entries:
       catalog.cattle.io/display-name: Logging
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-logging
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.9.4
-    created: "2021-08-25T15:50:58.604366808-07:00"
+    created: "2021-09-30T12:30:02.324922-07:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
-    digest: 7022eaf17da08bec0ce2f3fc69e7d5ecd7b37fc61e328e80d9738b65196ce030
+    digest: 565b721d95829592d0919944e45f0b38f9abe3e640457e447e3241c8eb25c614
     icon: https://charts.rancher.io/assets/logos/logging.svg
     keywords:
     - logging
@@ -2751,14 +2789,15 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-logging
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.9.0
-    created: "2021-08-25T15:50:58.602542094-07:00"
+    created: "2021-09-30T12:30:02.323298-07:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
-    digest: b6b5e0c627f5594033b3558ff1f2d9c01b1f504a53cbc91b4e75d443ef81a784
+    digest: 557423888e9d279e1748e09ee6e639ef739bf767757cfa496eea706a12e4f006
     icon: https://charts.rancher.io/assets/logos/logging.svg
     keywords:
     - logging
@@ -2775,14 +2814,15 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-logging
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.8.2
-    created: "2021-08-25T15:50:58.600782944-07:00"
+    created: "2021-09-30T12:30:02.321775-07:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
-    digest: 7ec4dfb2441832d22651e9263f4bbdcda9e1f064b9e32c70d0fb7c4f6641331a
+    digest: 9a530816512757cca175695707f5e5a2349c06bf076d1a50e4aa80f7e40c35d9
     icon: https://charts.rancher.io/assets/logos/logging.svg
     keywords:
     - logging
@@ -2799,14 +2839,15 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-logging
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.6.0
-    created: "2021-08-25T15:50:58.599223662-07:00"
+    created: "2021-09-30T12:30:02.320391-07:00"
     description: Collects and filter logs using highly configurable CRDs.  Powered
       by Banzai Cloud Logging Operator.
-    digest: a89b3a4327484343c59a88949479c106e40b2587df194e18910cf83099291aa6
+    digest: 47f857372c32fdbd0299631af812fb1fa8fa868375410f24a84fb91b86a977ec
     icon: https://charts.rancher.io/assets/logos/logging.svg
     keywords:
     - logging
@@ -2822,14 +2863,15 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-logging
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.6.0
-    created: "2021-08-25T15:50:58.597606505-07:00"
+    created: "2021-09-30T12:30:02.318999-07:00"
     description: Collects and filter logs using highly configurable CRDs.  Powered
       by Banzai Cloud Logging Operator.
-    digest: 3f3cd871fe5c6708b3fcdcd7a9f6e87ee41eb8f5505bdaed3f01791ac2bf7faf
+    digest: 9e213a66882cc8986d466ba95aa95388aa7ca87fe3a88ba9d894e30625d515ea
     icon: https://charts.rancher.io/assets/logos/logging.svg
     keywords:
     - logging
@@ -2846,7 +2888,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.609939054-07:00"
+    created: "2021-09-30T12:30:02.329851-07:00"
     description: Installs the CRDs for rancher-logging.
     digest: 8543212393b921630119d9f0bbaedd046c713e81c18d125c0f9a0b54083b3281
     name: rancher-logging-crd
@@ -2860,7 +2902,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.619888687-07:00"
+    created: "2021-09-30T12:30:02.340557-07:00"
     description: Installs the CRDs for rancher-logging.
     digest: 64103cfbf9e0a3f4a590e194022aeeda582cc96a5c3450eac839c0c3d448b059
     name: rancher-logging-crd
@@ -2874,7 +2916,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.616512887-07:00"
+    created: "2021-09-30T12:30:02.337632-07:00"
     description: Installs the CRDs for rancher-logging.
     digest: 2ab6fc36daf86c405b536970d9ed4dcb68f84ac93df7ac3811dd123ba82448bd
     name: rancher-logging-crd
@@ -2888,7 +2930,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.614196814-07:00"
+    created: "2021-09-30T12:30:02.335818-07:00"
     description: Installs the CRDs for rancher-logging.
     digest: 351b69ac821716e05b4648f6fe175bfc8b25fee5dc8b7088cc3b77a7d8596b76
     name: rancher-logging-crd
@@ -2902,7 +2944,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.612263154-07:00"
+    created: "2021-09-30T12:30:02.33412-07:00"
     description: Installs the CRDs for rancher-logging.
     digest: 582846a78f045a48088f355599a0abd62c98ce62698ef7fe59ed2180f2016441
     name: rancher-logging-crd
@@ -2916,7 +2958,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.611096918-07:00"
+    created: "2021-09-30T12:30:02.331875-07:00"
     description: Installs the CRDs for rancher-logging.
     digest: 1c24d7465ba9a4ae3613ffad12cea6d6a60df66a9fbf4d0f2674c4efec2616f2
     name: rancher-logging-crd
@@ -2944,7 +2986,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v2
     appVersion: 0.48.0
-    created: "2021-08-25T15:50:58.670768381-07:00"
+    created: "2021-09-30T12:30:02.37033-07:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -3057,13 +3099,14 @@ entries:
       catalog.cattle.io/display-name: Monitoring
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/provides-gvr: monitoring.coreos.com.prometheus/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-monitoring
       catalog.cattle.io/requests-cpu: 4500m
       catalog.cattle.io/requests-memory: 4000Mi
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v2
     appVersion: 0.46.0
-    created: "2021-08-25T15:50:58.715215559-07:00"
+    created: "2021-09-30T12:30:02.397855-07:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -3122,7 +3165,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: e9c04b9762e98505db5ee54d5b71a10f3c4bf423f16c21b98a8f311587012a4f
+    digest: 21e00758c396964ef0b9f561501fc900d8222705951b055cc328d3a4f83499d9
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:
@@ -3165,13 +3208,14 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: monitoring.coreos.com.prometheus/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-monitoring
       catalog.cattle.io/requests-cpu: 4500m
       catalog.cattle.io/requests-memory: 4000Mi
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-08-25T15:50:58.832293041-07:00"
+    created: "2021-09-30T12:30:02.485136-07:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -3227,7 +3271,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: 64604ea0359b468c9a768ec484ebfdf3f776da5524571c85dd42bc6e600aeead
+    digest: 8a796fc3ba8184f5a688b0f91edfbfe6e59571e0b480e54806fada024340395f
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:
@@ -3268,11 +3312,12 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: monitoring.coreos.com.prometheus/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-monitoring
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-08-25T15:50:58.796039312-07:00"
+    created: "2021-09-30T12:30:02.460937-07:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -3358,7 +3403,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: 0e032ffa7397d564f3d00aa7719b62314e25f6e32e723de5db0f312f4a0034de
+    digest: 5862300c5e9271e49d4ab203875b0c7b5e03f62fdd77a78d3fd6cba168063360
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:
@@ -3397,11 +3442,12 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: monitoring.coreos.com.prometheus/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-monitoring
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-08-25T15:50:58.765064124-07:00"
+    created: "2021-09-30T12:30:02.433894-07:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -3487,7 +3533,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: 36890f0d8ae2f9c4990e61122d727a5df31dbe017f49d6334e7e13fb9c257cd8
+    digest: f6bdd6f676cf39a8d03e42cf7eed021371673f2bb70c2375525ffe482f53e70a
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:
@@ -3525,11 +3571,12 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: monitoring.coreos.com.prometheus/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-monitoring
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-08-25T15:50:58.738044806-07:00"
+    created: "2021-09-30T12:30:02.415712-07:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -3625,7 +3672,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: 4c5845c1ca7c109052ce9cae5deea7dd0bc697cb334ba9d929f4c04f14835957
+    digest: b3d9f2e62d1260149bac7978281bd9a512c72f3a227b24ca15ab7ba3ec7f468e
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:
@@ -3658,7 +3705,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.83884583-07:00"
+    created: "2021-09-30T12:30:02.490036-07:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 8df09722ba0baf7a39f809432918fd46643667d4fcf22f025697a1b77c7f5014
     name: rancher-monitoring-crd
@@ -3672,7 +3719,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.849143617-07:00"
+    created: "2021-09-30T12:30:02.494681-07:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 6f4fc35013ee3d368502857afb8c466f2e1762c656c9502a154f6354a360361b
     name: rancher-monitoring-crd
@@ -3686,7 +3733,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.881122232-07:00"
+    created: "2021-09-30T12:30:02.515184-07:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 63a81f944774e646f6549c545f7c6b56635218bc135b9421eab224c6139dcbf7
     name: rancher-monitoring-crd
@@ -3700,7 +3747,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.875159925-07:00"
+    created: "2021-09-30T12:30:02.510598-07:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 60945c2274b7c169ad84240e7facc9aa8d3a0a4e649c3dcd6e6b21f336a257d8
     name: rancher-monitoring-crd
@@ -3714,7 +3761,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.866933331-07:00"
+    created: "2021-09-30T12:30:02.504981-07:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 09532cc000ee5a78dbda15c879ad1af9f9c2f8bc08db4067a6756df1a0206de3
     name: rancher-monitoring-crd
@@ -3728,7 +3775,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-08-25T15:50:58.855926501-07:00"
+    created: "2021-09-30T12:30:02.499965-07:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 101721abb2876816b54234568272d0372c274ed3e4851a9c94077f61fefb8a49
     name: rancher-monitoring-crd
@@ -3745,7 +3792,7 @@ entries:
       catalog.rancher.io/release-name: rancher-node-exporter
     apiVersion: v1
     appVersion: 1.1.2
-    created: "2021-08-25T15:50:58.882959603-07:00"
+    created: "2021-09-30T12:30:02.517487-07:00"
     description: A Helm chart for prometheus node-exporter
     digest: 940f60a7e56c13351c9f6088bde9230a03e579d0791e41f911a724b002580fbb
     home: https://github.com/prometheus/node_exporter/
@@ -3772,7 +3819,7 @@ entries:
       catalog.rancher.io/release-name: rancher-node-exporter
     apiVersion: v1
     appVersion: 1.1.2
-    created: "2021-08-25T15:50:58.882058081-07:00"
+    created: "2021-09-30T12:30:02.516343-07:00"
     description: A Helm chart for prometheus node-exporter
     digest: 423bbfe53c9137e1f9937601a3e573ed22e2aae2c7a19162781518ffc041ff35
     home: https://github.com/prometheus/node_exporter/
@@ -3799,7 +3846,7 @@ entries:
       catalog.cattle.io/release-name: rancher-prom2teams
     apiVersion: v1
     appVersion: 3.2.2
-    created: "2021-08-25T15:50:58.884109079-07:00"
+    created: "2021-09-30T12:30:02.519326-07:00"
     description: A Helm chart for Prom2Teams based on the upstream https://github.com/idealista/prom2teams
     digest: a278a9673dbe8dbb5ed21b3b6e2159f79c8fae1ba9e34e4e5e642e9a55a9bb95
     name: rancher-prom2teams
@@ -3813,7 +3860,7 @@ entries:
       catalog.cattle.io/release-name: rancher-prom2teams
     apiVersion: v1
     appVersion: 3.2.1
-    created: "2021-08-25T15:50:58.883539643-07:00"
+    created: "2021-09-30T12:30:02.518434-07:00"
     description: A Helm chart for Prom2Teams based on the upstream https://github.com/idealista/prom2teams
     digest: 2c83714457d157bc77c0f74ab01c1db84b63c5a811a99225b626f297455e0e3b
     name: rancher-prom2teams
@@ -3829,7 +3876,7 @@ entries:
       catalog.rancher.io/release-name: rancher-prometheus-adapter
     apiVersion: v1
     appVersion: v0.8.4
-    created: "2021-08-25T15:50:58.885121691-07:00"
+    created: "2021-09-30T12:30:02.520563-07:00"
     description: A Helm chart for k8s prometheus adapter
     digest: 45e2aad6b9edfa24e88f97038616a898b2b9693b2acb9087772d0377f009f9a4
     home: https://github.com/DirectXMan12/k8s-prometheus-adapter
@@ -3859,7 +3906,7 @@ entries:
       catalog.rancher.io/release-name: rancher-prometheus-adapter
     apiVersion: v1
     appVersion: v0.8.3
-    created: "2021-08-25T15:50:58.886149815-07:00"
+    created: "2021-09-30T12:30:02.521906-07:00"
     description: A Helm chart for k8s prometheus adapter
     digest: f1da6d7eac3c183afdc127810f8463d6d7bb597dce2ad6046e30d66c8b9423e6
     home: https://github.com/DirectXMan12/k8s-prometheus-adapter
@@ -3890,7 +3937,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.89343557-07:00"
+    created: "2021-09-30T12:30:02.527796-07:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: d2396d0961ee525846f485efa79b6182139567141a67b378bd775c4f86f2e7e8
@@ -3907,7 +3954,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.892181707-07:00"
+    created: "2021-09-30T12:30:02.526803-07:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: f1f1e0d4d24a20b4b995a8ecc360ff0db310d4af92ec7fcdf87e4b9d5f977dd4
@@ -3923,7 +3970,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.891084793-07:00"
+    created: "2021-09-30T12:30:02.525629-07:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: cb9552eb4ee8899ef1af5583c8080c27227dd3b10d919748f2caf79cb8197198
@@ -3939,7 +3986,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.890036048-07:00"
+    created: "2021-09-30T12:30:02.524672-07:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: a4b3506a74ea6cc4e8c6610cb92451d3072f4f7bac7b503e2dea9423697eaf68
@@ -3956,7 +4003,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.888930648-07:00"
+    created: "2021-09-30T12:30:02.523871-07:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: 4b53e4de2aede1f3d63c815ca36bd61f31d38c59769d9982b14aca3bbf575724
@@ -3973,7 +4020,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.887629174-07:00"
+    created: "2021-09-30T12:30:02.52298-07:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: 73b11a51246c216a7587628fee346541d6b5e82246e11d586b4926254f7999fa
@@ -3990,7 +4037,7 @@ entries:
       catalog.cattle.io/release-name: rancher-sachet
     apiVersion: v2
     appVersion: 0.2.3
-    created: "2021-08-25T15:50:58.895293407-07:00"
+    created: "2021-09-30T12:30:02.530166-07:00"
     description: A Helm chart for Sachet based on the upstream https://github.com/messagebird/sachet
     digest: face4a2ab50a6b7abcc88cf84fcf27efd9a257f19cc6869cf506c4c341a8c790
     name: rancher-sachet
@@ -4005,7 +4052,7 @@ entries:
       catalog.cattle.io/release-name: rancher-sachet
     apiVersion: v2
     appVersion: 0.2.3
-    created: "2021-08-25T15:50:58.894367879-07:00"
+    created: "2021-09-30T12:30:02.529295-07:00"
     description: A Helm chart for Sachet based on the upstream https://github.com/messagebird/sachet
     digest: 0c438e1f63546d35f8e48fbafdc5ef2bbe0fa8d59383f7a36b4f601c99677029
     name: rancher-sachet
@@ -4022,7 +4069,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-08-25T15:50:58.900090662-07:00"
+    created: "2021-09-30T12:30:02.535212-07:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4039,7 +4086,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-08-25T15:50:58.899496917-07:00"
+    created: "2021-09-30T12:30:02.534309-07:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4056,7 +4103,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-08-25T15:50:58.898844416-07:00"
+    created: "2021-09-30T12:30:02.53356-07:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4073,7 +4120,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-08-25T15:50:58.898006002-07:00"
+    created: "2021-09-30T12:30:02.53275-07:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4091,9 +4138,9 @@ entries:
       catalog.cattle.io/release-name: vsphere-cpi
     apiVersion: v1
     appVersion: 1.0.0
-    created: "2021-08-25T15:50:58.90112053-07:00"
+    created: "2021-09-30T12:30:02.536777-07:00"
     description: vSphere Cloud Provider Interface (CPI)
-    digest: 6fb58545cb7aa2e7dbe3037468866bf578982535ccb10d089da0c4a86e82d3a8
+    digest: 2da8c41576eec369cd5b61f6b0d240f09bb719e0e21e4f63ac976293c8bc130a
     icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
     keywords:
     - infrastructure
@@ -4111,12 +4158,13 @@ entries:
       catalog.cattle.io/display-name: vSphere CPI
       catalog.cattle.io/namespace: kube-system
       catalog.cattle.io/os: linux
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: vsphere-cpi
     apiVersion: v1
     appVersion: 1.0.0
-    created: "2021-08-25T15:50:58.900603278-07:00"
+    created: "2021-09-30T12:30:02.536006-07:00"
     description: vSphere Cloud Provider Interface (CPI)
-    digest: 932e0f16481f28b34d4dd991323da85da272f3d5d4cce28832a7442d4f2ca1f7
+    digest: 05298fce7dbfe5176fe509e1cde6ea8ab136c3c77af61b12f297880332f88840
     icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
     keywords:
     - infrastructure
@@ -4138,9 +4186,9 @@ entries:
       catalog.cattle.io/release-name: vsphere-csi
     apiVersion: v1
     appVersion: 2.2.0
-    created: "2021-08-25T15:50:58.902011206-07:00"
+    created: "2021-09-30T12:30:02.537983-07:00"
     description: vSphere Cloud Storage Interface (CSI)
-    digest: 8db3385ae16017f9f354a4e746ec44519eeadec8a0452b8a4833b224a7aac404
+    digest: a20bc110bca55c0059658daa7e5d5981ce2fcbbdcd2c957f0941170fa43c0afa
     icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
     keywords:
     - infrastructure
@@ -4158,12 +4206,13 @@ entries:
       catalog.cattle.io/display-name: vSphere CSI
       catalog.cattle.io/namespace: kube-system
       catalog.cattle.io/os: linux
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: vsphere-csi
     apiVersion: v1
     appVersion: 2.1.0
-    created: "2021-08-25T15:50:58.902817658-07:00"
+    created: "2021-09-30T12:30:02.539014-07:00"
     description: vSphere Cloud Storage Interface (CSI)
-    digest: 20bfaa758a97b0b89c51fefdf70d048a7e06b576932435ac03fc045a295c0535
+    digest: fbef8bf05ec18534a4108fa2de055eb212be24d8114a946de9b5c937eb0b1248
     icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
     keywords:
     - infrastructure
@@ -4185,7 +4234,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.2.1
-    created: "2021-09-27T11:37:55.876378-07:00"
+    created: "2021-09-30T12:30:02.544822-07:00"
     dependencies:
     - condition: capi.enabled
       name: capi
@@ -4204,7 +4253,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.2.0
-    created: "2021-08-27T15:04:23.560594-07:00"
+    created: "2021-09-30T12:30:02.543958-07:00"
     dependencies:
     - condition: capi.enabled
       name: capi
@@ -4223,7 +4272,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.1
-    created: "2021-08-25T15:50:58.904627443-07:00"
+    created: "2021-09-30T12:30:02.542804-07:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: a0ee1c4f1338c8c24f3c5129bb41a67a43bffb13bf28c138266cf58dd28f2ce4
     name: rancher-webhook
@@ -4238,7 +4287,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0
-    created: "2021-08-25T15:50:58.904332735-07:00"
+    created: "2021-09-30T12:30:02.542256-07:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 3c20cc0a6b0fdc9672d7fa84be46f74b208a00664397d1abcfd8acd9ae10ff0e
     name: rancher-webhook
@@ -4253,7 +4302,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta9
-    created: "2021-08-25T15:50:58.904023671-07:00"
+    created: "2021-09-30T12:30:02.541675-07:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 0d9ac76eff2b6e937e3e15970cd0192acff99a31aa1afa14941029088dc32f76
     name: rancher-webhook
@@ -4268,7 +4317,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta9
-    created: "2021-08-25T15:50:58.903748411-07:00"
+    created: "2021-09-30T12:30:02.541064-07:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 8881f7cf8b50e3b48a967ce8af477c96f986d42d3c1f4bbb8c0bfc09202d23f4
     name: rancher-webhook
@@ -4283,7 +4332,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta7
-    created: "2021-08-25T15:50:58.903468161-07:00"
+    created: "2021-09-30T12:30:02.540393-07:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: e185c6765de0bb0694d6d12e16c2dcce7f4c785125e614cf6c0020e5982d5f0e
     name: rancher-webhook
@@ -4298,7 +4347,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta5
-    created: "2021-08-25T15:50:58.903128697-07:00"
+    created: "2021-09-30T12:30:02.539648-07:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 574407c23b5827bd1d4d4f20609a5dc9d4558d6d29ef179093288a4a730ab8c2
     name: rancher-webhook
@@ -4314,7 +4363,7 @@ entries:
       catalog.rancher.io/release-name: rancher-windows-exporter
     apiVersion: v1
     appVersion: 0.0.2
-    created: "2021-08-25T15:50:58.907450417-07:00"
+    created: "2021-09-30T12:30:02.546553-07:00"
     description: Sets up monitoring metrics from Windows nodes via Prometheus windows-exporter
     digest: e8343b74c657a9ac4ea3d363e51bfd8e2551dd746e5992209f7a91724f972c78
     maintainers:
@@ -4333,7 +4382,7 @@ entries:
       catalog.rancher.io/release-name: rancher-windows-exporter
     apiVersion: v1
     appVersion: 0.0.4
-    created: "2021-08-25T15:50:58.905788013-07:00"
+    created: "2021-09-30T12:30:02.545618-07:00"
     description: Sets up monitoring metrics from Windows nodes via Prometheus windows-exporter
     digest: 329af930026bd58a3ffeeb202f362a2936031f14cc2a137593952d131db53afe
     maintainers:
@@ -4352,7 +4401,7 @@ entries:
       catalog.cattle.io/release-name: rancher-wins-upgrader
     apiVersion: v2
     appVersion: 0.1.1
-    created: "2021-08-25T15:50:58.909065017-07:00"
+    created: "2021-09-30T12:30:02.548102-07:00"
     description: Manages upgrading the wins server version and configuration across
       all of your Windows nodes
     digest: 5de123eda92b3a5823a8b3e6c304de112a02fc42e8531ccc1b64c0e9f4721e13
@@ -4371,7 +4420,7 @@ entries:
       catalog.cattle.io/release-name: rancher-wins-upgrader
     apiVersion: v2
     appVersion: 0.1.1
-    created: "2021-08-25T15:50:58.908441951-07:00"
+    created: "2021-09-30T12:30:02.547314-07:00"
     description: Manages upgrading the wins server version and configuration across
       all of your Windows nodes
     digest: 5f1a089d856a0f6a6ad17b0f6e2be19ddc42c1fbcc4f5f8576395e87368eba9d
@@ -4394,7 +4443,7 @@ entries:
       catalog.cattle.io/requires-gvr: networking.istio.io.virtualservice/v1beta1
     apiVersion: v1
     appVersion: 0.8.0
-    created: "2021-08-25T15:50:58.909802459-07:00"
+    created: "2021-09-30T12:30:02.550215-07:00"
     description: The application deployment engine for Kubernetes
     digest: 8baa5c330cc152b3d3d87f918ed3ff96b927efad412f4b97bd7db90445e28602
     home: https://rio.io
@@ -4414,7 +4463,7 @@ entries:
       catalog.cattle.io/requires-gvr: networking.istio.io.virtualservice/v1beta1
     apiVersion: v1
     appVersion: 0.8.0
-    created: "2021-08-25T15:50:58.909456427-07:00"
+    created: "2021-09-30T12:30:02.549509-07:00"
     description: The application deployment engine for Kubernetes
     digest: d58ca3b147627fec6d5f4b99fae680f97edaed98967f1fc1914a537dede0d897
     home: https://rio.io
@@ -4433,7 +4482,7 @@ entries:
       catalog.cattle.io/release-name: sriov
     apiVersion: v2
     appVersion: 1.0.0
-    created: "2021-08-26T18:32:38.059961868+02:00"
+    created: "2021-09-30T12:30:02.531255-07:00"
     description: SR-IOV network operator configures and manages SR-IOV networks in
       the kubernetes cluster
     digest: fbb5f88710506b872767657b8b29aef0b84019d8d7e57b66eaea1563cae5a4a4
@@ -4461,7 +4510,7 @@ entries:
       catalog.cattle.io/namespace: cattle-sriov-system
       catalog.cattle.io/release-name: sriov-crd
     apiVersion: v2
-    created: "2021-08-26T18:32:38.060417232+02:00"
+    created: "2021-09-30T12:30:02.531963-07:00"
     description: Installs the CRDs for rke2-sriov.
     digest: db8031e9088de70c02778bedae7149b0678439a931ef987b0b4f57ca52415589
     name: sriov-crd
@@ -4478,7 +4527,7 @@ entries:
       catalog.cattle.io/release-name: system-upgrade-controller
     apiVersion: v1
     appVersion: v0.7.5
-    created: "2021-08-25T15:50:58.91004463-07:00"
+    created: "2021-09-30T12:30:02.550729-07:00"
     description: General purpose controller to make system level updates to nodes
     digest: ecc9bf23666bd63dedd95b22c3a5c806ad084800f05a765fba133f8de4e4814f
     home: https://github.com/rancher/system-charts/charts/system-upgrade-controller
@@ -4488,4 +4537,4 @@ entries:
     urls:
     - assets/system-upgrade-controller/system-upgrade-controller-100.0.0+up0.3.0.tgz
     version: 100.0.0+up0.3.0
-generated: "2021-08-25T15:50:58.447798684-07:00"
+generated: "2021-09-30T12:30:02.061847-07:00"


### PR DESCRIPTION
Problem:
When Helm generates the index.yaml, it skips the existing ones(determined by version). As a result, all those existing charts to which we added the annotation are not updated in the index.yaml

Fix:
wipe the index.yaml and rerun the `make charts` command 