### PR TITLE
Inherit index.yaml from release-v2.6

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -12,13 +12,13 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.7
-    created: "2021-09-30T12:30:02.133338-07:00"
+    created: "2021-10-08T15:04:30.316709-07:00"
     dependencies:
     - condition: gitops.enabled
       name: gitjob
       repository: file://./charts/gitjob
     description: Fleet Manager - GitOps at Scale
-    digest: 60cce943a53d723a9c05d35adbb0162443956fe20e80f183883395c46ca80fda
+    digest: ce396dafcedad05a55e8b4b408f738b0c7cd0b9473d00b89d32b269c4f775210
     icon: https://charts.rancher.io/assets/logos/fleet.svg
     name: fleet
     urls:
@@ -35,7 +35,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.6
-    created: "2021-09-30T12:30:02.081889-07:00"
+    created: "2021-09-30T14:07:17.903422323-04:00"
     dependencies:
     - condition: gitops.enabled
       name: gitjob
@@ -58,7 +58,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.5
-    created: "2021-09-30T12:30:02.080647-07:00"
+    created: "2021-09-30T14:07:17.902795436-04:00"
     description: Fleet Manager - GitOps at Scale
     digest: b2d52dd2c2815be26d1eabedd0ca230e7709073bfc7a9b15018f1aa4d29d814e
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -77,7 +77,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.4
-    created: "2021-09-30T12:30:02.079682-07:00"
+    created: "2021-09-30T14:07:17.90208994-04:00"
     description: Fleet Manager - GitOps at Scale
     digest: 3dc07290740992da2a36c0d0cf2ef3592bcb1e2c5482a37a49336794795944f0
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -96,7 +96,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.3
-    created: "2021-09-30T12:30:02.078521-07:00"
+    created: "2021-09-30T14:07:17.901514668-04:00"
     description: Fleet Manager - GitOps at Scale
     digest: f33de3f1deb1cdfe0ff8af7cde8919bbe3e594b30e423735caddfcf3117d3224
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -115,7 +115,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.2
-    created: "2021-09-30T12:30:02.077533-07:00"
+    created: "2021-09-30T14:07:17.901007893-04:00"
     description: Fleet Manager - GitOps at Scale
     digest: 7604d7eb2a6ef5b119b0ee102ea528e63db77caff3441bd47c116964ac530887
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -134,7 +134,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.1
-    created: "2021-09-30T12:30:02.076577-07:00"
+    created: "2021-09-30T14:07:17.900521865-04:00"
     description: Fleet Manager - GitOps at Scale
     digest: 2b05e7779f54c0bd853594b798662be27043d401ee4df1ef2393d25ae4ebbdb8
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -153,7 +153,7 @@ entries:
       catalog.cattle.io/release-name: fleet
     apiVersion: v2
     appVersion: 0.3.0
-    created: "2021-09-30T12:30:02.075533-07:00"
+    created: "2021-09-30T14:07:17.900029689-04:00"
     description: Fleet Manager - GitOps at Scale
     digest: 80ebb76232c4d9c17199901ccce179c86d78202872266fdec29c417c78ee1a9d
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -170,7 +170,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.7
-    created: "2021-09-30T12:30:02.146527-07:00"
+    created: "2021-10-08T15:04:30.321638-07:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 7987910c8dd050d84e7a5bc20bc323652e85be1026507f507f626389712e4077
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -186,7 +186,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.6
-    created: "2021-09-30T12:30:02.144603-07:00"
+    created: "2021-09-30T14:07:17.906259606-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 547e6663ef2b3bebff4f09e4bae7cc702838ba0513740cd8d4db8693cd587f94
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -202,7 +202,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.5
-    created: "2021-09-30T12:30:02.142621-07:00"
+    created: "2021-09-30T14:07:17.905835883-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 7d41b4ee8f0103d2200cd9347aa08a94df5598a5be047b3e283787b86724a5e6
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -218,7 +218,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.4
-    created: "2021-09-30T12:30:02.140439-07:00"
+    created: "2021-09-30T14:07:17.905369774-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 59fb278112c907eaf12dd963ded1aa6ae03be09bb795d2129fd35b6888fbd31c
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -234,7 +234,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.3
-    created: "2021-09-30T12:30:02.138313-07:00"
+    created: "2021-09-30T14:07:17.904977299-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: f92cbe28d99ae754a590e3de5a3226109704c7a69376e1b824b5eb01e3997df3
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -250,7 +250,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.2
-    created: "2021-09-30T12:30:02.136639-07:00"
+    created: "2021-09-30T14:07:17.904609271-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 2be8d753ca9d2ddc9f0c152a81021b146838223796a497841850486bc26f6457
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -266,7 +266,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.1
-    created: "2021-09-30T12:30:02.135376-07:00"
+    created: "2021-09-30T14:07:17.904229751-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 1913e45bcda723490e3c1c1613f99a328b6414c472f9f7c490c087d7697563f1
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -282,7 +282,7 @@ entries:
       catalog.cattle.io/release-name: fleet-agent
     apiVersion: v2
     appVersion: 0.3.0
-    created: "2021-09-30T12:30:02.134331-07:00"
+    created: "2021-09-30T14:07:17.903859783-04:00"
     description: Fleet Manager Agent - GitOps at Scale
     digest: 8b517f7d18f2aa1e34e5ac475684752dc8ff46f050cfd2b2d91fd343cab8cf50
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -299,7 +299,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.7
-    created: "2021-09-30T12:30:02.165537-07:00"
+    created: "2021-10-08T15:04:30.332365-07:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: fd052765600dae535ce53e13567dd528c5b143f948afc89a78f3483f051775c5
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -315,7 +315,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.6
-    created: "2021-09-30T12:30:02.162447-07:00"
+    created: "2021-09-30T14:07:17.912849738-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 560aac95a80d2fb343ed79590752672f627c3984d4be54e75b94b781f4da45db
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -331,7 +331,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.5
-    created: "2021-09-30T12:30:02.158444-07:00"
+    created: "2021-09-30T14:07:17.911789965-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: cab5177c5c69ef4d35a3b9efd60ce9d07d6313c30aa76bc0062f26087b44a828
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -347,7 +347,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.4
-    created: "2021-09-30T12:30:02.156515-07:00"
+    created: "2021-09-30T14:07:17.910694631-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 36c8f232f6d3f2698d0e43d7a95359555f0e8852cfb2c41d901eb09f807d291f
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -363,7 +363,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.3
-    created: "2021-09-30T12:30:02.154625-07:00"
+    created: "2021-09-30T14:07:17.909976136-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 35bbfc8e2276379965d8671b752530b4b3603cacab9106dad64f37839b2f1342
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -379,7 +379,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.2
-    created: "2021-09-30T12:30:02.152985-07:00"
+    created: "2021-09-30T14:07:17.909302816-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 025f0b2ee6f8b709c19ed2676faecba9579c9a14d526d9e16573eb8b98d5bc52
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -394,7 +394,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.1
-    created: "2021-09-30T12:30:02.15136-07:00"
+    created: "2021-09-30T14:07:17.908641329-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: f47abbbcd5b2ca28dcb8303e01a5562da698ec78423c0dc4aa249e6f6b3b7eb4
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -409,7 +409,7 @@ entries:
       catalog.cattle.io/release-name: fleet-crd
     apiVersion: v2
     appVersion: 0.3.0
-    created: "2021-09-30T12:30:02.148306-07:00"
+    created: "2021-09-30T14:07:17.907549299-04:00"
     description: Fleet Manager CustomResourceDefinitions
     digest: 08e3af78da30602b47b60ebfb8e509703dbedc5b312f6aa3a9e9b0275adca75a
     icon: https://charts.rancher.io/assets/logos/fleet.svg
@@ -431,7 +431,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.2.2
-    created: "2021-10-08T02:14:07.541433+08:00"
+    created: "2021-10-08T15:04:30.365794-07:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 6a17d0267b137f60af34afb5c768d64d5f7ea06167edf6f838dffeb0ebd9c581
     home: https://github.com/longhorn/longhorn
