### PR TITLE
Update k8s version on Rancher Windows GMSA chart

### DIFF
--- a/charts/rancher-windows-gmsa/1.0.0/Chart.yaml
+++ b/charts/rancher-windows-gmsa/1.0.0/Chart.yaml
@@ -3,7 +3,7 @@ annotations:
   catalog.cattle.io/certified: rancher
   catalog.cattle.io/display-name: Windows GMSA
   catalog.cattle.io/experimental: "true"
-  catalog.cattle.io/kube-version: '>= 1.21.0-0 < 1.24.0-0'
+  catalog.cattle.io/kube-version: '>= 1.21.0-0 < 1.25.0-0'
   catalog.cattle.io/namespace: cattle-windows-gmsa-system
   catalog.cattle.io/os: windows
   catalog.cattle.io/permits-os: linux,windows


### PR DESCRIPTION
This PR fixes issue https://github.com/rancher/dashboard/issues/6813
Rancher Windows GMSA chart does not show for Kubernetes >1.24.0 clusters
Although Rancher 2.6.7 (latest atm) supports RKE2 1.24
This PR allows the GMSA chart to show for Kubernetes versions from 1.21.0 until 1.25.0