### PR TITLE
Update the charts-build-script to v0.2.4 in dev-v2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 bin
 *.DS_Store
 .idea
-*.iml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Staging Branch
+## Dev Branch
 
 This branch contains Packages and generated assets that have not been officially released yet.
 
@@ -6,7 +6,7 @@ See the README.md under `packages/`, `assets/`, and `charts/` for more informati
 
 The following directory structure is expected:
 ```text
-package/
+packages/
   <package>/
   ...
 assets/
@@ -20,6 +20,18 @@ charts/
         # Unarchived Helm chart
   ...
 ```
+
+### "Orphaned" Charts
+
+Not all charts tracked in `charts/` and `assets/` will have a corresponding entry in `packages/`,
+but all charts tracked in `packages/` must exist in `charts/` and `assets/` to pass a `make validate`.
+
+Some situations that would merit "orphaned" charts include, but are not limited to:
+- Charts that are no longer in active development (e.g. deprecated charts, older versions of released charts)
+- Charts that are forward-ported / backward-ported over from other Helm repositories
+
+Note: as long as it doesn't modify an already released version of a chart (which will be checked on a `make validate`),
+you can always bring back a previously removed package to the `packages/` directory to move it back to active development.
 
 ### Configuration
 

--- a/scripts/version
+++ b/scripts/version
@@ -2,4 +2,4 @@
 set -e
 
 CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
-CHARTS_BUILD_SCRIPT_VERSION=v0.2.1
+CHARTS_BUILD_SCRIPT_VERSION=v0.2.4


### PR DESCRIPTION
What does the PR do:
- bump the charts-build-script to v0.2.4
- run make template