@@ -473,7 +473,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.2
-    created: "2021-09-30T12:30:02.178531-07:00"
+    created: "2021-09-30T14:07:17.92046819-04:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 6a2ce555892a327c3ea0b22c0ceed32125b60fc482fef8efd59cf4c94c24322e
     home: https://github.com/longhorn/longhorn
@@ -516,7 +516,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.1
-    created: "2021-09-30T12:30:02.17663-07:00"
+    created: "2021-09-30T14:07:17.918680509-04:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 59485d7ff4e0fa36c29930ce3d1fb1996189d3fff841ce5cb3919b41d04066ff
     home: https://github.com/longhorn/longhorn
@@ -558,7 +558,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.0
-    created: "2021-09-30T12:30:02.1747-07:00"
+    created: "2021-09-30T14:07:17.91752133-04:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 6f552a95ecfdad686750d8446ed4322a8d5d87a4ec394542e8d9fc85386c8e69
     home: https://github.com/longhorn/longhorn
@@ -600,7 +600,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.1.0
-    created: "2021-09-30T12:30:02.172621-07:00"
+    created: "2021-09-30T14:07:17.915955056-04:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 6dd88e8250e3776569b46a534269ecefa1804a3d85e5bf244b81987f5e70a8be
     home: https://github.com/longhorn/longhorn
@@ -642,7 +642,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-09-30T12:30:02.170225-07:00"
+    created: "2021-09-30T14:07:17.914893611-04:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 327b75f1d0a5bdfcbe9eadc9e8a2ff0c5c68f7b40d15f70b4c556cd2f0fc132f
     home: https://github.com/longhorn/longhorn
@@ -682,7 +682,7 @@ entries:
       catalog.cattle.io/ui-component: longhorn
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-09-30T12:30:02.16839-07:00"
+    created: "2021-09-30T14:07:17.914002916-04:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: fe67a68e6ddb15c8746bd630dd12a47885aad49d44305eb84e170d8900e1fc58
     home: https://github.com/longhorn/longhorn
@@ -718,7 +718,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-10-08T02:14:07.542027+08:00"
+    created: "2021-10-08T15:04:30.366357-07:00"
     description: Installs the CRDs for longhorn.
     digest: f8c89bdf20e883d664affebb6d0d8e8b647c7b93e747e68971ba99f2e8fe897e
     name: longhorn-crd
@@ -732,7 +732,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.183571-07:00"
+    created: "2021-09-30T14:07:17.921971918-04:00"
     description: Installs the CRDs for longhorn.
     digest: b11d2d8ed60e7a4767c0411324e84f9825290f346bb9532df92ea16a78a12722
     name: longhorn-crd
@@ -746,7 +746,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.182729-07:00"
+    created: "2021-09-30T14:07:17.921733951-04:00"
     description: Installs the CRDs for longhorn.
     digest: eec1b37ef0f12930cac4b8dc812e0c08af32ec5af8afb37114f3932e333bb5b6
     name: longhorn-crd
@@ -760,7 +760,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.181978-07:00"
+    created: "2021-09-30T14:07:17.921489847-04:00"
     description: Installs the CRDs for longhorn.
     digest: 305196027ef02e1f01519b99302321fbb48dd5faca8084751758c5954f83f488
     name: longhorn-crd
@@ -774,7 +774,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.18067-07:00"
+    created: "2021-09-30T14:07:17.921267408-04:00"
     description: Installs the CRDs for longhorn.
     digest: 5d5f3a3493810aa0dfd263757819e00a8a483c5410c5ff4ff61f5d5fee3561b9
     name: longhorn-crd
@@ -788,7 +788,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.17984-07:00"
+    created: "2021-09-30T14:07:17.921026762-04:00"
     description: Installs the CRDs for longhorn.
     digest: 4da0eeeef78a45c8b0111bb66cfca1734088bcd9bb15b8bfd6712b0ab6320ca1
     name: longhorn-crd
@@ -802,7 +802,7 @@ entries:
       catalog.cattle.io/namespace: longhorn-system
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.179219-07:00"
+    created: "2021-09-30T14:07:17.920775953-04:00"
     description: Installs the CRDs for longhorn.
     digest: c3fc8df8818d884c9df73999999834cebe41ce6567f60222792c2593ad853d31
     name: longhorn-crd
@@ -823,7 +823,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.0.2
-    created: "2021-09-30T12:30:02.19421-07:00"
+    created: "2021-10-08T15:04:30.367724-07:00"
     description: A Helm chart for provisioning AKS clusters
     digest: 756963b5366daa89106db55c19e21069361cfd4f166260b8bebae8508464ac5a
     home: https://github.com/rancher/aks-operator
@@ -845,7 +845,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.0.1
-    created: "2021-09-30T12:30:02.193266-07:00"
+    created: "2021-09-30T14:07:17.922290374-04:00"
     description: A Helm chart for provisioning AKS clusters
     digest: f37ff6a67aed0e87ea879d86d4ce318580f693ce2d8d69060425ca99760bb177
     home: https://github.com/rancher/aks-operator
@@ -864,7 +864,7 @@ entries:
       catalog.cattle.io/release-name: rancher-aks-operator-crd
     apiVersion: v2
     appVersion: 1.0.2
-    created: "2021-09-30T12:30:02.195705-07:00"
+    created: "2021-10-08T15:04:30.368452-07:00"
     description: AKS Operator CustomResourceDefinitions
     digest: 0361a5d82f025056d5b76691fbe158a3f73499b40e3179ef2a75361d9f455f30
     name: rancher-aks-operator-crd
@@ -879,7 +879,7 @@ entries:
       catalog.cattle.io/release-name: rancher-aks-operator-crd
     apiVersion: v2
     appVersion: 1.0.1
-    created: "2021-09-30T12:30:02.194967-07:00"
+    created: "2021-09-30T14:07:17.922529625-04:00"
     description: AKS Operator CustomResourceDefinitions
     digest: f3286e4909fb5fa22e88dda79712831aa9d2c5df780d31df0e5c7ef3553984ee
     name: rancher-aks-operator-crd
@@ -895,7 +895,7 @@ entries:
       catalog.cattle.io/type: cluster-tool
     apiVersion: v2
     appVersion: 1.16.0
-    created: "2021-09-30T12:30:02.200818-07:00"
+    created: "2021-09-30T14:07:17.924423497-04:00"
     dependencies:
     - condition: prom2teams.enabled
       name: prom2teams
@@ -923,7 +923,7 @@ entries:
       catalog.cattle.io/release-name: rancher-alerting-drivers
     apiVersion: v2
     appVersion: 1.16.0
-    created: "2021-09-30T12:30:02.198089-07:00"
+    created: "2021-09-30T14:07:17.923469857-04:00"
     dependencies:
     - condition: prom2teams.enabled
       name: prom2teams
@@ -957,7 +957,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v2
     appVersion: 2.0.1
-    created: "2021-09-30T12:30:02.211487-07:00"
+    created: "2021-10-08T15:04:30.379118-07:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: a4bde8a1e5098ef43a6e4754b7ff066f32389fa5ad9e5df4fbe679caac483e63
@@ -976,16 +976,17 @@ entries:
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: resources.cattle.io.resourceset/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup
       catalog.cattle.io/scope: management
       catalog.cattle.io/type: cluster-tool
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v2
     appVersion: 2.0.0
-    created: "2021-09-30T12:30:02.209792-07:00"
+    created: "2021-09-30T14:07:17.927313549-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
-    digest: 0995c2bc4ba1949a10281c3668fc9d12fb155556bff228b7ef92097514fca523
+    digest: 2961dc9acc26aaab8109f022e03f08f451fca03ebce92c206176c20455dae7e7
     icon: https://charts.rancher.io/assets/logos/backup-restore.svg
     keywords:
     - applications
@@ -1007,7 +1008,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v2
     appVersion: 1.0.4
