### PR TITLE
vSphere CSI provider: allow getting csinodetopologies, as it is expected by node-driver-registrar

### DIFF
--- a/charts/rancher-vsphere-csi/100.3.0+up2.5.1-rancher1/templates/node/role.yaml
+++ b/charts/rancher-vsphere-csi/100.3.0+up2.5.1-rancher1/templates/node/role.yaml
@@ -15,7 +15,7 @@ metadata:
 rules:
   - apiGroups: ["cns.vmware.com"]
     resources: ["csinodetopologies"]
-    verbs: ["create", "watch"]
+    verbs: ["get", "create", "watch"]
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get"]


### PR DESCRIPTION
PR for issue rancher/rancher#43439