### PR TITLE
Add SecurityContext to the rancher-gatekeeper CRD upgrade hook

### DIFF
--- a/packages/rancher-gatekeeper/generated-changes/patch/templates/upgrade-crds-hook.yaml.patch
+++ b/packages/rancher-gatekeeper/generated-changes/patch/templates/upgrade-crds-hook.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/upgrade-crds-hook.yaml
 +++ charts/templates/upgrade-crds-hook.yaml
-@@ -72,8 +72,8 @@
+@@ -72,11 +72,20 @@
        restartPolicy: Never
        containers:
        - name: crds-upgrade
@@ -11,3 +11,15 @@
          args:
          - apply
          - -f
+         - crds/
++        securityContext:
++          allowPrivilegeEscalation: false
++          capabilities:
++            drop:
++            - all
++          readOnlyRootFilesystem: true
++          runAsGroup: 999
++          runAsNonRoot: true
++          runAsUser: 1000
+       nodeSelector:
+         kubernetes.io/os: linux


### PR DESCRIPTION
Add a SecurityContext to the upgrade-crds-hook to allow the job to run in clusters that have the PodSecurityPolicy Admission controller enabled.

Fixes rancher/rancher#43453 