-    created: "2021-09-30T12:30:02.208095-07:00"
+    created: "2021-09-30T14:07:17.92684908-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: 2aea8c5bbcd18f68975e129383661c307edafed2f6d399da31fd6b2142065ff1
@@ -1032,7 +1033,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-09-30T12:30:02.2066-07:00"
+    created: "2021-09-30T14:07:17.92634988-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: eba830b48b495863c3477f391fbfc9043877c5809d565f6a316964dc31f88066
@@ -1057,7 +1058,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-09-30T12:30:02.205032-07:00"
+    created: "2021-09-30T14:07:17.925878796-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: 92fc70f5c051d9808bf614624bdf1a0164202a1b14a1996cf26720188ce0826e
@@ -1082,7 +1083,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-09-30T12:30:02.203553-07:00"
+    created: "2021-09-30T14:07:17.925399773-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: cc9946d5f3f06d9d78c0dec481641015d3e71d86e0e1bff246eeba110e37d9f4
@@ -1106,7 +1107,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-backup
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-09-30T12:30:02.202222-07:00"
+    created: "2021-09-30T14:07:17.9249059-04:00"
     description: Provides ability to back up and restore the Rancher application running
       on any Kubernetes cluster
     digest: b155f48daab42a9a36c7a7e1710da31c160756e7e391d92dffafc976d89114f8
@@ -1126,7 +1127,7 @@ entries:
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
     appVersion: 2.0.1
-    created: "2021-09-30T12:30:02.218859-07:00"
+    created: "2021-10-08T15:04:30.38197-07:00"
     description: Installs the CRDs for rancher-backup.
     digest: 8eb03a61506b7feb4cd6a8322551868b32422fceea5aba923f2e057cb925810b
     name: rancher-backup-crd
@@ -1141,7 +1142,7 @@ entries:
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
     appVersion: 2.0.0
-    created: "2021-09-30T12:30:02.218007-07:00"
+    created: "2021-09-30T14:07:17.928858957-04:00"
     description: Installs the CRDs for rancher-backup.
     digest: 15a2769a275b4b22d160044f60b10c39e7922f59fb2ff627c67208a045133cbc
     name: rancher-backup-crd
@@ -1156,7 +1157,7 @@ entries:
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v2
     appVersion: 1.0.4
-    created: "2021-09-30T12:30:02.217137-07:00"
+    created: "2021-09-30T14:07:17.928595969-04:00"
     description: Installs the CRDs for rancher-backup.
     digest: 26f7baa1bf1934cf7cfae2720eac74ea1c338dc56aab35a221c688cea6a7ead0
     name: rancher-backup-crd
@@ -1171,7 +1172,7 @@ entries:
       catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.216198-07:00"
+    created: "2021-09-30T14:07:17.928347621-04:00"
     description: Installs the CRDs for rancher-backup.
     digest: 52c7d5853d97a3720060cd89c21b560c05780df46b8ae075377fedebbe2fd229
     name: rancher-backup-crd
@@ -1186,7 +1187,7 @@ entries:
       catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.214249-07:00"
+    created: "2021-09-30T14:07:17.928091087-04:00"
     description: Installs the CRDs for rancher-backup.
     digest: d01a45589bc99ef39000e4e1731921be7ef864bd30b255c5230ca89bbbf05fc8
     name: rancher-backup-crd
@@ -1201,7 +1202,7 @@ entries:
       catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.213335-07:00"
+    created: "2021-09-30T14:07:17.927828199-04:00"
     description: Installs the CRDs for rancher-backup.
     digest: 1a25dccee9394a65915677330d359e89bf56c9bd6c959191755c943eee51b3df
     name: rancher-backup-crd
@@ -1216,7 +1217,7 @@ entries:
       catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-backup-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.212426-07:00"
+    created: "2021-09-30T14:07:17.927581664-04:00"
     description: Installs the CRDs for rancher-backup.
     digest: 68280009fd6465318c19808dc093de64f492decf1313348fac5e4fd408faef9b
     name: rancher-backup-crd
@@ -1238,7 +1239,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.6
-    created: "2021-09-30T12:30:02.227793-07:00"
+    created: "2021-10-08T15:04:30.389899-07:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
     digest: 4168cc0bbd8836fd793f547607a7c3b7dcff91653ad6e167795befe1c44187f9
@@ -1256,15 +1257,16 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: cis.cattle.io.clusterscans/v1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-cis-benchmark
       catalog.cattle.io/type: cluster-tool
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.5
-    created: "2021-09-30T12:30:02.226636-07:00"
+    created: "2021-09-30T14:07:17.932249184-04:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
-    digest: e6445d18c93b85593c1f962115afbfb12af6c4d1786583204f401f5e9ebe058f
+    digest: 612bfa6acfec3d97d7f8919309f7f0ba24508736f66edd7837ca0f502c321b77
     icon: https://charts.rancher.io/assets/logos/cis-kube-bench.svg
     keywords:
     - security
@@ -1284,7 +1286,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.4
-    created: "2021-09-30T12:30:02.225428-07:00"
+    created: "2021-09-30T14:07:17.931819754-04:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
     digest: 2425c71f5f5b5958483b7ed1fdba0925840e0a9cd87965000664663c8d9812dd
@@ -1307,7 +1309,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-09-30T12:30:02.224189-07:00"
+    created: "2021-09-30T14:07:17.931232072-04:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
     digest: f0bd86f0f0bdbf5f309ab8837a34445d25e0a0c32c054b3fbd2e7e74a9089760
@@ -1330,7 +1332,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.3
-    created: "2021-09-30T12:30:02.222359-07:00"
+    created: "2021-09-30T14:07:17.930716551-04:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
     digest: 02c597d8a06b8b36e12bb4881e1de82f0204a2806565cd007a7f6b8d8a872d28
@@ -1353,7 +1355,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.2
-    created: "2021-09-30T12:30:02.221046-07:00"
+    created: "2021-09-30T14:07:17.930190143-04:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
     digest: 91a4efc7f01aa8a1f26e32a3bb8a092fcbc63a7a9c6413a40e7c333dcbb74d10
@@ -1375,7 +1377,7 @@ entries:
       catalog.cattle.io/ui-component: rancher-cis-benchmark
     apiVersion: v1
     appVersion: v1.0.1
-    created: "2021-09-30T12:30:02.21994-07:00"
+    created: "2021-09-30T14:07:17.929727625-04:00"
     description: The cis-operator enables running CIS benchmark security scans on
       a kubernetes cluster
     digest: a18925b456386610da24f29f7a8f34b76b61f2db5d94cd7b398bb51be7a472df
@@ -1393,7 +1395,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.231916-07:00"
+    created: "2021-10-08T15:04:30.392225-07:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: a07236a3f8c025600416189c5cc60a309be12c00b39b9d3b1f58af8c0b4b36ac
     name: rancher-cis-benchmark-crd
@@ -1407,7 +1409,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.231402-07:00"
+    created: "2021-09-30T14:07:17.933740341-04:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: 33df5c14654fae5364b074129cae71fdcdb5eaa47aabae3c195906f3d9a37aa5
     name: rancher-cis-benchmark-crd
@@ -1421,7 +1423,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.23086-07:00"
+    created: "2021-09-30T14:07:17.933479759-04:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: df1bf2270629356a5ad545053da7f18b1782a5441ed98c66d6030c41a3d421d0
     name: rancher-cis-benchmark-crd
@@ -1435,7 +1437,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.230279-07:00"
+    created: "2021-09-30T14:07:17.933245721-04:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: cabb44716892582bee08bd13c48caa3863c9f53218f2ffa1f1bc123ae7234d5a
     name: rancher-cis-benchmark-crd
@@ -1449,7 +1451,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.229731-07:00"
+    created: "2021-09-30T14:07:17.933014133-04:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: 20d71a2ae15f77913229f809c4acf5924f988a0cfc09061306d65c45899618ce
     name: rancher-cis-benchmark-crd
@@ -1463,7 +1465,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.229082-07:00"
+    created: "2021-09-30T14:07:17.932780061-04:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: b12e7bc934602f88087b34540446a2cdc8af5cb30ede6d4d3a48dc29ded1daaa
     name: rancher-cis-benchmark-crd
@@ -1477,7 +1479,7 @@ entries:
       catalog.cattle.io/namespace: cis-operator-system
       catalog.cattle.io/release-name: rancher-cis-benchmark-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.228364-07:00"
