### PR TITLE
fixes the path to Harvester's cloud provider configuration

### DIFF
--- a/charts/harvester-csi-driver/100.0.1+up0.1.9/values.yaml
+++ b/charts/harvester-csi-driver/100.0.1+up0.1.9/values.yaml
@@ -28,7 +28,7 @@ fullnameOverride: ""
 kubeletRootDir: /var/lib/kubelet
 cloudConfig:
   secretName: ""
-  hostPath: "/etc/kubernetes/cloud-config"
+  hostPath: "/var/lib/rancher/rke2/etc/config-files/cloud-provider-config"
 
 nodeSelector:
   kubernetes.io/os: linux


### PR DESCRIPTION
As mentioned in this issue: https://github.com/rancher/rancher/issues/36309 or this one: https://github.com/rancher/rancher/issues/36833 , the Harvester Cloud Provider configuration in the HostPath scenario is at `/var/lib/rancher/rke2/etc/config-files/cloud-provider-config` not `/etc/kubernetes/cloud-config`.