### PR TITLE
fix rancher-node-exporter nodeSelector template

### DIFF
--- a/packages/rancher-monitoring/rancher-node-exporter/generated-changes/patch/templates/daemonset.yaml.patch
+++ b/packages/rancher-monitoring/rancher-node-exporter/generated-changes/patch/templates/daemonset.yaml.patch
@@ -9,19 +9,15 @@
            imagePullPolicy: {{ .Values.image.pullPolicy }}
            args:
              - --path.procfs=/host/proc
-@@ -134,18 +134,18 @@
-       affinity:
- {{ toYaml .Values.affinity | indent 8 }}
- {{- end }}
-+      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
- {{- with .Values.dnsConfig }}
+@@ -138,14 +138,14 @@
        dnsConfig:
  {{ toYaml . | indent 8 }}
  {{- end }}
++      nodeSelector: {{ include "linux-node-selector" . | nindent 8 }}
  {{- if .Values.nodeSelector }}
 -      nodeSelector:
 -{{ toYaml .Values.nodeSelector | indent 8 }}
-+{{- toYaml .Values.Selector | nindent 8 }}
++{{- toYaml .Values.nodeSelector | nindent 8 }}
 +{{- end }}
 +      tolerations: {{ include "linux-node-tolerations" . | nindent 8 }}
 +{{- if .Values.tolerations }}


### PR DESCRIPTION
Fix to use nodeSelector in rancher-monitoring/rancher-node-exporter package.
