### PR TITLE
Clean up old releases in release.yaml

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -1,24 +1,25 @@
+neuvector:
+- 100.0.0+up2.2.0-b1
+neuvector-crd:
+- 100.0.0+up2.2.0-b1
+rancher-aks-operator:
+- 100.0.4+up1.0.5-rc1
+rancher-aks-operator-crd:
+- 100.0.4+up1.0.5-rc1
 rancher-backup:
 - 2.1.2-rc3
 rancher-backup-crd:
 - 2.1.2-rc3
+rancher-gatekeeper:
+- 100.1.0+up3.7.1
+rancher-gatekeeper-crd:
+- 100.1.0+up3.7.1
+rancher-istio:
+- 100.2.0+up1.12.6
 rancher-logging:
-- 100.1.0+up3.17.3
-- 100.1.1+up3.17.3
 - 100.1.2+up3.17.4
 rancher-logging-crd:
-- 100.1.0+up3.17.3
-- 100.1.1+up3.17.3
 - 100.1.2+up3.17.4
-rancher-monitoring:
-- 100.1.1+up19.0.3
-- 100.1.2+up19.0.3
-rancher-monitoring-crd:
-- 100.1.1+up19.0.3
-- 100.1.2+up19.0.3
-rancher-webhook:
-- 1.0.3+up0.2.5
-- 1.0.4+up0.2.5
 rancher-vsphere-cpi:
 - 100.3.0+up1.2.1
 rancher-vsphere-csi:
@@ -27,17 +28,3 @@ sriov:
 - 100.0.3+up0.1.0
 sriov-crd:
 - 100.0.3+up0.1.0
-rancher-aks-operator:
-- 100.0.4+up1.0.5-rc1
-rancher-aks-operator-crd:
-- 100.0.4+up1.0.5-rc1
-rancher-istio:
-- 100.2.0+up1.12.6
-neuvector:
-- 100.0.0+up2.2.0-b1
-neuvector-crd:
-- 100.0.0+up2.2.0-b1
-rancher-gatekeeper:
-- 100.1.0+up3.7.1
-rancher-gatekeeper-crd:
-- 100.1.0+up3.7.1


### PR DESCRIPTION
The deletions are charts that have already been released and are listed in the release.yaml in the release-v2.6 branch.