### PR TITLE
Add commonLabels to pushProxy subcharts

### DIFF
--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/hardenedKubelet/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/hardenedKubelet/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/hardenedNodeExporter/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/hardenedNodeExporter/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/k3sServer/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/k3sServer/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmControllerManager/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmControllerManager/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmEtcd/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmEtcd/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmProxy/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmProxy/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmScheduler/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/kubeAdmScheduler/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2ControllerManager/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2ControllerManager/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2Etcd/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2Etcd/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2IngressNginx/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2IngressNginx/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2Proxy/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2Proxy/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2Scheduler/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rke2Scheduler/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeControllerManager/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeControllerManager/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeEtcd/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeEtcd/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeIngressNginx/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeIngressNginx/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeProxy/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeProxy/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeScheduler/templates/_helpers.tpl
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/charts/rkeScheduler/templates/_helpers.tpl
@@ -42,6 +42,9 @@ kubernetes.io/os: linux
 release: {{ .Release.Name }}
 component: {{ .Values.component | quote }}
 provider: kubernetes
+{{- if .Values.commonLabels}}
+{{ toYaml .Values.commonLabels }}
+{{- end }}
 {{- end -}}
 
 {{- define "pushProxy.proxyUrl" -}}

--- a/charts/rancher-monitoring/100.1.1+up19.0.3/values.yaml
+++ b/charts/rancher-monitoring/100.1.1+up19.0.3/values.yaml
@@ -20,6 +20,7 @@ prometheus-adapter:
 ## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 ##
 rkeControllerManager:
+  commonLabels: {}
   enabled: false
   metricsPort: 10252
   component: kube-controller-manager
@@ -35,6 +36,7 @@ rkeControllerManager:
       operator: "Exists"
 
 rkeScheduler:
+  commonLabels: {}
   enabled: false
   metricsPort: 10251
   component: kube-scheduler
@@ -50,6 +52,7 @@ rkeScheduler:
       operator: "Exists"
 
 rkeProxy:
+  commonLabels: {}
   enabled: false
   metricsPort: 10249
   component: kube-proxy
@@ -63,6 +66,7 @@ rkeProxy:
       operator: "Exists"
 
 rkeEtcd:
+  commonLabels: {}
   enabled: false
   metricsPort: 2379
   component: kube-etcd
@@ -83,6 +87,7 @@ rkeEtcd:
       operator: "Exists"
 
 rkeIngressNginx:
+  commonLabels: {}
   enabled: false
   metricsPort: 10254
   component: ingress-nginx
@@ -101,6 +106,7 @@ rkeIngressNginx:
 ## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 ##
 k3sServer:
+  commonLabels: {}
   enabled: false
   metricsPort: 10250
   component: k3s-server
@@ -147,6 +153,7 @@ k3sServer:
 ## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 ##
 kubeAdmControllerManager:
+  commonLabels: {}
   enabled: false
   metricsPort: 10257
   component: kube-controller-manager
@@ -166,6 +173,7 @@ kubeAdmControllerManager:
       operator: "Exists"
 
 kubeAdmScheduler:
+  commonLabels: {}
   enabled: false
   metricsPort: 10259
   component: kube-scheduler
@@ -185,6 +193,7 @@ kubeAdmScheduler:
       operator: "Exists"
 
 kubeAdmProxy:
+  commonLabels: {}
   enabled: false
   metricsPort: 10249
   component: kube-proxy
@@ -198,6 +207,7 @@ kubeAdmProxy:
       operator: "Exists"
 
 kubeAdmEtcd:
+  commonLabels: {}
   enabled: false
   metricsPort: 2381
   component: kube-etcd
@@ -216,6 +226,7 @@ kubeAdmEtcd:
 ## ref: https://github.com/rancher/charts/tree/dev-v2.5-source/packages/rancher-pushprox
 ##
 rke2ControllerManager:
+  commonLabels: {}
   enabled: false
   metricsPort: 10252
   component: kube-controller-manager
@@ -231,6 +242,7 @@ rke2ControllerManager:
         operator: "Exists"
 
 rke2Scheduler:
+  commonLabels: {}
   enabled: false
   metricsPort: 10251
   component: kube-scheduler
@@ -246,6 +258,7 @@ rke2Scheduler:
         operator: "Exists"
 
 rke2Proxy:
+  commonLabels: {}
   enabled: false
   metricsPort: 10249
   component: kube-proxy
@@ -259,6 +272,7 @@ rke2Proxy:
       operator: "Exists"
 
 rke2Etcd:
+  commonLabels: {}
   enabled: false
   metricsPort: 2381
   component: kube-etcd
@@ -274,6 +288,7 @@ rke2Etcd:
         operator: "Exists"
 
 rke2IngressNginx:
+  commonLabels: {}
   enabled: false
   metricsPort: 10254
   component: ingress-nginx
@@ -314,6 +329,7 @@ rke2IngressNginx:
 # If enabled, it replaces the ServiceMonitor deployed by the default kubelet option with a 
 # PushProx-based exporter that does not require a host port to be open to scrape metrics.
 hardenedKubelet:
+  commonLabels: {}
   enabled: false
   metricsPort: 10250
   component: kubelet
@@ -360,6 +376,7 @@ hardenedKubelet:
 # If enabled, it replaces the ServiceMonitor deployed by the default nodeExporter with a 
 # PushProx-based exporter that does not require a host port to be open to scrape metrics.
 hardenedNodeExporter:
+  commonLabels: {}
   enabled: false
   metricsPort: 9796
   component: node-exporter
@@ -519,9 +536,9 @@ global:
     windows:
       enabled: false
   kubectl:
-     repository: rancher/kubectl
-     tag: v1.20.2
-     pullPolicy: IfNotPresent
+      repository: rancher/kubectl
+      tag: v1.20.2
+      pullPolicy: IfNotPresent
   rbac:
     ## Create RBAC resources for ServiceAccounts and users
     ##


### PR DESCRIPTION
This should solve: https://github.com/rancher/rancher/issues/39427

This will ensure push proxy subcharts have the option to use `commonLabels`. This allows teams to scope the ServiceMonitors Prometheus is targeting. Otherwise using `prometheus.prometheusSpec.serviceMonitorSelector` and `commonLabels` in the main chart is not viable as ServiceMonitors by subcharts are not included.