### PR TITLE
Feature/rancher dashboards add cluster filter

### DIFF
--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/ingress-nginx/nginx.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/ingress-nginx/nginx.json
@@ -43,7 +43,7 @@
       {
         "datasource": "${DS_PROMETHEUS}",
         "enable": true,
-        "expr": "sum(changes(nginx_ingress_controller_config_last_reload_successful_timestamp_seconds{instance!=\"unknown\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[30s])) by (controller_class)",
+        "expr": "sum(changes(nginx_ingress_controller_config_last_reload_successful_timestamp_seconds{instance!=\"unknown\",controller_class=~\"$controller_class\",namespace=~\"$namespace\", cluster=~\"$cluster\"}[30s])) by (controller_class)",
         "hide": false,
         "iconColor": "rgba(255, 96, 96, 1)",
         "limit": 100,
@@ -124,7 +124,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "round(sum(irate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[2m])), 0.001)",
+          "expr": "round(sum(irate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\", cluster=~\"$cluster\"}[2m])), 0.001)",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -206,7 +206,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",state=\"active\"}[2m]))",
+          "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",state=\"active\"}[2m]))",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -289,7 +289,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",status!~\"[4-5].*\"}[2m])) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[2m]))",
+          "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\", cluster=~\"$cluster\",status!~\"[4-5].*\"}[2m])) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\", cluster=~\"$cluster\"}[2m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A",
@@ -372,7 +372,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg(irate(nginx_ingress_controller_success{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[1m])) * 60",
+          "expr": "avg(irate(nginx_ingress_controller_success{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\"}[1m])) * 60",
           "format": "time_series",
           "instant": false,
           "intervalFactor": 1,
@@ -456,7 +456,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(nginx_ingress_controller_config_last_reload_successful{controller_pod=~\"$controller\",controller_namespace=~\"$namespace\"} == 0)",
+          "expr": "count(nginx_ingress_controller_config_last_reload_successful{controller_pod=~\"$controller\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\"} == 0)",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -530,7 +530,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "round(sum(irate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress), 0.001)",
+          "expr": "round(sum(irate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (ingress), 0.001)",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -637,7 +637,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",ingress=~\"$ingress\",status!~\"[4-5].*\"}[2m])) by (ingress) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+          "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\",status!~\"[4-5].*\"}[2m])) by (ingress) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (ingress)",
           "format": "time_series",
           "instant": false,
           "interval": "10s",
@@ -737,7 +737,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum (irate (nginx_ingress_controller_request_size_sum{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m]))",
+          "expr": "sum (irate (nginx_ingress_controller_request_size_sum{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\"}[2m]))",
           "format": "time_series",
           "instant": false,
           "interval": "10s",
@@ -748,7 +748,7 @@
           "step": 10
         },
         {
-          "expr": "- sum (irate (nginx_ingress_controller_response_size_sum{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m]))",
+          "expr": "- sum (irate (nginx_ingress_controller_response_size_sum{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\"}[2m]))",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
@@ -852,7 +852,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(nginx_ingress_controller_nginx_process_resident_memory_bytes{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}) ",
+          "expr": "avg(nginx_ingress_controller_nginx_process_resident_memory_bytes{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\"}) ",
           "format": "time_series",
           "instant": false,
           "interval": "10s",
@@ -954,7 +954,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg (rate (nginx_ingress_controller_nginx_process_cpu_seconds_total{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m])) ",
+          "expr": "avg (rate (nginx_ingress_controller_nginx_process_cpu_seconds_total{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\"}[2m])) ",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,
@@ -1182,7 +1182,7 @@
       ],
       "targets": [
         {
-          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
+          "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1191,7 +1191,7 @@
           "refId": "C"
         },
         {
-          "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
+          "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1200,7 +1200,7 @@
           "refId": "D"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
+          "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1209,7 +1209,7 @@
           "refId": "E"
         },
         {
-          "expr": "sum(irate(nginx_ingress_controller_request_size_sum{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+          "expr": "sum(irate(nginx_ingress_controller_request_size_sum{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (ingress)",
           "format": "table",
           "hide": false,
           "instant": true,
@@ -1219,7 +1219,7 @@
           "refId": "F"
         },
         {
-          "expr": "sum(irate(nginx_ingress_controller_response_size_sum{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+          "expr": "sum(irate(nginx_ingress_controller_response_size_sum{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}[2m])) by (ingress)",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -1300,7 +1300,7 @@
       ],
       "targets": [
         {
-          "expr": "avg(nginx_ingress_controller_ssl_expire_time_seconds{kubernetes_pod_name=~\"$controller\",namespace=~\"$namespace\",ingress=~\"$ingress\"}) by (host) - time()",
+          "expr": "avg(nginx_ingress_controller_ssl_expire_time_seconds{kubernetes_pod_name=~\"$controller\",namespace=~\"$namespace\", cluster=~\"$cluster\",ingress=~\"$ingress\"}) by (host) - time()",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ host }}",
@@ -1332,6 +1332,29 @@
         "regex": "",
         "type": "datasource"
       },
+      {
+        "current": {
+          "isNone": true,
+          "selected": false,
+          "text": "None",
+          "value": ""
+        },
+        "definition": "label_values(nginx_ingress_controller_build_info,cluster)",
+        "hide": 2,
+        "includeAll": false,
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(nginx_ingress_controller_build_info,cluster)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },      
       {
         "allValue": ".*",
         "current": {
@@ -1368,7 +1391,7 @@
         "multi": false,
         "name": "controller_class",
         "options": [],
-        "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\"}, controller_class) ",
+        "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\", cluster=~\"$cluster\"}, controller_class) ",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -1391,7 +1414,7 @@
         "multi": false,
         "name": "controller",
         "options": [],
-        "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
+        "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\", cluster=~\"$cluster\",controller_class=~\"$controller_class\"}, controller_pod) ",
         "refresh": 1,
         "regex": "",
         "sort": 0,
@@ -1415,7 +1438,7 @@
         "multi": false,
         "name": "ingress",
         "options": [],
-        "query": "label_values(nginx_ingress_controller_requests{namespace=~\"$namespace\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\"}, ingress) ",
+        "query": "label_values(nginx_ingress_controller_requests{namespace=~\"$namespace\", cluster=~\"$cluster\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\"}, ingress) ",
         "refresh": 1,
         "regex": "",
         "sort": 2,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/ingress-nginx/request-handling-performance.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/ingress-nginx/request-handling-performance.json
@@ -92,19 +92,19 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "interval": "",
             "legendFormat": ".5",
             "refId": "D"
           },
           {
-            "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_request_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "interval": "",
             "legendFormat": ".95",
             "refId": "B"
           },
           {
-            "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "interval": "",
             "legendFormat": ".99",
             "refId": "A"
@@ -193,7 +193,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "instant": false,
             "interval": "",
             "intervalFactor": 1,
@@ -201,13 +201,13 @@
             "refId": "D"
           },
           {
-            "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_response_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "interval": "",
             "legendFormat": ".95",
             "refId": "B"
           },
           {
-            "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "interval": "",
             "legendFormat": ".99",
             "refId": "A"
@@ -297,7 +297,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "  sum by (path)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n",
+            "expr": "  sum by (path)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n",
             "interval": "",
             "intervalFactor": 1,
             "legendFormat": "{{ path }}",
@@ -389,7 +389,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "histogram_quantile(\n  .5,\n  sum by (le, path)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
+            "expr": "histogram_quantile(\n  .5,\n  sum by (le, path)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\"\n      }[1m]\n    )\n  )\n)",
             "interval": "",
             "intervalFactor": 1,
             "legendFormat": "{{ path }}",
@@ -481,7 +481,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum by (path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n  status =~ \"[4-5].*\"\n}[1m])) / sum by (path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n}[1m]))",
+            "expr": "sum by (path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  cluster=~\"$cluster\",ingress =~ \"$ingress\",\n  status =~ \"[4-5].*\"\n}[1m])) / sum by (path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  cluster=~\"$cluster\",ingress =~ \"$ingress\",\n}[1m]))",
             "interval": "",
             "intervalFactor": 1,
             "legendFormat": "{{ path }}",
@@ -664,7 +664,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "  sum (\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\",\n        status =~\"[4-5].*\",\n      }[1m]\n    )\n  ) by(path, status)\n",
+            "expr": "  sum (\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\",\n        status =~\"[4-5].*\",\n      }[1m]\n    )\n  ) by(path, status)\n",
             "interval": "",
             "intervalFactor": 1,
             "legendFormat": "{{ path }} {{ status }}",
@@ -755,7 +755,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum (\n  rate (\n      nginx_ingress_controller_response_size_sum {\n        ingress =~ \"$ingress\",\n      }[1m]\n  )\n)  by (path) / sum (\n  rate(\n      nginx_ingress_controller_response_size_count {\n        ingress =~ \"$ingress\",\n      }[1m]\n  )\n) by (path)\n",
+            "expr": "sum (\n  rate (\n      nginx_ingress_controller_response_size_sum {\n        cluster=~\"$cluster\",ingress =~ \"$ingress\",\n      }[1m]\n  )\n)  by (path) / sum (\n  rate(\n      nginx_ingress_controller_response_size_count {\n        cluster=~\"$cluster\",ingress =~ \"$ingress\",\n      }[1m]\n  )\n) by (path)\n",
             "hide": false,
             "instant": false,
             "interval": "",
@@ -764,7 +764,7 @@
             "refId": "D"
           },
           {
-            "expr": "    sum (rate(nginx_ingress_controller_response_size_bucket{\n        ingress =~ \"$ingress\",\n    }[1m])) by (le)\n",
+            "expr": "    sum (rate(nginx_ingress_controller_response_size_bucket{\n        cluster=~\"$cluster\",ingress =~ \"$ingress\",\n    }[1m])) by (le)\n",
             "hide": true,
             "legendFormat": "{{le}}",
             "refId": "A"
@@ -852,7 +852,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_sum {\n        ingress =~ \"$ingress\",\n      }[1m]\n)) / sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_count {\n        ingress =~ \"$ingress\",\n      }[1m]\n  )\n)\n",
+            "expr": "sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_sum {\n        cluster=~\"$cluster\",ingress =~ \"$ingress\",\n      }[1m]\n)) / sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_count {\n        cluster=~\"$cluster\",ingress =~ \"$ingress\",\n      }[1m]\n  )\n)\n",
             "hide": false,
             "instant": false,
             "interval": "",
@@ -922,17 +922,40 @@
           "type": "datasource"
         },
         {
+          "current": {
+            "isNone": true,
+            "selected": false,
+            "text": "None",
+            "value": ""
+          },
+          "definition": "label_values(nginx_ingress_controller_build_info,cluster)",
+          "hide": 2,
+          "includeAll": false,
+          "multi": false,
+          "name": "cluster",
+          "options": [],
+          "query": {
+            "query": "label_values(nginx_ingress_controller_build_info,cluster)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 1,
+          "type": "query"
+        },        
+        {
           "allValue": ".*",
           "current": {},
           "datasource": "${DS_PROMETHEUS}",
-          "definition": "label_values(nginx_ingress_controller_requests, ingress) ",
+          "definition": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\"}, ingress) ",
           "hide": 0,
           "includeAll": true,
           "label": "Service Ingress",
           "multi": false,
           "name": "ingress",
           "options": [],
-          "query": "label_values(nginx_ingress_controller_requests, ingress) ",
+          "query": "label_values(nginx_ingress_controller_requests{cluster=~\"$cluster\"}, ingress) ",
           "refresh": 1,
           "regex": "",
           "skipUrlSync": false,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/cluster/rancher-cluster-nodes.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/cluster/rancher-cluster-nodes.json
@@ -65,7 +65,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - avg(irate({__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\",mode=\"idle\"}[$__rate_interval])) by (instance)",
+          "expr": "1 - avg(irate({cluster=~\"$cluster\",__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\",mode=\"idle\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -168,19 +168,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_load5 OR avg_over_time(windows_system_processor_queue_length[5m])) by (instance)",
+          "expr": "sum(node_load5{cluster=~\"$cluster\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\"}[5m])) by (instance)",
           "interval": "",
           "legendFormat": "Load[5m] ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(node_load1 OR avg_over_time(windows_system_processor_queue_length[1m])) by (instance)",
+          "expr": "sum(node_load1{cluster=~\"$cluster\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\"}[1m])) by (instance)",
           "interval": "",
           "legendFormat": "Load[1m] ({{instance}})",
           "refId": "B"
         },
         {
-          "expr": "sum(node_load15 OR avg_over_time(windows_system_processor_queue_length[15m])) by (instance)",
+          "expr": "sum(node_load15{cluster=~\"$cluster\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\"}[15m])) by (instance)",
           "interval": "",
           "legendFormat": "Load[15m] ({{instance}})",
           "refId": "C"
@@ -274,7 +274,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - sum(node_memory_MemAvailable_bytes OR windows_os_physical_memory_free_bytes) by (instance) / sum(node_memory_MemTotal_bytes OR windows_cs_physical_memory_bytes) by (instance) ",
+          "expr": "1 - sum(node_memory_MemAvailable_bytes{cluster=~\"$cluster\"} OR windows_os_physical_memory_free_bytes{cluster=~\"$cluster\"}) by (instance) / sum(node_memory_MemTotal_bytes{cluster=~\"$cluster\"} OR windows_cs_physical_memory_bytes{cluster=~\"$cluster\"}) by (instance) ",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -369,7 +369,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum(node_filesystem_free_bytes{device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_free_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) by (instance) / sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_size_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) by (instance))",
+          "expr": "1 - (sum(node_filesystem_free_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_free_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) by (instance) / sum(node_filesystem_size_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_size_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) by (instance))",
           "interval": "",
           "legendFormat": "{{instance}}",
           "refId": "A"
@@ -464,13 +464,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_read_bytes_total[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_disk_read_bytes_total{cluster=~\"$cluster\"}[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total{cluster=~\"$cluster\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Read ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_written_bytes_total[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_disk_written_bytes_total{cluster=~\"$cluster\"}[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total{cluster=~\"$cluster\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Write ({{instance}})",
           "refId": "B"
@@ -565,37 +565,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_received_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_receive_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_received_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Receive Errors ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_receive_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_receive_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Receive Total ({{instance}})",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(node_network_transmit_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_outbound_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_transmit_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_outbound_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Transmit Errors ({{instance}})",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(node_network_receive_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_received_discarded_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_receive_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_received_discarded_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Receive Dropped ({{instance}})",
           "refId": "D"
         },
         {
-          "expr": "sum(rate(node_network_transmit_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_outbound_discarded{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_transmit_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_outbound_discarded{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Transmit Dropped ({{instance}})",
           "refId": "E"
         },
         {
-          "expr": "sum(rate(node_network_transmit_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_transmit_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) by (instance) OR sum(rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Transmit Total ({{instance}})",
           "refId": "F"
@@ -690,13 +690,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_transmit_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Transmit Total ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(node_network_receive_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Receive Total ({{instance}})",
           "refId": "B"
@@ -749,7 +749,30 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       }]
   },
   "time": {
     "from": "now-1h",

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/cluster/rancher-cluster.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/cluster/rancher-cluster.json
@@ -63,7 +63,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - avg(irate({__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\",mode=\"idle\"}[$__rate_interval]))",
+          "expr": "1 - avg(irate({cluster=~\"$cluster\",__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\",mode=\"idle\"}[$__rate_interval]))",
           "legendFormat": "Total",
           "interval": "",
           "refId": "A"
@@ -164,19 +164,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_load5 OR avg_over_time(windows_system_processor_queue_length[5m]))",
+          "expr": "sum(node_load5{cluster=~\"$cluster\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\"}[5m]))",
           "interval": "",
           "legendFormat": "Load[5m]",
           "refId": "A"
         },
         {
-          "expr": "sum(node_load1 OR avg_over_time(windows_system_processor_queue_length[1m]))",
+          "expr": "sum(node_load1{cluster=~\"$cluster\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\"}[1m]))",
           "interval": "",
           "legendFormat": "Load[1m]",
           "refId": "B"
         },
         {
-          "expr": "sum(node_load15 OR avg_over_time(windows_system_processor_queue_length[15m]))",
+          "expr": "sum(node_load15{cluster=~\"$cluster\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\"}[15m]))",
           "interval": "",
           "legendFormat": "Load[15m]",
           "refId": "C"
@@ -268,7 +268,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - sum(node_memory_MemAvailable_bytes OR windows_os_physical_memory_free_bytes) / sum(node_memory_MemTotal_bytes OR windows_cs_physical_memory_bytes)",
+          "expr": "1 - sum(node_memory_MemAvailable_bytes{cluster=~\"$cluster\"} OR windows_os_physical_memory_free_bytes{cluster=~\"$cluster\"}) / sum(node_memory_MemTotal_bytes{cluster=~\"$cluster\"} OR windows_cs_physical_memory_bytes{cluster=~\"$cluster\"})",
           "legendFormat": "Total",
           "interval": "",
           "refId": "A"
@@ -361,7 +361,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum(node_filesystem_free_bytes{device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_free_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) / sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_size_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}))",
+          "expr": "1 - (sum(node_filesystem_free_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_free_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}) / sum(node_filesystem_size_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\"} OR windows_logical_disk_size_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\"}))",
           "legendFormat": "Total",
           "interval": "",
           "refId": "A"
@@ -453,13 +453,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_read_bytes_total[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_read_bytes_total{cluster=~\"$cluster\"}[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Read",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_written_bytes_total[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_written_bytes_total{cluster=~\"$cluster\"}[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Write",
           "refId": "B"
@@ -551,37 +551,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(rate(node_network_receive_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_receive_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Receive Errors",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(node_network_receive_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_receive_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "B"
         },
         {
-          "expr": "(sum(rate(node_network_transmit_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_transmit_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Transmit Errors",
           "refId": "C"
         },
         {
-          "expr": "(sum(rate(node_network_receive_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_discarded_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_receive_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_discarded_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Receive Dropped",
           "refId": "D"
         },
         {
-          "expr": "(sum(rate(node_network_transmit_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_discarded{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_transmit_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_discarded{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Transmit Dropped",
           "refId": "E"
         },
         {
-          "expr": "(sum(rate(node_network_transmit_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_transmit_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "F"
@@ -673,13 +673,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_transmit_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_receive_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*'}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "B"
@@ -732,7 +732,29 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [{
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       }]
   },
   "time": {
     "from": "now-1h",

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-etcd-nodes.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-etcd-nodes.json
@@ -65,13 +65,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total{job=\"kube-etcd\"}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total{cluster=~\"$cluster\",job=\"kube-etcd\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Client Traffic In ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total{job=\"kube-etcd\"}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total{cluster=~\"$cluster\",job=\"kube-etcd\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Client Traffic Out ({{instance}})",
           "refId": "B"
@@ -174,7 +174,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(etcd_debugging_mvcc_db_total_size_in_bytes) by (instance)",
+          "expr": "sum(etcd_debugging_mvcc_db_total_size_in_bytes{cluster=~\"$cluster\"}) by (instance)",
           "interval": "",
           "legendFormat": "DB Size ({{instance}})",
           "refId": "A"
@@ -268,13 +268,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) by (instance) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) by (instance)",
+          "expr": "sum(grpc_server_started_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) by (instance) - sum(grpc_server_handled_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) by (instance)",
           "interval": "",
           "legendFormat": "Watch Streams ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) by (instance) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) by (instance)",
+          "expr": "sum(grpc_server_started_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) by (instance) - sum(grpc_server_handled_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) by (instance)",
           "interval": "",
           "legendFormat": "Lease Watch Stream ({{instance}})",
           "refId": "B"
@@ -369,25 +369,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(etcd_server_proposals_committed_total[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(etcd_server_proposals_committed_total{cluster=~\"$cluster\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Proposal Committed ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(etcd_server_proposals_applied_total[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(etcd_server_proposals_applied_total{cluster=~\"$cluster\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Proposal Applied ({{instance}})",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(etcd_server_proposals_failed_total[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(etcd_server_proposals_failed_total{cluster=~\"$cluster\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "Proposal Failed ({{instance}})",
           "refId": "C"
         },
         {
-          "expr": "sum(etcd_server_proposals_pending) by (instance)",
+          "expr": "sum(etcd_server_proposals_pending{cluster=~\"$cluster\"}) by (instance)",
           "interval": "",
           "legendFormat": "Proposal Pending ({{instance}})",
           "refId": "D"
@@ -482,13 +482,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\"}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(grpc_server_started_total{cluster=~\"$cluster\",grpc_type=\"unary\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "RPC Rate ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(grpc_server_handled_total{grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval])) by (instance)",
+          "expr": "sum(rate(grpc_server_handled_total{cluster=~\"$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval])) by (instance)",
           "interval": "",
           "legendFormat": "RPC Failure Rate ({{instance}})",
           "refId": "B"
@@ -584,13 +584,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[$__rate_interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "interval": "",
           "legendFormat": "WAL fsync ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[$__rate_interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "interval": "",
           "legendFormat": "DB fsync ({{instance}})",
           "refId": "B"
@@ -643,7 +643,29 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [{
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       }]
   },
   "time": {
     "from": "now-1h",

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-etcd.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-etcd.json
@@ -63,13 +63,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total{job=\"kube-etcd\"}[$__rate_interval]))",
+          "expr": "sum(rate(etcd_network_client_grpc_received_bytes_total{cluster=~\"$cluster\",job=\"kube-etcd\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Client Traffic In",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total{job=\"kube-etcd\"}[$__rate_interval]))",
+          "expr": "sum(rate(etcd_network_client_grpc_sent_bytes_total{cluster=~\"$cluster\",job=\"kube-etcd\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Client Traffic Out",
           "refId": "B"
@@ -166,7 +166,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(etcd_debugging_mvcc_db_total_size_in_bytes)",
+          "expr": "sum(etcd_debugging_mvcc_db_total_size_in_bytes{cluster=~\"$cluster\"})",
           "interval": "",
           "legendFormat": "DB Size",
           "refId": "A"
@@ -258,13 +258,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
+          "expr": "sum(grpc_server_started_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Watch\",grpc_type=\"bidi_stream\"})",
           "interval": "",
           "legendFormat": "Watch Streams",
           "refId": "A"
         },
         {
-          "expr": "sum(grpc_server_started_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
+          "expr": "sum(grpc_server_started_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"}) - sum(grpc_server_handled_total{cluster=~\"$cluster\",grpc_service=\"etcdserverpb.Lease\",grpc_type=\"bidi_stream\"})",
           "interval": "",
           "legendFormat": "Lease Watch Stream",
           "refId": "B"
@@ -357,25 +357,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(etcd_server_proposals_committed_total[$__rate_interval]))",
+          "expr": "sum(rate(etcd_server_proposals_committed_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Proposal Committed",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(etcd_server_proposals_applied_total[$__rate_interval]))",
+          "expr": "sum(rate(etcd_server_proposals_applied_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Proposal Applied",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(etcd_server_proposals_failed_total[$__rate_interval]))",
+          "expr": "sum(rate(etcd_server_proposals_failed_total{cluster=~\"$cluster\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Proposal Failed",
           "refId": "C"
         },
         {
-          "expr": "sum(etcd_server_proposals_pending)",
+          "expr": "sum(etcd_server_proposals_pending{cluster=~\"$cluster\"})",
           "interval": "",
           "legendFormat": "Proposal Pending",
           "refId": "D"
@@ -467,13 +467,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(grpc_server_started_total{grpc_type=\"unary\"}[$__rate_interval]))",
+          "expr": "sum(rate(grpc_server_started_total{cluster=~\"$cluster\",grpc_type=\"unary\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "RPC Rate",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(grpc_server_handled_total{grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
+          "expr": "sum(rate(grpc_server_handled_total{cluster=~\"$cluster\",grpc_type=\"unary\",grpc_code!=\"OK\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "RPC Failure Rate",
           "refId": "B"
@@ -566,13 +566,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket[$__rate_interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_wal_fsync_duration_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "interval": "",
           "legendFormat": "WAL fsync",
           "refId": "A"
         },
         {
-          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket[$__rate_interval])) by (instance, le))",
+          "expr": "histogram_quantile(0.99, sum(rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster=~\"$cluster\"}[$__rate_interval])) by (instance, le))",
           "interval": "",
           "legendFormat": "DB fsync",
           "refId": "B"
@@ -625,7 +625,29 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [{
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       }]
   },
   "time": {
     "from": "now-1h",

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-k8s-components-nodes.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-k8s-components-nodes.json
@@ -65,7 +65,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total[$__rate_interval])) by (instance, code)",
+          "expr": "sum(rate(apiserver_request_total{cluster=~\"$cluster\"}[$__rate_interval])) by (instance, code)",
           "interval": "",
           "legendFormat": "{{code}}({{instance}})",
           "refId": "A"
@@ -168,55 +168,55 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"deployment\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"deployment\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "Deployment Depth ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"volumes\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"volumes\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "Volumes Depth ({{instance}})",
           "refId": "B"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"replicaset\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"replicaset\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "ReplicaSet Depth ({{instance}})",
           "refId": "C"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"service\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"service\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "Service Depth ({{instance}})",
           "refId": "D"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"serviceaccount\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"serviceaccount\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "ServiceAccount Depth ({{instance}})",
           "refId": "E"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"endpoint\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"endpoint\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "Endpoint Depth ({{instance}})",
           "refId": "F"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"daemonset\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"daemonset\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "DaemonSet Depth ({{instance}})",
           "refId": "G"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"statefulset\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"statefulset\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "StatefulSet Depth ({{instance}})",
           "refId": "H"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"replicationmanager\"}) by (instance, name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"replicationmanager\"}) by (instance, name)",
           "interval": "",
           "legendFormat": "ReplicationManager Depth ({{instance}})",
           "refId": "I"
@@ -311,7 +311,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kube_pod_status_scheduled{condition=\"false\"})",
+          "expr": "sum(kube_pod_status_scheduled{cluster=~\"$cluster\",condition=\"false\"})",
           "interval": "",
           "legendFormat": "Failed To Schedule",
           "refId": "A"
@@ -406,31 +406,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(nginx_ingress_controller_nginx_process_connections{state=\"reading\"}) by (instance)",
+          "expr": "sum(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",state=\"reading\"}) by (instance)",
           "interval": "",
           "legendFormat": "Reading ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "sum(nginx_ingress_controller_nginx_process_connections{state=\"waiting\"}) by (instance)",
+          "expr": "sum(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",state=\"waiting\"}) by (instance)",
           "interval": "",
           "legendFormat": "Waiting ({{instance}})",
           "refId": "B"
         },
         {
-          "expr": "sum(nginx_ingress_controller_nginx_process_connections{state=\"writing\"}) by (instance)",
+          "expr": "sum(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",state=\"writing\"}) by (instance)",
           "interval": "",
           "legendFormat": "Writing ({{instance}})",
           "refId": "C"
         },
         {
-          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{state=\"accepted\"}[$__rate_interval]))) by (instance)",
+          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{cluster=~\"$cluster\",state=\"accepted\"}[$__rate_interval]))) by (instance)",
           "interval": "",
           "legendFormat": "Accepted ({{instance}})",
           "refId": "D"
         },
         {
-          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{state=\"handled\"}[$__rate_interval]))) by (instance)",
+          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{cluster=~\"$cluster\",state=\"handled\"}[$__rate_interval]))) by (instance)",
           "interval": "",
           "legendFormat": "Handled ({{instance}})",
           "refId": "E"
@@ -483,7 +483,29 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [{
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       }]
   },
   "time": {
     "from": "now-1h",

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-k8s-components.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/k8s/rancher-k8s-components.json
@@ -63,7 +63,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total[$__rate_interval])) by (code)",
+          "expr": "sum(rate(apiserver_request_total{cluster=~\"$cluster\"}[$__rate_interval])) by (code)",
           "interval": "",
           "legendFormat": "{{code}}",
           "refId": "A"
@@ -164,55 +164,55 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"deployment\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"deployment\"}) by (name)",
           "interval": "",
           "legendFormat": "Deployment Depth",
           "refId": "A"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"volumes\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"volumes\"}) by (name)",
           "interval": "",
           "legendFormat": "Volumes Depth",
           "refId": "B"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"replicaset\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"replicaset\"}) by (name)",
           "interval": "",
           "legendFormat": "Replicaset Depth",
           "refId": "C"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"service\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"service\"}) by (name)",
           "interval": "",
           "legendFormat": "Service Depth",
           "refId": "D"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"serviceaccount\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"serviceaccount\"}) by (name)",
           "interval": "",
           "legendFormat": "ServiceAccount Depth",
           "refId": "E"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"endpoint\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"endpoint\"}) by (name)",
           "interval": "",
           "legendFormat": "Endpoint Depth",
           "refId": "F"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"daemonset\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"daemonset\"}) by (name)",
           "interval": "",
           "legendFormat": "DaemonSet Depth",
           "refId": "G"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"statefulset\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"statefulset\"}) by (name)",
           "interval": "",
           "legendFormat": "StatefulSet Depth",
           "refId": "H"
         },
         {
-          "expr": "sum(workqueue_depth{component=\"kube-controller-manager\", name=\"replicationmanager\"}) by (name)",
+          "expr": "sum(workqueue_depth{cluster=~\"$cluster\",component=\"kube-controller-manager\", name=\"replicationmanager\"}) by (name)",
           "interval": "",
           "legendFormat": "ReplicationManager Depth",
           "refId": "I"
@@ -305,7 +305,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(kube_pod_status_scheduled{condition=\"false\"})",
+          "expr": "sum(kube_pod_status_scheduled{cluster=~\"$cluster\",condition=\"false\"})",
           "interval": "",
           "legendFormat": "Failed To Schedule",
           "refId": "A"
@@ -398,31 +398,31 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(nginx_ingress_controller_nginx_process_connections{state=\"reading\"})",
+          "expr": "sum(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",state=\"reading\"})",
           "interval": "",
           "legendFormat": "Reading",
           "refId": "A"
         },
         {
-          "expr": "sum(nginx_ingress_controller_nginx_process_connections{state=\"waiting\"})",
+          "expr": "sum(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",state=\"waiting\"})",
           "interval": "",
           "legendFormat": "Waiting",
           "refId": "B"
         },
         {
-          "expr": "sum(nginx_ingress_controller_nginx_process_connections{state=\"writing\"})",
+          "expr": "sum(nginx_ingress_controller_nginx_process_connections{cluster=~\"$cluster\",state=\"writing\"})",
           "interval": "",
           "legendFormat": "Writing",
           "refId": "C"
         },
         {
-          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{state=\"accepted\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{cluster=~\"$cluster\",state=\"accepted\"}[$__rate_interval])))",
           "interval": "",
           "legendFormat": "Accepted",
           "refId": "D"
         },
         {
-          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{state=\"handled\"}[$__rate_interval])))",
+          "expr": "sum(ceil(increase(nginx_ingress_controller_nginx_process_connections_total{cluster=~\"$cluster\",state=\"handled\"}[$__rate_interval])))",
           "interval": "",
           "legendFormat": "Handled",
           "refId": "E"
@@ -475,7 +475,29 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [{
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       }]
   },
   "time": {
     "from": "now-1h",

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/nodes/rancher-node-detail.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/nodes/rancher-node-detail.json
@@ -65,7 +65,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(irate({__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\", instance=\"$instance\"}[$__rate_interval])) by (mode)",
+          "expr": "avg(irate({cluster=~\"$cluster\",__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\", instance=\"$instance\"}[$__rate_interval])) by (mode)",
           "interval": "",
           "legendFormat": "{{mode}}",
           "refId": "A"
@@ -166,19 +166,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_load5{instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{instance=~\"$instance\"}[5m]))",
+          "expr": "sum(node_load5{cluster=~\"$cluster\",instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\",instance=~\"$instance\"}[5m]))",
           "interval": "",
           "legendFormat": "Load[5m]",
           "refId": "A"
         },
         {
-          "expr": "sum(node_load1{instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{instance=~\"$instance\"}[1m]))",
+          "expr": "sum(node_load1{cluster=~\"$cluster\",instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\",instance=~\"$instance\"}[1m]))",
           "interval": "",
           "legendFormat": "Load[1m]",
           "refId": "B"
         },
         {
-          "expr": "sum(node_load15{instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{instance=~\"$instance\"}[15m]))",
+          "expr": "sum(node_load15{cluster=~\"$cluster\",instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\",instance=~\"$instance\"}[15m]))",
           "interval": "",
           "legendFormat": "Load[15m]",
           "refId": "C"
@@ -270,7 +270,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (node_memory_MemAvailable_bytes{instance=~\"$instance\"} OR windows_os_physical_memory_free_bytes{instance=~\"$instance\"}) / (node_memory_MemTotal_bytes{instance=~\"$instance\"} OR windows_cs_physical_memory_bytes{instance=~\"$instance\"})",
+          "expr": "1 - (node_memory_MemAvailable_bytes{cluster=~\"$cluster\",instance=~\"$instance\"} OR windows_os_physical_memory_free_bytes{cluster=~\"$cluster\",instance=~\"$instance\"}) / (node_memory_MemTotal_bytes{cluster=~\"$cluster\",instance=~\"$instance\"} OR windows_cs_physical_memory_bytes{cluster=~\"$cluster\",instance=~\"$instance\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "A"
@@ -365,7 +365,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum(node_filesystem_free_bytes{device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_free_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}) by (device) / sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_size_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}) by (device))",
+          "expr": "1 - (sum(node_filesystem_free_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_free_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}) by (device) / sum(node_filesystem_size_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_size_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}) by (device))",
           "interval": "",
           "legendFormat": "{{device}}",
           "refId": "A"
@@ -460,13 +460,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total{instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_disk_read_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Read ({{device}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total{instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_disk_written_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Write ({{device}})",
           "refId": "B"
@@ -561,37 +561,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_receive_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_received_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_receive_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_received_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Receive Errors ({{device}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_receive_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_receive_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Receive Total ({{device}})",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(node_network_transmit_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_outbound_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_transmit_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_outbound_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Transmit Errors ({{device}})",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(node_network_receive_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_received_discarded_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_receive_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_received_discarded_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Receive Dropped ({{device}})",
           "refId": "D"
         },
         {
-          "expr": "sum(rate(node_network_transmit_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_outbound_discarded{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_transmit_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_outbound_discarded{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Transmit Dropped ({{device}})",
           "refId": "E"
         },
         {
-          "expr": "sum(rate(node_network_transmit_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_transmit_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) by (device) OR sum(rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Transmit Total ({{device}})",
           "refId": "F"
@@ -686,13 +686,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_transmit_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Transmit Total ({{device}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
+          "expr": "sum(rate(node_network_receive_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) by (device)",
           "interval": "",
           "legendFormat": "Receive Total ({{device}})",
           "refId": "B"
@@ -746,6 +746,29 @@
   "tags": [],
   "templating": {
     "list": [
+     {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=~\"node-exporter.*\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=~\"node-exporter.*\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       },
       {
         "allValue": null,
         "hide": 0,
@@ -753,7 +776,7 @@
         "label": null,
         "multi": false,
         "name": "instance",
-        "query": "label_values({__name__=~\"node_exporter_build_info|windows_exporter_build_info\"}, instance)",
+        "query": "label_values({cluster=~\"$cluster\",__name__=~\"node_exporter_build_info|windows_exporter_build_info\"}, instance)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/nodes/rancher-node.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/nodes/rancher-node.json
@@ -63,7 +63,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - avg(irate({__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\", instance=\"$instance\", mode=\"idle\"}[$__rate_interval]))",
+          "expr": "1 - avg(irate({cluster=~\"$cluster\",__name__=~\"node_cpu_seconds_total|windows_cpu_time_total\", instance=\"$instance\", mode=\"idle\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "A"
@@ -164,19 +164,19 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_load5{instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{instance=~\"$instance\"}[5m]))",
+          "expr": "sum(node_load5{cluster=~\"$cluster\",instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\",instance=~\"$instance\"}[5m]))",
           "interval": "",
           "legendFormat": "Load[5m]",
           "refId": "A"
         },
         {
-          "expr": "sum(node_load1{instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{instance=~\"$instance\"}[1m]))",
+          "expr": "sum(node_load1{cluster=~\"$cluster\",instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\",instance=~\"$instance\"}[1m]))",
           "interval": "",
           "legendFormat": "Load[1m]",
           "refId": "B"
         },
         {
-          "expr": "sum(node_load15{instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{instance=~\"$instance\"}[15m]))",
+          "expr": "sum(node_load15{cluster=~\"$cluster\",instance=~\"$instance\"} OR avg_over_time(windows_system_processor_queue_length{cluster=~\"$cluster\",instance=~\"$instance\"}[15m]))",
           "interval": "",
           "legendFormat": "Load[15m]",
           "refId": "C"
@@ -268,7 +268,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - sum(node_memory_MemAvailable_bytes{instance=~\"$instance\"} OR windows_os_physical_memory_free_bytes{instance=~\"$instance\"}) / sum(node_memory_MemTotal_bytes{instance=~\"$instance\"} OR windows_cs_physical_memory_bytes{instance=~\"$instance\"})",
+          "expr": "1 - sum(node_memory_MemAvailable_bytes{cluster=~\"$cluster\",instance=~\"$instance\"} OR windows_os_physical_memory_free_bytes{cluster=~\"$cluster\",instance=~\"$instance\"}) / sum(node_memory_MemTotal_bytes{cluster=~\"$cluster\",instance=~\"$instance\"} OR windows_cs_physical_memory_bytes{cluster=~\"$cluster\",instance=~\"$instance\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "A"
@@ -361,7 +361,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1 - (sum(node_filesystem_free_bytes{device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_free_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}) / sum(node_filesystem_size_bytes{device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_size_bytes{volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}))",
+          "expr": "1 - (sum(node_filesystem_free_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_free_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}) / sum(node_filesystem_size_bytes{cluster=~\"$cluster\",device!~\"rootfs|HarddiskVolume.+\", instance=~\"$instance\"} OR windows_logical_disk_size_bytes{cluster=~\"$cluster\",volume!~\"(HarddiskVolume.+|[A-Z]:.+)\", instance=~\"$instance\"}))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "A"
@@ -453,13 +453,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_disk_read_bytes_total{instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_read_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_read_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Read",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_disk_written_bytes_total{instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total{instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_disk_written_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_logical_disk_write_bytes_total{cluster=~\"$cluster\",instance=~\"$instance\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Write",
           "refId": "B"
@@ -551,37 +551,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(rate(node_network_receive_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_receive_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Receive Errors",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(node_network_receive_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_receive_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "B"
         },
         {
-          "expr": "(sum(rate(node_network_transmit_errs_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_errors_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_transmit_errs_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_errors_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Transmit Errors",
           "refId": "C"
         },
         {
-          "expr": "(sum(rate(node_network_receive_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_discarded_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_receive_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_received_discarded_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Receive Dropped",
           "refId": "D"
         },
         {
-          "expr": "(sum(rate(node_network_transmit_drop_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_discarded{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_transmit_drop_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_outbound_discarded{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Transmit Dropped",
           "refId": "E"
         },
         {
-          "expr": "(sum(rate(node_network_transmit_packets_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
+          "expr": "(sum(rate(node_network_transmit_packets_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0)) + (sum(rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval])) OR on() vector(0))",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "F"
@@ -673,13 +673,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(node_network_transmit_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_transmit_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_sent_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(node_network_receive_bytes_total{device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_network_receive_bytes_total{cluster=~\"$cluster\",device!~\"lo|veth.*|docker.*|flannel.*|cali.*|cbr.*\", instance=~\"$instance\"}[$__rate_interval]) OR rate(windows_net_packets_received_total_total{cluster=~\"$cluster\",nic!~'.*isatap.*|.*VPN.*|.*Pseudo.*|.*tunneling.*', instance=~\"$instance\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "B"
@@ -734,13 +734,36 @@
   "templating": {
     "list": [
       {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=~\"node-exporter.*\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=~\"node-exporter.*\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       },
+      {
         "allValue": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "instance",
-        "query": "label_values({__name__=~\"node_exporter_build_info|windows_exporter_build_info\"}, instance)",
+        "query": "label_values({cluster=~\"$cluster\",__name__=~\"node_exporter_build_info|windows_exporter_build_info\"}, instance)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/pods/rancher-pod-containers.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/pods/rancher-pod-containers.json
@@ -66,25 +66,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "CFS throttled ({{container}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_cpu_system_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_cpu_system_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "System ({{container}})",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_cpu_usage_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_cpu_usage_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Total ({{container}})",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_cpu_usage_seconds_usermode{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_cpu_user_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_cpu_usage_seconds_usermode{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "User ({{container}})",
           "refId": "D"
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_working_set_bytes{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"} OR windows_container_memory_usage_commit_bytes{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"}) by (container)",
+          "expr": "sum(container_memory_working_set_bytes{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"} OR windows_container_memory_usage_commit_bytes{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"}) by (container)",
           "interval": "",
           "legendFormat": "({{container}})",
           "refId": "A"
@@ -274,37 +274,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_receive_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Receive Total ({{container}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_transmit_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_transmit_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Transmit Total ({{container}})",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(container_network_receive_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_receive_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Receive Dropped ({{container}})",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(container_network_receive_errors_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_receive_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Receive Errors ({{container}})",
           "refId": "D"
         },
         {
-          "expr": "sum(rate(container_network_transmit_errors_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_transmit_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Transmit Errors ({{container}})",
           "refId": "E"
         },
         {
-          "expr": "sum(rate(container_network_transmit_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_transmit_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Transmit Dropped ({{container}})",
           "refId": "F"
@@ -399,13 +399,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_receive_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Receive Total ({{container}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_transmit_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container) OR sum(rate(windows_container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Transmit Total ({{container}})",
           "refId": "B"
@@ -500,13 +500,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_fs_writes_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Write ({{container}})",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_fs_reads_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) by (container)",
           "interval": "",
           "legendFormat": "Read ({{container}})",
           "refId": "B"
@@ -561,6 +561,29 @@
   "tags": [],
   "templating": {
     "list": [
+     {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       },
       {
         "allValue": null,
         "hide": 0,
@@ -568,7 +591,7 @@
         "label": null,
         "multi": false,
         "name": "namespace",
-        "query": "label_values({__name__=~\"container_.*|windows_container_.*\", namespace!=\"\"}, namespace)",
+        "query": "label_values({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", namespace!=\"\"}, namespace)",
         "refresh": 2,
         "regex": "",
         "sort": 0,
@@ -584,7 +607,7 @@
         "label": null,
         "multi": false,
         "name": "pod",
-        "query": "label_values({__name__=~\"container_.*|windows_container_.*\", namespace=\"$namespace\", pod!=\"\"}, pod)",
+        "query": "label_values({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", namespace=\"$namespace\", pod!=\"\"}, pod)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/pods/rancher-pod.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/pods/rancher-pod.json
@@ -66,25 +66,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_cpu_cfs_throttled_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "CFS throttled",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_cpu_system_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_cpu_system_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "System",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_cpu_usage_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_cpu_usage_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Total",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(container_cpu_user_seconds_total{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_cpu_usage_seconds_usermode{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_cpu_user_seconds_total{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_cpu_usage_seconds_usermode{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "User",
           "refId": "D"
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(container_memory_working_set_bytes{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"} OR windows_container_memory_usage_commit_bytes{container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"})",
+          "expr": "sum(container_memory_working_set_bytes{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"} OR windows_container_memory_usage_commit_bytes{cluster=~\"$cluster\",container!=\"POD\",namespace=~\"$namespace\",pod=~\"$pod\", container!=\"\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "A"
@@ -274,37 +274,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_network_receive_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) OR sum(rate(windows_container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_transmit_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_network_transmit_packets_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) OR sum(rate(windows_container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "B"
         },
         {
-          "expr": "sum(rate(container_network_receive_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_network_receive_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) OR sum(rate(windows_container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Receive Dropped",
           "refId": "C"
         },
         {
-          "expr": "sum(rate(container_network_receive_errors_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_receive_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Receive Errors",
           "refId": "D"
         },
         {
-          "expr": "sum(rate(container_network_transmit_errors_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_transmit_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Transmit Errors",
           "refId": "E"
         },
         {
-          "expr": "sum(rate(container_network_transmit_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_network_transmit_packets_dropped_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) OR sum(rate(windows_container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Transmit Dropped",
           "refId": "F"
@@ -399,13 +399,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_network_receive_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) OR sum(rate(windows_container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval])) OR sum(rate(windows_container_network_transmit_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval])) OR sum(rate(windows_container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "B"
@@ -500,13 +500,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_fs_writes_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Write",
           "refId": "A"
         },
         {
-          "expr": "sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_fs_reads_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\",pod=~\"$pod\",container!=\"\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Read",
           "refId": "B"
@@ -561,6 +561,29 @@
   "tags": [],
   "templating": {
     "list": [
+     {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       },
       {
         "allValue": null,
         "hide": 0,
@@ -568,7 +591,7 @@
         "label": null,
         "multi": false,
         "name": "namespace",
-        "query": "label_values({__name__=~\"container_.*|windows_container_.*\", namespace!=\"\"}, namespace)",
+        "query": "label_values({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", namespace!=\"\"}, namespace)",
         "refresh": 2,
         "regex": "",
         "sort": 0,
@@ -584,7 +607,7 @@
         "label": null,
         "multi": false,
         "name": "pod",
-        "query": "label_values({__name__=~\"container_.*|windows_container_.*\", namespace=\"$namespace\", pod!=\"\"}, pod)",
+        "query": "label_values({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", namespace=\"$namespace\", pod!=\"\"}, pod)",
         "refresh": 2,
         "regex": "",
         "sort": 0,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/workloads/rancher-workload-pods.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/workloads/rancher-workload-pods.json
@@ -66,25 +66,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_cpu_cfs_throttled_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "CFS throttled ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(container_cpu_system_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_cpu_system_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "System ({{pod}})",
           "refId": "B"
         },
         {
-          "expr": "(sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Total ({{pod}})",
           "refId": "C"
         },
         {
-          "expr": "(sum(rate(container_cpu_user_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_usermode{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_cpu_user_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_usermode{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "User ({{pod}})",
           "refId": "D"
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(container_memory_working_set_bytes{namespace=~\"$namespace\"} OR windows_container_memory_usage_commit_bytes{namespace=~\"$namespace\"}) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(container_memory_working_set_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"} OR windows_container_memory_usage_commit_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "({{pod}})",
           "refId": "A"
@@ -274,37 +274,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(rate(container_network_receive_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Receive Total ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(container_network_transmit_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Transmit Total ({{pod}})",
           "refId": "B"
         },
         {
-          "expr": "(sum(rate(container_network_receive_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Receive Dropped ({{pod}})",
           "refId": "C"
         },
         {
-          "expr": "(sum(rate(container_network_receive_errors_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_receive_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Receive Errors ({{pod}})",
           "refId": "D"
         },
         {
-          "expr": "(sum(rate(container_network_transmit_errors_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_transmit_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Transmit Errors ({{pod}})",
           "refId": "E"
         },
         {
-          "expr": "(sum(rate(container_network_transmit_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Transmit Dropped ({{pod}})",
           "refId": "F"
@@ -399,13 +399,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Receive Total ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Transmit Total ({{pod}})",
           "refId": "B"
@@ -500,13 +500,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "(sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_fs_writes_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Write ({{pod}})",
           "refId": "A"
         },
         {
-          "expr": "(sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
+          "expr": "(sum(rate(container_fs_reads_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"}",
           "interval": "",
           "legendFormat": "Read ({{pod}})",
           "refId": "B"
@@ -561,6 +561,29 @@
   "tags": [],
   "templating": {
     "list": [
+     {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       },
       {
         "allValue": null,
         "hide": 0,
@@ -568,7 +591,7 @@
         "label": null,
         "multi": false,
         "name": "namespace",
-        "query": "query_result(kube_pod_info{namespace!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
+        "query": "query_result(kube_pod_info{cluster=~\"$cluster\",namespace!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
         "refresh": 2,
         "regex": "/.*namespace=\"([^\"]*)\"/",
         "sort": 0,
@@ -584,7 +607,7 @@
         "label": null,
         "multi": false,
         "name": "kind",
-        "query": "query_result(kube_pod_info{namespace=\"$namespace\", created_by_kind!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
+        "query": "query_result(kube_pod_info{cluster=~\"$cluster\",namespace=\"$namespace\", created_by_kind!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
         "refresh": 2,
         "regex": "/.*created_by_kind=\"([^\"]*)\"/",
         "sort": 0,
@@ -600,7 +623,7 @@
         "label": null,
         "multi": false,
         "name": "workload",
-        "query": "query_result(kube_pod_info{namespace=\"$namespace\", created_by_kind=\"$kind\", created_by_name!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
+        "query": "query_result(kube_pod_info{cluster=~\"$cluster\",namespace=\"$namespace\", created_by_kind=\"$kind\", created_by_name!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
         "refresh": 2,
         "regex": "/.*created_by_name=\"([^\"]*)\"/",
         "sort": 0,

--- a/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/workloads/rancher-workload.json
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/files/rancher/workloads/rancher-workload.json
@@ -66,25 +66,25 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((sum(rate(container_cpu_cfs_throttled_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_cpu_cfs_throttled_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "CFS throttled",
           "refId": "A"
         },
         {
-          "expr": "sum((sum(rate(container_cpu_system_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_cpu_system_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_kernelmode{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "System",
           "refId": "B"
         },
         {
-          "expr": "sum((sum(rate(container_cpu_usage_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_cpu_usage_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "C"
         },
         {
-          "expr": "sum((sum(rate(container_cpu_user_seconds_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_usermode{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_cpu_user_seconds_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_cpu_usage_seconds_usermode{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "User",
           "refId": "D"
@@ -179,7 +179,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((sum(container_memory_working_set_bytes{namespace=~\"$namespace\"} OR windows_container_memory_usage_commit_bytes{namespace=~\"$namespace\"}) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(container_memory_working_set_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"} OR windows_container_memory_usage_commit_bytes{cluster=~\"$cluster\",namespace=~\"$namespace\"}) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Total",
           "refId": "A"
@@ -274,37 +274,37 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((sum(rate(container_network_receive_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "A"
         },
         {
-          "expr": "sum((sum(rate(container_network_transmit_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "B"
         },
         {
-          "expr": "sum((sum(rate(container_network_receive_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Receive Dropped",
           "refId": "C"
         },
         {
-          "expr": "sum((sum(rate(container_network_receive_errors_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_receive_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Receive Errors",
           "refId": "D"
         },
         {
-          "expr": "sum((sum(rate(container_network_transmit_errors_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_transmit_errors_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Transmit Errors",
           "refId": "E"
         },
         {
-          "expr": "sum((sum(rate(container_network_transmit_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_dropped_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_packets_dropped_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Transmit Dropped",
           "refId": "F"
@@ -399,13 +399,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((sum(rate(container_network_receive_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_receive_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Receive Total",
           "refId": "A"
         },
         {
-          "expr": "sum((sum(rate(container_network_transmit_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod) OR sum(rate(windows_container_network_transmit_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Transmit Total",
           "refId": "B"
@@ -500,13 +500,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum((sum(rate(container_fs_writes_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_fs_writes_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Write",
           "refId": "A"
         },
         {
-          "expr": "sum((sum(rate(container_fs_reads_bytes_total{namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
+          "expr": "sum((sum(rate(container_fs_reads_bytes_total{cluster=~\"$cluster\",namespace=~\"$namespace\"}[$__rate_interval])) by (pod)) * on(pod) kube_pod_info{cluster=~\"$cluster\",namespace=~\"$namespace\", created_by_kind=\"$kind\", created_by_name=\"$workload\"})",
           "interval": "",
           "legendFormat": "Read",
           "refId": "B"
@@ -562,13 +562,36 @@
   "templating": {
     "list": [
       {
+         "current": {
+           "isNone": true,
+           "selected": false,
+           "text": "None",
+           "value": ""
+         },
+         "definition": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+         "hide": 2,
+         "includeAll": false,
+         "multi": false,
+         "name": "cluster",
+         "options": [],
+         "query": {
+           "query": "label_values(up{job=\"kubelet\", metrics_path=\"/metrics/cadvisor\"},cluster)",
+           "refId": "StandardVariableQuery"
+         },
+         "refresh": 2,
+         "regex": "",
+         "skipUrlSync": false,
+         "sort": 1,
+         "type": "query"
+       },
+      {
         "allValue": null,
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "namespace",
-        "query": "query_result(kube_pod_info{namespace!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
+        "query": "query_result(kube_pod_info{cluster=~\"$cluster\",namespace!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
         "refresh": 2,
         "regex": "/.*namespace=\"([^\"]*)\"/",
         "sort": 0,
@@ -584,7 +607,7 @@
         "label": null,
         "multi": false,
         "name": "kind",
-        "query": "query_result(kube_pod_info{namespace=\"$namespace\", created_by_kind!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
+        "query": "query_result(kube_pod_info{cluster=~\"$cluster\",namespace=\"$namespace\", created_by_kind!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
         "refresh": 2,
         "regex": "/.*created_by_kind=\"([^\"]*)\"/",
         "sort": 0,
@@ -600,7 +623,7 @@
         "label": null,
         "multi": false,
         "name": "workload",
-        "query": "query_result(kube_pod_info{namespace=\"$namespace\", created_by_kind=\"$kind\", created_by_name!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
+        "query": "query_result(kube_pod_info{cluster=~\"$cluster\",namespace=\"$namespace\", created_by_kind=\"$kind\", created_by_name!=\"\"} * on(pod) group_right(namespace, created_by_kind, created_by_name) count({cluster=~\"$cluster\",__name__=~\"container_.*|windows_container_.*\", pod!=\"\"}) by (pod))",
         "refresh": 2,
         "regex": "/.*created_by_name=\"([^\"]*)\"/",
         "sort": 0,


### PR DESCRIPTION
We would like to use the Rancher Dashboards via a central metrics storage datasource, where multiple Rancher local cluster and Harvester clusters send there metrics via remote write.

I would we be awesome, if you could maintain your dashboards analog to the kubernetes mixin dashboards from https://github.com/rancher/charts/tree/dev-v2.6/charts/rancher-monitoring/100.1.3%2Bup19.0.3/templates/grafana/dashboards-1.14 with a cluster variable filter, which is hidden by default.

I have done the adaption manually, you find the adapted dashboard json files in this PR.
Then the dashboards be simply converted to multi cluster versions via the Grafana helmchart sidecar configuration `sidecar.dashboards.multicluster`  from https://github.com/ulikl/rancher-charts/blob/dev-v2.6/charts/rancher-monitoring/100.1.3%2Bup19.0.3/values.yaml.