+    created: "2021-09-30T14:07:17.93251495-04:00"
     description: Installs the CRDs for rancher-cis-benchmark.
     digest: 2be8b1e2aa24e83d8b20439d0b0343851fbd32495306d38d5d20c62d95b0a8b5
     name: rancher-cis-benchmark-crd
@@ -1498,7 +1500,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-09-30T12:30:02.232579-07:00"
+    created: "2021-09-30T14:07:17.934053696-04:00"
     description: A Helm chart for provisioning EKS clusters
     digest: 2a2bf847905a4ff67086e78c7e5009a4f1d113e354a23ccde453611f04712d68
     home: https://github.com/rancher/eks-operator
@@ -1517,7 +1519,7 @@ entries:
       catalog.cattle.io/release-name: rancher-eks-operator-crd
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-09-30T12:30:02.233073-07:00"
+    created: "2021-09-30T14:07:17.934317637-04:00"
     description: EKS Operator CustomResourceDefinitions
     digest: c5de8e1b4058f0329e78e495ebac023a8130ed4e11e9028338368831cbb6b67a
     name: rancher-eks-operator-crd
@@ -1534,9 +1536,8 @@ entries:
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v1.0.0
-    created: "2021-09-30T12:30:02.240233-07:00"
-    description: |
-      Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
+    created: "2021-09-30T14:07:17.937127837-04:00"
+    description: 'Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554 '
     digest: 7183b83b6dee2a781cd862b95b6b0b1898bc2616cb68d2ff65e13646965a1a97
     home: https://github.com/rancher/externalip-webhook
     keywords:
@@ -1563,9 +1564,8 @@ entries:
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v0.1.6
-    created: "2021-09-30T12:30:02.238085-07:00"
-    description: |
-      Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
+    created: "2021-09-30T14:07:17.936321611-04:00"
+    description: 'Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554 '
     digest: fd85e0a713273e9ef44514fd121037c358fed3d03d35bf1e5cd6d7e0f79dc964
     home: https://github.com/rancher/externalip-webhook
     keywords:
@@ -1592,9 +1592,8 @@ entries:
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v0.1.6
-    created: "2021-09-30T12:30:02.236462-07:00"
-    description: |
-      Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
+    created: "2021-09-30T14:07:17.93565969-04:00"
+    description: 'Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554 '
     digest: 4b35561c85c41372f096c5bba85ba2d50171b47158648d645317f1732eb32d35
     home: https://github.com/rancher/externalip-webhook
     keywords:
@@ -1621,9 +1620,8 @@ entries:
       catalog.cattle.io/ui-component: rancher-external-ip-webhook
     apiVersion: v1
     appVersion: v0.1.4
-    created: "2021-09-30T12:30:02.234787-07:00"
-    description: |
-      Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554
+    created: "2021-09-30T14:07:17.934985252-04:00"
+    description: 'Deploy the external-ip-webhook to mitigate k8s CVE-2020-8554 '
     digest: e44114c31dcedbe8432b287204b07345617cfdce503bfc6525925319a19107e2
     home: https://github.com/rancher/externalip-webhook
     keywords:
@@ -1653,7 +1651,7 @@ entries:
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v2
     appVersion: v3.6.0
-    created: "2021-09-30T12:30:02.244448-07:00"
+    created: "2021-10-08T15:04:30.401462-07:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 5e869a471a4e29cc17e91d17f6dd2b78edfb37d4f683f9a3bbc8b65d13a35a80
@@ -1675,15 +1673,16 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/os: linux
       catalog.cattle.io/provides-gvr: config.gatekeeper.sh.config/v1alpha1
+      catalog.cattle.io/rancher-version: < 2.6.1-0
       catalog.cattle.io/release-name: rancher-gatekeeper
       catalog.cattle.io/type: cluster-tool
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v2
     appVersion: v3.5.1
-    created: "2021-09-30T12:30:02.242784-07:00"
+    created: "2021-09-30T14:07:17.938296133-04:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
-    digest: 51bfa57851f61cdf73d0712b2957a0c75891b79814bdb0a5304ca478971983fc
+    digest: a2b6149004bd85d1d1d0755f9161265d0a392420d804e04349a773653bbaab86
     home: https://github.com/open-policy-agent/gatekeeper
     icon: https://charts.rancher.io/assets/logos/gatekeeper.svg
     keywords:
@@ -1707,7 +1706,7 @@ entries:
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v1
     appVersion: v3.3.0
-    created: "2021-09-30T12:30:02.251479-07:00"
+    created: "2021-09-30T14:07:17.941579611-04:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 9a44d486245ea45243372ac07e56e180ecf31b51c415a6f090ab34ae2b878869
@@ -1734,7 +1733,7 @@ entries:
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v1
     appVersion: v3.3.0
-    created: "2021-09-30T12:30:02.250158-07:00"
+    created: "2021-09-30T14:07:17.940873721-04:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: ba24497df58da6ee771f4d5d4a8f25e94eb86d3b8aa48854bfb4b86ff904f736
@@ -1762,7 +1761,7 @@ entries:
       catalog.cattle.io/ui-component: gatekeeper
     apiVersion: v1
     appVersion: v3.2.1
-    created: "2021-09-30T12:30:02.248798-07:00"
+    created: "2021-09-30T14:07:17.940156789-04:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 703878390aa6c6c70e3c07805312c70e51ef0e657621f870dfab5a69c46d6adc
@@ -1789,7 +1788,7 @@ entries:
       catalog.cattle.io/release-name: rancher-gatekeeper
     apiVersion: v1
     appVersion: v3.1.1
-    created: "2021-09-30T12:30:02.247484-07:00"
+    created: "2021-09-30T14:07:17.939471401-04:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 20f9b2f7d562f0ef13024ad178ebfe4535d1584502d3f90543a4f7d694ab92b1
@@ -1815,7 +1814,7 @@ entries:
       catalog.cattle.io/release-name: rancher-gatekeeper
     apiVersion: v1
     appVersion: v3.1.1
-    created: "2021-09-30T12:30:02.246185-07:00"
+    created: "2021-09-30T14:07:17.938870419-04:00"
     description: Modifies Open Policy Agent's upstream gatekeeper chart that provides
       policy-based control for cloud native environments
     digest: 074c34d0c2f46236a34e96a7d3c00bdfdad36de1d0e3b6e1a874f69e0b286b49
@@ -1837,7 +1836,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.253873-07:00"
+    created: "2021-10-08T15:04:30.409908-07:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 2473133618927588bb5cf2f7829aad41e17dc0743b954025c898683853476ce7
     name: rancher-gatekeeper-crd
@@ -1851,7 +1850,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.252486-07:00"
+    created: "2021-09-30T14:07:17.942002343-04:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: ec199aafd94d27c19e78c858ff990fe057a31a0240c062b99334e97fbdf7fb46
     name: rancher-gatekeeper-crd
@@ -1865,7 +1864,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.259019-07:00"
+    created: "2021-09-30T14:07:17.943577256-04:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: d82c0a0eae6ef19cd815fa0f78730403fac042c886c4564af1a0935d9be54d08
     name: rancher-gatekeeper-crd
@@ -1879,7 +1878,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.258285-07:00"
+    created: "2021-09-30T14:07:17.943230088-04:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 48a03a80fadacabc507fec107dbed749d94fafbef0d26e4eb37e92c974a7c56b
     name: rancher-gatekeeper-crd
@@ -1894,7 +1893,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.25743-07:00"
+    created: "2021-09-30T14:07:17.94289054-04:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 34f449b69d1b50ff1743ae3b1e81553aec3f0a70c8ac7572c60071a8271b53e2
     name: rancher-gatekeeper-crd
@@ -1909,7 +1908,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.256282-07:00"
+    created: "2021-09-30T14:07:17.942562256-04:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: e3da4139207bfa07850db780574a028b5e32c66c1ee57b706fb13fdec5311514
     name: rancher-gatekeeper-crd
@@ -1924,7 +1923,7 @@ entries:
       catalog.cattle.io/namespace: cattle-gatekeeper-system
       catalog.cattle.io/release-name: rancher-gatekeeper-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.255296-07:00"
