### PR TITLE
#1815 adding useLocalhost=true for rkeEtcd

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/rancher-monitoring/generated-changes/patch/values.yaml.patch
@@ -95,6 +95,7 @@
 +  metricsPort: 2379
 +  component: kube-etcd
 +  clients:
++    useLocalhost: true
 +    port: 10014
 +    https:
 +      enabled: true


### PR DESCRIPTION
fix for etcd metrics available in rancher 2.6