### PR TITLE
Add RKE2 in the k3s containerd runtime section

### DIFF
--- a/charts/neuvector/100.0.1+up2.2.2/questions.yaml
+++ b/charts/neuvector/100.0.1+up2.2.2/questions.yaml
@@ -108,15 +108,15 @@ questions:
     label: Runtime Path
 - variable: k3s.enabled
   default: "false"
-  description: k3s containerd runtime. Enable only one runtime
+  description: k3s/RKE2 containerd runtime. Enable only one runtime
   type: boolean
-  label: k3s Containerd Runtime
+  label: k3s/RKE2 Containerd Runtime
   show_subquestion_if: true
   group: "Container Runtime"
   subquestions:
   - variable: k3s.runtimePath
     default: " /run/k3s/containerd/containerd.sock"
-    description: "k3s Containerd Runtime Path"
+    description: "k3s/RKE2 Containerd Runtime Path"
     type: string
     label: Runtime Path
 #storage configurations


### PR DESCRIPTION
For visibility/ease of use, including RKE2 on the k3s runtime section

Signed-off-by: Alejandro Bonilla <abonilla@suse.com>