+    created: "2021-09-30T14:07:17.942277746-04:00"
     description: Installs the CRDs for rancher-gatekeeper.
     digest: 89d80de1bea71d134b19e6092ae123c08173c172a5201d54b4baa6afedea3855
     name: rancher-gatekeeper-crd
@@ -1945,7 +1944,7 @@ entries:
       catalog.cattle.io/scope: management
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-09-30T12:30:02.259754-07:00"
+    created: "2021-09-30T14:07:17.943886547-04:00"
     description: A Helm chart for provisioning GKE clusters
     digest: 647914b2fe504d4a06d7de71ff432125d25cd8708ac9d856399097aaaaccffe4
     home: https://github.com/rancher/gke-operator
@@ -1964,7 +1963,7 @@ entries:
       catalog.cattle.io/release-name: rancher-gke-operator-crd
     apiVersion: v2
     appVersion: 1.1.1
-    created: "2021-09-30T12:30:02.260329-07:00"
+    created: "2021-09-30T14:07:17.94413327-04:00"
     description: GKE Operator CustomResourceDefinitions
     digest: 2c7fa7ace2acea04dcf5f35e74a206c30a0592a07313b5e2456f5f753e2ebdb0
     name: rancher-gke-operator-crd
@@ -1980,7 +1979,7 @@ entries:
       catalog.rancher.io/release-name: rancher-grafana
     apiVersion: v2
     appVersion: 7.5.8
-    created: "2021-09-30T12:30:02.263705-07:00"
+    created: "2021-09-30T14:07:17.945943054-04:00"
     description: The leading tool for querying and visualizing time series and metrics.
     digest: c7e3f13f88da598678e6634a1987271a6fea214d26c266286d40476b2fda7ce8
     home: https://grafana.net
@@ -2012,7 +2011,7 @@ entries:
       catalog.rancher.io/release-name: rancher-grafana
     apiVersion: v2
     appVersion: 7.4.5
-    created: "2021-09-30T12:30:02.267268-07:00"
+    created: "2021-09-30T14:07:17.948108667-04:00"
     description: The leading tool for querying and visualizing time series and metrics.
     digest: 938a0dc18011b95a3db0c94cb37a8db868a22fb41436242724d81391404426d2
     home: https://grafana.net
@@ -2052,7 +2051,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.10.4
-    created: "2021-10-04T11:28:53.802582-07:00"
+    created: "2021-10-08T15:04:30.435754-07:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2085,7 +2084,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.10.4
-    created: "2021-09-30T12:30:02.280726-07:00"
+    created: "2021-09-30T14:07:17.956802105-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2118,7 +2117,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.9.6
-    created: "2021-09-30T12:30:02.29845-07:00"
+    created: "2021-09-30T14:07:17.967040486-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2151,7 +2150,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.9.5
-    created: "2021-09-30T12:30:02.295915-07:00"
+    created: "2021-09-30T14:07:17.964864918-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2184,7 +2183,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.9.3
-    created: "2021-09-30T12:30:02.293034-07:00"
+    created: "2021-09-30T14:07:17.963189369-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2217,7 +2216,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.8.6
-    created: "2021-09-30T12:30:02.29019-07:00"
+    created: "2021-09-30T14:07:17.961483223-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2250,7 +2249,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.8.5
-    created: "2021-09-30T12:30:02.287379-07:00"
+    created: "2021-09-30T14:07:17.959521153-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2283,7 +2282,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.8.3
-    created: "2021-09-30T12:30:02.278054-07:00"
+    created: "2021-09-30T14:07:17.954212467-04:00"
     dependencies:
     - condition: kiali.enabled
       name: kiali
@@ -2314,7 +2313,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.7.3
-    created: "2021-09-30T12:30:02.275087-07:00"
+    created: "2021-09-30T14:07:17.952501155-04:00"
     dependencies:
     - alias: kiali
       condition: kiali.enabled
@@ -2349,7 +2348,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.7.3
-    created: "2021-09-30T12:30:02.271781-07:00"
+    created: "2021-09-30T14:07:17.950825321-04:00"
     dependencies:
     - alias: kiali
       condition: kiali.enabled
@@ -2379,7 +2378,7 @@ entries:
       catalog.cattle.io/ui-component: istio
     apiVersion: v1
     appVersion: 1.7.1
-    created: "2021-09-30T12:30:02.269624-07:00"
+    created: "2021-09-30T14:07:17.949495848-04:00"
     dependencies:
     - alias: kiali
       condition: kiali.enabled
@@ -2408,7 +2407,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.35.0
-    created: "2021-09-30T12:30:02.309035-07:00"
+    created: "2021-09-30T14:07:17.973807561-04:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2443,7 +2442,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.32.0
-    created: "2021-09-30T12:30:02.307443-07:00"
+    created: "2021-09-30T14:07:17.972450561-04:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2478,7 +2477,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.29.0
-    created: "2021-09-30T12:30:02.305181-07:00"
+    created: "2021-09-30T14:07:17.971162378-04:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2513,7 +2512,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.24.0
-    created: "2021-09-30T12:30:02.30323-07:00"
+    created: "2021-09-30T14:07:17.969904815-04:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2548,7 +2547,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.24.0
-    created: "2021-09-30T12:30:02.301503-07:00"
+    created: "2021-09-30T14:07:17.968748983-04:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2583,7 +2582,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kiali-server
     apiVersion: v2
     appVersion: v1.23.0
-    created: "2021-09-30T12:30:02.299928-07:00"
+    created: "2021-09-30T14:07:17.967910099-04:00"
     description: Kiali is an open source project for service mesh observability, refer
       to https://www.kiali.io for details. This is installed as sub-chart with customized
       values in Rancher's Istio.
@@ -2612,7 +2611,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-09-30T12:30:02.312765-07:00"
+    created: "2021-09-30T14:07:17.975460015-04:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 04339f84a5ddac166de594dc621534a95360b967cf225933ce686f9c8cb7fb15
     name: rancher-kiali-server-crd
@@ -2623,7 +2622,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-09-30T12:30:02.312128-07:00"
+    created: "2021-09-30T14:07:17.975166634-04:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 20b301ef9430f4d4d3dd75474e96f3ba75bd5adf0f88371970d7c77530f74874
     name: rancher-kiali-server-crd
@@ -2634,7 +2633,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-09-30T12:30:02.311497-07:00"
+    created: "2021-09-30T14:07:17.974874304-04:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 4ddd8248707294cb91fdd1c2fd9994417bf265b7f649312e82a4f1a86b60e9b6
     name: rancher-kiali-server-crd
@@ -2645,7 +2644,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-09-30T12:30:02.311007-07:00"
+    created: "2021-09-30T14:07:17.974586586-04:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: c8635521da746674695c7833a5509ee92c615adabd47e511e1dd7c2617a4bf7b
     name: rancher-kiali-server-crd
@@ -2656,7 +2655,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-09-30T12:30:02.310353-07:00"
+    created: "2021-09-30T14:07:17.974330778-04:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: bd55c5af7c26744e91922c6a9463c10e52ba65ddf0cf148107461f2983a71223
     name: rancher-kiali-server-crd
@@ -2667,7 +2666,7 @@ entries:
   - annotations:
       catalog.cattle.io/hidden: "true"
     apiVersion: v2
-    created: "2021-09-30T12:30:02.309786-07:00"
+    created: "2021-09-30T14:07:17.974069253-04:00"
     description: Installs the CRDs for rancher-kiali-server.
     digest: 5d5ebb3498ac0b64cf1a73d743b0f3f45fd40c0a9ee3b26d94ae60176e523574
     name: rancher-kiali-server-crd
@@ -2684,7 +2683,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kube-state-metrics
     apiVersion: v2
     appVersion: 2.0.0
-    created: "2021-09-30T12:30:02.314222-07:00"
+    created: "2021-09-30T14:07:17.97666013-04:00"
     description: Install kube-state-metrics to generate and expose cluster-level metrics
     digest: c7a76ad182ca687673327e5ebef5558c9243f876f3241ade6161cd9aa739c0cc
     home: https://github.com/kubernetes/kube-state-metrics/
@@ -2713,7 +2712,7 @@ entries:
       catalog.rancher.io/release-name: rancher-kube-state-metrics
     apiVersion: v1
     appVersion: 1.9.8
