### PR TITLE
Run CI workflows on all dev and release branches

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -3,8 +3,8 @@ name: CI-pullrequest
 on:
   pull_request:
     branches:
-      - dev-v2.6
-      - release-v2.6
+      - dev-v*
+      - release-v*
 
 jobs:
   build:


### PR DESCRIPTION
CI should be running on OOB release branches like https://github.com/rancher/charts/pull/2046.

(cherry picked from commit 02d9f120682d51573c43d966bf89b1b7d06497a5)