### PR TITLE
Remove duplicate label "release" from pushProxy serviceMonitor.

### DIFF
--- a/charts/rancher-pushprox/rancher-pushprox/0.1.400/templates/_helpers.tpl
+++ b/charts/rancher-pushprox/rancher-pushprox/0.1.400/templates/_helpers.tpl
@@ -82,7 +82,6 @@ k8s-app: {{ template "pushProxy.proxy.name" . }}
 
 {{- define "pushProxy.serviceMonitor.labels" -}}
 app: {{ template "pushprox.serviceMonitor.name" . }}
-release: {{ .Release.Name | quote }}
 {{ template "pushProxy.commonLabels" . }}
 {{- end -}}
 


### PR DESCRIPTION
Fix #1534.

Signed-off-by: Alessandro Degano <a.degano@gmail.com>