-    created: "2021-09-30T12:30:02.315613-07:00"
+    created: "2021-09-30T14:07:17.977794725-04:00"
     description: Install kube-state-metrics to generate and expose cluster-level metrics
     digest: bf852a0682030a0386010427fceb71204d1aedf48c7c4af85dd5e9198fbbcfb0
     home: https://github.com/kubernetes/kube-state-metrics/
@@ -2745,7 +2744,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.12.0
-    created: "2021-09-30T12:30:02.317732-07:00"
+    created: "2021-09-30T14:07:17.979425172-04:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
     digest: 725703ad277825cf79620504a097bbd3cd529e4c33f4fdaa1834409f08b7b297
@@ -2769,7 +2768,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.9.4
-    created: "2021-09-30T12:30:02.324922-07:00"
+    created: "2021-09-30T14:07:17.983544185-04:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
     digest: 565b721d95829592d0919944e45f0b38f9abe3e640457e447e3241c8eb25c614
@@ -2794,7 +2793,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.9.0
-    created: "2021-09-30T12:30:02.323298-07:00"
+    created: "2021-09-30T14:07:17.98259936-04:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
     digest: 557423888e9d279e1748e09ee6e639ef739bf767757cfa496eea706a12e4f006
@@ -2819,7 +2818,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.8.2
-    created: "2021-09-30T12:30:02.321775-07:00"
+    created: "2021-09-30T14:07:17.981773083-04:00"
     description: Collects and filter logs using highly configurable CRDs. Powered
       by Banzai Cloud Logging Operator.
     digest: 9a530816512757cca175695707f5e5a2349c06bf076d1a50e4aa80f7e40c35d9
@@ -2844,7 +2843,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.6.0
-    created: "2021-09-30T12:30:02.320391-07:00"
+    created: "2021-09-30T14:07:17.9809651-04:00"
     description: Collects and filter logs using highly configurable CRDs.  Powered
       by Banzai Cloud Logging Operator.
     digest: 47f857372c32fdbd0299631af812fb1fa8fa868375410f24a84fb91b86a977ec
@@ -2868,7 +2867,7 @@ entries:
       catalog.cattle.io/ui-component: logging
     apiVersion: v1
     appVersion: 3.6.0
-    created: "2021-09-30T12:30:02.318999-07:00"
+    created: "2021-09-30T14:07:17.980192998-04:00"
     description: Collects and filter logs using highly configurable CRDs.  Powered
       by Banzai Cloud Logging Operator.
     digest: 9e213a66882cc8986d466ba95aa95388aa7ca87fe3a88ba9d894e30625d515ea
@@ -2888,7 +2887,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.329851-07:00"
+    created: "2021-09-30T14:07:17.987241483-04:00"
     description: Installs the CRDs for rancher-logging.
     digest: 8543212393b921630119d9f0bbaedd046c713e81c18d125c0f9a0b54083b3281
     name: rancher-logging-crd
@@ -2902,7 +2901,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.340557-07:00"
+    created: "2021-09-30T14:07:17.993507968-04:00"
     description: Installs the CRDs for rancher-logging.
     digest: 64103cfbf9e0a3f4a590e194022aeeda582cc96a5c3450eac839c0c3d448b059
     name: rancher-logging-crd
@@ -2916,7 +2915,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.337632-07:00"
+    created: "2021-09-30T14:07:17.991749963-04:00"
     description: Installs the CRDs for rancher-logging.
     digest: 2ab6fc36daf86c405b536970d9ed4dcb68f84ac93df7ac3811dd123ba82448bd
     name: rancher-logging-crd
@@ -2930,7 +2929,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.335818-07:00"
+    created: "2021-09-30T14:07:17.990653894-04:00"
     description: Installs the CRDs for rancher-logging.
     digest: 351b69ac821716e05b4648f6fe175bfc8b25fee5dc8b7088cc3b77a7d8596b76
     name: rancher-logging-crd
@@ -2944,7 +2943,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.33412-07:00"
+    created: "2021-09-30T14:07:17.989595721-04:00"
     description: Installs the CRDs for rancher-logging.
     digest: 582846a78f045a48088f355599a0abd62c98ce62698ef7fe59ed2180f2016441
     name: rancher-logging-crd
@@ -2958,7 +2957,7 @@ entries:
       catalog.cattle.io/namespace: cattle-logging-system
       catalog.cattle.io/release-name: rancher-logging-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.331875-07:00"
+    created: "2021-09-30T14:07:17.988250207-04:00"
     description: Installs the CRDs for rancher-logging.
     digest: 1c24d7465ba9a4ae3613ffad12cea6d6a60df66a9fbf4d0f2674c4efec2616f2
     name: rancher-logging-crd
@@ -2986,7 +2985,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v2
     appVersion: 0.48.0
-    created: "2021-09-30T12:30:02.37033-07:00"
+    created: "2021-09-30T14:07:18.013634255-04:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -3106,7 +3105,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v2
     appVersion: 0.46.0
-    created: "2021-09-30T12:30:02.397855-07:00"
+    created: "2021-09-30T14:07:18.032113531-04:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -3215,7 +3214,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-09-30T12:30:02.485136-07:00"
+    created: "2021-09-30T14:07:18.093174812-04:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -3317,7 +3316,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-09-30T12:30:02.460937-07:00"
+    created: "2021-09-30T14:07:18.073948521-04:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -3447,7 +3446,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-09-30T12:30:02.433894-07:00"
+    created: "2021-09-30T14:07:18.058102201-04:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -3576,7 +3575,7 @@ entries:
       catalog.cattle.io/ui-component: monitoring
     apiVersion: v1
     appVersion: 0.38.1
-    created: "2021-09-30T12:30:02.415712-07:00"
+    created: "2021-09-30T14:07:18.045693388-04:00"
     dependencies:
     - condition: kubeStateMetrics.enabled
       name: kube-state-metrics
@@ -3705,7 +3704,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.490036-07:00"
+    created: "2021-09-30T14:07:18.09654425-04:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 8df09722ba0baf7a39f809432918fd46643667d4fcf22f025697a1b77c7f5014
     name: rancher-monitoring-crd
@@ -3719,7 +3718,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.494681-07:00"
+    created: "2021-09-30T14:07:18.099866155-04:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 6f4fc35013ee3d368502857afb8c466f2e1762c656c9502a154f6354a360361b
     name: rancher-monitoring-crd
@@ -3733,7 +3732,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.515184-07:00"
+    created: "2021-09-30T14:07:18.114467489-04:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 63a81f944774e646f6549c545f7c6b56635218bc135b9421eab224c6139dcbf7
     name: rancher-monitoring-crd
@@ -3747,7 +3746,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.510598-07:00"
+    created: "2021-09-30T14:07:18.110881539-04:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 60945c2274b7c169ad84240e7facc9aa8d3a0a4e649c3dcd6e6b21f336a257d8
     name: rancher-monitoring-crd
@@ -3761,7 +3760,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.504981-07:00"
+    created: "2021-09-30T14:07:18.107239908-04:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 09532cc000ee5a78dbda15c879ad1af9f9c2f8bc08db4067a6756df1a0206de3
     name: rancher-monitoring-crd
@@ -3775,7 +3774,7 @@ entries:
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/release-name: rancher-monitoring-crd
     apiVersion: v1
-    created: "2021-09-30T12:30:02.499965-07:00"
+    created: "2021-09-30T14:07:18.104045828-04:00"
     description: Installs the CRDs for rancher-monitoring.
     digest: 101721abb2876816b54234568272d0372c274ed3e4851a9c94077f61fefb8a49
     name: rancher-monitoring-crd
@@ -3792,7 +3791,7 @@ entries:
       catalog.rancher.io/release-name: rancher-node-exporter
     apiVersion: v1
     appVersion: 1.1.2
-    created: "2021-09-30T12:30:02.517487-07:00"
+    created: "2021-09-30T14:07:18.115900029-04:00"
     description: A Helm chart for prometheus node-exporter
     digest: 940f60a7e56c13351c9f6088bde9230a03e579d0791e41f911a724b002580fbb
     home: https://github.com/prometheus/node_exporter/
