### PR TITLE
Add script to automate chart version bumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ Since this repository uses [`rancher/charts-build-scripts`](https://github.com/r
 2. Running `make charts` to automatically generate assets used to serve a Helm repository (`charts/`, `assets/`, and `index.yaml`) based on the contents of `packages/`.
 3. [CI] Running `make validate` to ensure that all generated assets are up-to-date and ready to be merged.
 
+A first attempt was made to automate these steps for url only based charts, in the following way (example with rancher-backup chart values):
+
+1. Remove existing chart(s): `CHARTS=rancher-backup/rancher-backup,rancher-backup/rancher-backup-crd ./scripts/remove-chart-version-if-exists`
+2. Commit changes (git add/git commit)
+3. Add new chart(s): `TEMPLATE_BASE_URL=https://raw.githubusercontent.com/rancher/your_chart CHARTS=rancher-backup/rancher-backup,rancher-backup/rancher-backup-crd TEMPLATE_VALUES='VERSION=2.1.3-rc1' ./scripts/add-chart-version`, the `TEMPLATE_BASE_URL` will be used to retrieve the template `package.yaml` and the `TEMPLATE_VALUES` will be replaced in that template. In this example, the template files should be present at `https://raw.githubusercontent.com/rancher/your_chart/rancher-backup.tmpl` and `https://raw.githubusercontent.com/rancher/your_chart/rancher-backup-crd.tmpl`.
+4. Commit changes (git add/git commit)
+5. Run make charts: `CHARTS=rancher-backup/rancher-backup,rancher-backup/rancher-backup-crd VERSION=2.1.3-rc1 ./scripts/make-charts`
+6. Commit changes (git add/git commit)
+
 #### Versioning Charts
 
 In this repository, all packages specify the `version` field in the `package.yaml`.

--- a/scripts/add-chart-version
+++ b/scripts/add-chart-version
@@ -1,0 +1,39 @@
+#!/bin/bash
+usage() {
+  echo "Usage: CHARTS=<chart1,chart2> TEMPLATE_BASE_URL=https://raw.githubusercontent.com/rancher/your_chart TEMPLATE_VALUES='KEY1=value1' $0"
+}
+
+if [ "x${CHARTS}" = "x" ]; then
+  usage
+  exit 1
+fi
+
+if [ "x${TEMPLATE_BASE_URL}" = "x" ]; then
+  usage
+  exit 1
+fi
+
+if [ "x${TEMPLATE_VALUES}" = "x" ]; then
+  usage
+  exit 1
+fi
+
+for CHART in $(echo $CHARTS | sed 's/,/ /g'); do
+  if echo $CHART | grep -q '/'; then
+    CHARTNAME=$(echo $CHART | awk -F'/' '{ print $2 }')
+  else
+    CHARTNAME=$CHART
+  fi
+
+  TEMPDIR=$(mktemp -d)
+  wget "${TEMPLATE_BASE_URL}/${CHARTNAME}.tmpl" -O "${TEMPDIR}/${CHARTNAME}.tmpl"
+  for KVPAIR in $(echo $TEMPLATE_VALUES | sed 's/,/ /g'); do
+    KVK=$(echo $KVPAIR | awk -F'=' '{ print $1 }')
+    KVV=$(echo $KVPAIR | awk -F'=' '{ print $2 }')
+    sed -i '' "s/$KVK/$KVV/g" "${TEMPDIR}/${CHARTNAME}.tmpl"
+  done
+  mv "${TEMPDIR}/${CHARTNAME}.tmpl" packages/$CHART/package.yaml
+  PACKAGE=$CHART make prepare
+  PACKAGE=$CHART make patch
+  PACKAGE=$CHART make clean
+done

--- a/scripts/make-charts
+++ b/scripts/make-charts
@@ -1,0 +1,24 @@
+#!/bin/bash
+usage() {
+  echo "Usage: CHARTS=<chart1,chart2> VERSION=<version> $0"
+}
+
+if [ "x${CHARTS}" = "x" ]; then
+  usage
+  exit 1
+fi
+
+if [ "x${VERSION}" = "x" ]; then
+  usage
+  exit 1
+fi
+
+for CHART in $(echo $CHARTS | sed 's/,/ /g'); do
+  if echo $CHART | grep -q '/'; then
+    CHARTNAME=$(echo $CHART | awk -F'/' '{ print $2 }')
+  else
+    CHARTNAME=$CHART
+  fi
+  echo PACKAGE=$CHART make charts
+  yq -i e '. + {"'"$CHARTNAME"'":["'"$VERSION"'"]}' release.yaml
+done

--- a/scripts/remove-chart-version-if-exists
+++ b/scripts/remove-chart-version-if-exists
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ "x${CHARTS}" = "x" ]; then
+  echo "Usage: CHARTS=<chart1,chart2> $0"
+  exit 1
+fi
+
+CHARTS=$1
+
+for CHART in $(echo $CHARTS | sed "s/,/ /g"); do
+  # Check if there already is a version in release.yaml
+  if yq -e 'has("'"$CHART"'")' ../release.yaml >/dev/null 2>&1; then
+    echo "chart ${CHART} already has a version, looking up version to delete"
+    if [[ `yq '."'"$CHART"'" | length' ../release.yaml` -gt 1 ]]; then
+      echo "more than one version found, dont know which one to delete"
+      exit 1
+    else
+      EXISTINGVERSION=$(yq '."'"$CHART"'"[]' ../release.yaml)
+      echo "version to delete for ${CHART} is: ${EXISTINGVERSION}"
+      # $ ./remove-asset 
+      # Usage: CHART=<chart> VERSION=<version> make remove
+      echo CHART=$CHART VERSION=$EXISTINGVERSION make remove
+    fi
+  fi
+done


### PR DESCRIPTION
First attempt to automate chart versions bumps so it can be added as a post action when tagging a new chart release.

The flow is described in the changes in the `README.md`