### PR TITLE
fix fluentd statefulset not running with a uid when PodSecurityPolicy is enabled

### DIFF
--- a/charts/rancher-logging/100.1.2+up3.17.4/templates/_generic_logging.yaml
+++ b/charts/rancher-logging/100.1.2+up3.17.4/templates/_generic_logging.yaml
@@ -77,6 +77,9 @@ spec:
     security:
       podSecurityPolicyCreate: true
       roleBasedAccessControlCreate: true
+      {{- with .Values.fluentd.security.podSecurityContext }}
+      podSecurityContext: {{- toYaml . | nindent 8 }}
+      {{- end }}
     {{- end }}
     {{- with (default .Values.tolerations .Values.fluentd.tolerations) }}
     tolerations: {{- toYaml . | nindent 6 }}

--- a/charts/rancher-logging/100.1.2+up3.17.4/values.yaml
+++ b/charts/rancher-logging/100.1.2+up3.17.4/values.yaml
@@ -209,6 +209,9 @@ fluentd:
   nodeSelector: {}
   resources: {}
   tolerations: {}
+  security:
+    podSecurityContext:
+      runAsUser: 100
 fluentbit:
   inputTail:
     Buffer_Chunk_Size: ""


### PR DESCRIPTION
fixes rancher/rancher#43442 for the [100.1.2+up3.17.4](https://github.com/rancher/charts/tree/dev-v2.6/charts/rancher-logging/100.1.2%2Bup3.17.4) chart