@@ -3819,7 +3818,7 @@ entries:
       catalog.rancher.io/release-name: rancher-node-exporter
     apiVersion: v1
     appVersion: 1.1.2
-    created: "2021-09-30T12:30:02.516343-07:00"
+    created: "2021-09-30T14:07:18.115199764-04:00"
     description: A Helm chart for prometheus node-exporter
     digest: 423bbfe53c9137e1f9937601a3e573ed22e2aae2c7a19162781518ffc041ff35
     home: https://github.com/prometheus/node_exporter/
@@ -3846,7 +3845,7 @@ entries:
       catalog.cattle.io/release-name: rancher-prom2teams
     apiVersion: v1
     appVersion: 3.2.2
-    created: "2021-09-30T12:30:02.519326-07:00"
+    created: "2021-09-30T14:07:18.116870199-04:00"
     description: A Helm chart for Prom2Teams based on the upstream https://github.com/idealista/prom2teams
     digest: a278a9673dbe8dbb5ed21b3b6e2159f79c8fae1ba9e34e4e5e642e9a55a9bb95
     name: rancher-prom2teams
@@ -3860,7 +3859,7 @@ entries:
       catalog.cattle.io/release-name: rancher-prom2teams
     apiVersion: v1
     appVersion: 3.2.1
-    created: "2021-09-30T12:30:02.518434-07:00"
+    created: "2021-09-30T14:07:18.11639603-04:00"
     description: A Helm chart for Prom2Teams based on the upstream https://github.com/idealista/prom2teams
     digest: 2c83714457d157bc77c0f74ab01c1db84b63c5a811a99225b626f297455e0e3b
     name: rancher-prom2teams
@@ -3876,7 +3875,7 @@ entries:
       catalog.rancher.io/release-name: rancher-prometheus-adapter
     apiVersion: v1
     appVersion: v0.8.4
-    created: "2021-09-30T12:30:02.520563-07:00"
+    created: "2021-09-30T14:07:18.117792064-04:00"
     description: A Helm chart for k8s prometheus adapter
     digest: 45e2aad6b9edfa24e88f97038616a898b2b9693b2acb9087772d0377f009f9a4
     home: https://github.com/DirectXMan12/k8s-prometheus-adapter
@@ -3906,7 +3905,7 @@ entries:
       catalog.rancher.io/release-name: rancher-prometheus-adapter
     apiVersion: v1
     appVersion: v0.8.3
-    created: "2021-09-30T12:30:02.521906-07:00"
+    created: "2021-09-30T14:07:18.118694769-04:00"
     description: A Helm chart for k8s prometheus adapter
     digest: f1da6d7eac3c183afdc127810f8463d6d7bb597dce2ad6046e30d66c8b9423e6
     home: https://github.com/DirectXMan12/k8s-prometheus-adapter
@@ -3937,7 +3936,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.527796-07:00"
+    created: "2021-09-30T14:07:18.122133416-04:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: d2396d0961ee525846f485efa79b6182139567141a67b378bd775c4f86f2e7e8
@@ -3954,7 +3953,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.526803-07:00"
+    created: "2021-09-30T14:07:18.121582649-04:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: f1f1e0d4d24a20b4b995a8ecc360ff0db310d4af92ec7fcdf87e4b9d5f977dd4
@@ -3970,7 +3969,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.525629-07:00"
+    created: "2021-09-30T14:07:18.121026052-04:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: cb9552eb4ee8899ef1af5583c8080c27227dd3b10d919748f2caf79cb8197198
@@ -3986,7 +3985,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.524672-07:00"
+    created: "2021-09-30T14:07:18.120496596-04:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: a4b3506a74ea6cc4e8c6610cb92451d3072f4f7bac7b503e2dea9423697eaf68
@@ -4003,7 +4002,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.523871-07:00"
+    created: "2021-09-30T14:07:18.119941938-04:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: 4b53e4de2aede1f3d63c815ca36bd61f31d38c59769d9982b14aca3bbf575724
@@ -4020,7 +4019,7 @@ entries:
       catalog.rancher.io/release-name: rancher-pushprox
     apiVersion: v1
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.52298-07:00"
+    created: "2021-09-30T14:07:18.119352495-04:00"
     description: Sets up a deployment of the PushProx proxy and a DaemonSet of PushProx
       clients.
     digest: 73b11a51246c216a7587628fee346541d6b5e82246e11d586b4926254f7999fa
@@ -4037,7 +4036,7 @@ entries:
       catalog.cattle.io/release-name: rancher-sachet
     apiVersion: v2
     appVersion: 0.2.3
-    created: "2021-09-30T12:30:02.530166-07:00"
+    created: "2021-09-30T14:07:18.123039455-04:00"
     description: A Helm chart for Sachet based on the upstream https://github.com/messagebird/sachet
     digest: face4a2ab50a6b7abcc88cf84fcf27efd9a257f19cc6869cf506c4c341a8c790
     name: rancher-sachet
@@ -4052,7 +4051,7 @@ entries:
       catalog.cattle.io/release-name: rancher-sachet
     apiVersion: v2
     appVersion: 0.2.3
-    created: "2021-09-30T12:30:02.529295-07:00"
+    created: "2021-09-30T14:07:18.122576387-04:00"
     description: A Helm chart for Sachet based on the upstream https://github.com/messagebird/sachet
     digest: 0c438e1f63546d35f8e48fbafdc5ef2bbe0fa8d59383f7a36b4f601c99677029
     name: rancher-sachet
@@ -4069,7 +4068,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-09-30T12:30:02.535212-07:00"
+    created: "2021-09-30T14:07:18.126061344-04:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4086,7 +4085,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-09-30T12:30:02.534309-07:00"
+    created: "2021-09-30T14:07:18.125606777-04:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4103,7 +4102,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-09-30T12:30:02.53356-07:00"
+    created: "2021-09-30T14:07:18.125126449-04:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4120,7 +4119,7 @@ entries:
       catalog.rancher.io/release-name: rancher-tracing
     apiVersion: v1
     appVersion: 1.20.0
-    created: "2021-09-30T12:30:02.53275-07:00"
+    created: "2021-09-30T14:07:18.124684659-04:00"
     description: A quick start Jaeger Tracing installation using the all-in-one demo.
       This is not production qualified. Refer to https://www.jaegertracing.io/ for
       details.
@@ -4138,7 +4137,7 @@ entries:
       catalog.cattle.io/release-name: vsphere-cpi
     apiVersion: v1
     appVersion: 1.0.0
-    created: "2021-09-30T12:30:02.536777-07:00"
+    created: "2021-09-30T14:07:18.126915021-04:00"
     description: vSphere Cloud Provider Interface (CPI)
     digest: 2da8c41576eec369cd5b61f6b0d240f09bb719e0e21e4f63ac976293c8bc130a
     icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
@@ -4162,7 +4161,7 @@ entries:
       catalog.cattle.io/release-name: vsphere-cpi
     apiVersion: v1
     appVersion: 1.0.0
-    created: "2021-09-30T12:30:02.536006-07:00"
+    created: "2021-09-30T14:07:18.126500633-04:00"
     description: vSphere Cloud Provider Interface (CPI)
     digest: 05298fce7dbfe5176fe509e1cde6ea8ab136c3c77af61b12f297880332f88840
     icon: https://charts.rancher.io/assets/logos/vsphere-cpi.svg
@@ -4186,7 +4185,7 @@ entries:
       catalog.cattle.io/release-name: vsphere-csi
     apiVersion: v1
     appVersion: 2.2.0
-    created: "2021-09-30T12:30:02.537983-07:00"
+    created: "2021-09-30T14:07:18.127547932-04:00"
     description: vSphere Cloud Storage Interface (CSI)
     digest: a20bc110bca55c0059658daa7e5d5981ce2fcbbdcd2c957f0941170fa43c0afa
     icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
@@ -4210,7 +4209,7 @@ entries:
       catalog.cattle.io/release-name: vsphere-csi
     apiVersion: v1
     appVersion: 2.1.0
-    created: "2021-09-30T12:30:02.539014-07:00"
+    created: "2021-09-30T14:07:18.128130786-04:00"
     description: vSphere Cloud Storage Interface (CSI)
     digest: fbef8bf05ec18534a4108fa2de055eb212be24d8114a946de9b5c937eb0b1248
     icon: https://charts.rancher.io/assets/logos/vsphere-csi.svg
@@ -4234,7 +4233,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.2.1
-    created: "2021-09-30T12:30:02.544822-07:00"
+    created: "2021-10-08T15:04:30.621692-07:00"
     dependencies:
     - condition: capi.enabled
       name: capi
@@ -4253,7 +4252,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.2.0
-    created: "2021-09-30T12:30:02.543958-07:00"
+    created: "2021-09-30T14:07:18.130959593-04:00"
     dependencies:
     - condition: capi.enabled
       name: capi
@@ -4272,7 +4271,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.1
-    created: "2021-09-30T12:30:02.542804-07:00"
+    created: "2021-09-30T14:07:18.130499284-04:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: a0ee1c4f1338c8c24f3c5129bb41a67a43bffb13bf28c138266cf58dd28f2ce4
     name: rancher-webhook
@@ -4287,7 +4286,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0
-    created: "2021-09-30T12:30:02.542256-07:00"
+    created: "2021-09-30T14:07:18.130209741-04:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 3c20cc0a6b0fdc9672d7fa84be46f74b208a00664397d1abcfd8acd9ae10ff0e
     name: rancher-webhook
@@ -4302,7 +4301,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta9
-    created: "2021-09-30T12:30:02.541675-07:00"
+    created: "2021-09-30T14:07:18.129916577-04:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 0d9ac76eff2b6e937e3e15970cd0192acff99a31aa1afa14941029088dc32f76
     name: rancher-webhook
@@ -4317,7 +4316,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta9
-    created: "2021-09-30T12:30:02.541064-07:00"
+    created: "2021-09-30T14:07:18.129511691-04:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 8881f7cf8b50e3b48a967ce8af477c96f986d42d3c1f4bbb8c0bfc09202d23f4
     name: rancher-webhook
@@ -4332,7 +4331,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta7
-    created: "2021-09-30T12:30:02.540393-07:00"
+    created: "2021-09-30T14:07:18.128737779-04:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: e185c6765de0bb0694d6d12e16c2dcce7f4c785125e614cf6c0020e5982d5f0e
     name: rancher-webhook
@@ -4347,7 +4346,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.1.0-beta5
-    created: "2021-09-30T12:30:02.539648-07:00"
+    created: "2021-09-30T14:07:18.128458238-04:00"
     description: ValidatingAdmissionWebhook for Rancher types
     digest: 574407c23b5827bd1d4d4f20609a5dc9d4558d6d29ef179093288a4a730ab8c2
     name: rancher-webhook
@@ -4363,7 +4362,7 @@ entries:
       catalog.rancher.io/release-name: rancher-windows-exporter
     apiVersion: v1
     appVersion: 0.0.2
-    created: "2021-09-30T12:30:02.546553-07:00"
+    created: "2021-09-30T14:07:18.132016078-04:00"
     description: Sets up monitoring metrics from Windows nodes via Prometheus windows-exporter
     digest: e8343b74c657a9ac4ea3d363e51bfd8e2551dd746e5992209f7a91724f972c78
     maintainers:
@@ -4382,7 +4381,7 @@ entries:
       catalog.rancher.io/release-name: rancher-windows-exporter
     apiVersion: v1
     appVersion: 0.0.4
-    created: "2021-09-30T12:30:02.545618-07:00"
+    created: "2021-09-30T14:07:18.13152779-04:00"
     description: Sets up monitoring metrics from Windows nodes via Prometheus windows-exporter
     digest: 329af930026bd58a3ffeeb202f362a2936031f14cc2a137593952d131db53afe
     maintainers:
@@ -4401,7 +4400,7 @@ entries:
       catalog.cattle.io/release-name: rancher-wins-upgrader
     apiVersion: v2
     appVersion: 0.1.1
-    created: "2021-09-30T12:30:02.548102-07:00"
+    created: "2021-09-30T14:07:18.132999721-04:00"
     description: Manages upgrading the wins server version and configuration across
       all of your Windows nodes
     digest: 5de123eda92b3a5823a8b3e6c304de112a02fc42e8531ccc1b64c0e9f4721e13
@@ -4420,7 +4419,7 @@ entries:
       catalog.cattle.io/release-name: rancher-wins-upgrader
     apiVersion: v2
     appVersion: 0.1.1
-    created: "2021-09-30T12:30:02.547314-07:00"
+    created: "2021-09-30T14:07:18.132520391-04:00"
     description: Manages upgrading the wins server version and configuration across
       all of your Windows nodes
     digest: 5f1a089d856a0f6a6ad17b0f6e2be19ddc42c1fbcc4f5f8576395e87368eba9d
@@ -4443,7 +4442,7 @@ entries:
       catalog.cattle.io/requires-gvr: networking.istio.io.virtualservice/v1beta1
     apiVersion: v1
     appVersion: 0.8.0
-    created: "2021-09-30T12:30:02.550215-07:00"
+    created: "2021-09-30T14:07:18.133854676-04:00"
     description: The application deployment engine for Kubernetes
     digest: 8baa5c330cc152b3d3d87f918ed3ff96b927efad412f4b97bd7db90445e28602
     home: https://rio.io
@@ -4463,7 +4462,7 @@ entries:
       catalog.cattle.io/requires-gvr: networking.istio.io.virtualservice/v1beta1
     apiVersion: v1
     appVersion: 0.8.0
-    created: "2021-09-30T12:30:02.549509-07:00"
+    created: "2021-09-30T14:07:18.133428988-04:00"
     description: The application deployment engine for Kubernetes
     digest: d58ca3b147627fec6d5f4b99fae680f97edaed98967f1fc1914a537dede0d897
     home: https://rio.io
@@ -4482,7 +4481,7 @@ entries:
       catalog.cattle.io/release-name: sriov
     apiVersion: v2
     appVersion: 1.0.0
-    created: "2021-09-30T12:30:02.531255-07:00"
+    created: "2021-09-30T14:07:18.12386196-04:00"
     description: SR-IOV network operator configures and manages SR-IOV networks in
       the kubernetes cluster
     digest: fbb5f88710506b872767657b8b29aef0b84019d8d7e57b66eaea1563cae5a4a4
@@ -4510,7 +4509,7 @@ entries:
       catalog.cattle.io/namespace: cattle-sriov-system
       catalog.cattle.io/release-name: sriov-crd
     apiVersion: v2
-    created: "2021-09-30T12:30:02.531963-07:00"
+    created: "2021-09-30T14:07:18.124226973-04:00"
     description: Installs the CRDs for rke2-sriov.
     digest: db8031e9088de70c02778bedae7149b0678439a931ef987b0b4f57ca52415589
     name: sriov-crd
@@ -4527,7 +4526,7 @@ entries:
       catalog.cattle.io/release-name: system-upgrade-controller
     apiVersion: v1
     appVersion: v0.7.5
-    created: "2021-09-30T12:30:02.550729-07:00"
+    created: "2021-09-30T14:07:18.134198707-04:00"
     description: General purpose controller to make system level updates to nodes
     digest: ecc9bf23666bd63dedd95b22c3a5c806ad084800f05a765fba133f8de4e4814f
     home: https://github.com/rancher/system-charts/charts/system-upgrade-controller
@@ -4537,4 +4536,4 @@ entries:
     urls:
     - assets/system-upgrade-controller/system-upgrade-controller-100.0.0+up0.3.0.tgz
     version: 100.0.0+up0.3.0
-generated: "2021-09-30T12:30:02.061847-07:00"
+generated: "2021-09-30T14:07:17.89939889-04:00"


### PR DESCRIPTION
Followup to https://github.com/rancher/charts/pull/1541. The index.yaml also needs to be pulled in.

---

This is the equivalent of running the following script:

```
git fetch upstream
git checkout upstream/release-v2.6 -- index.yaml
git add index.yaml
git commit -m "Inherit index.yaml from release-v2.6"
make charts
git add index.yaml
git commit --amend --no-edit
```