### PR TITLE
Bump Grafana Version to 7.5.11

### DIFF
--- a/charts/rancher-monitoring/101.0.0+up19.0.3/charts/grafana/values.yaml
+++ b/charts/rancher-monitoring/101.0.0+up19.0.3/charts/grafana/values.yaml
@@ -84,7 +84,7 @@ livenessProbe:
 
 image:
   repository: rancher/mirrored-grafana-grafana
-  tag: 7.5.11
+  tag: 7.5.17
   sha: ""
   pullPolicy: IfNotPresent
 

--- a/index.yaml
+++ b/index.yaml
@@ -6970,7 +6970,7 @@ entries:
       catalog.cattle.io/upstream-version: 19.0.3
     apiVersion: v2
     appVersion: 0.50.0
-    created: "2022-09-22T14:33:54.306221-07:00"
+    created: "2022-10-08T01:01:11.489014348+02:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -7041,7 +7041,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: 85f6118717ec0473d0fd9101441a9613fbf5e950af32388c4d2a7b6a195de48a
+    digest: 85ebf7ddd97cb4031bb2f514cd2e34c875b5cca74782349bac1aa03104390a17
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:

--- a/packages/rancher-monitoring/rancher-grafana/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/rancher-grafana/generated-changes/patch/values.yaml.patch
@@ -32,7 +32,7 @@
 -  repository: grafana/grafana
 -  tag: 8.2.1
 +  repository: rancher/mirrored-grafana-grafana
-+  tag: 7.5.11
++  tag: 7.5.17
    sha: ""
    pullPolicy: IfNotPresent
  


### PR DESCRIPTION
This version fixes an issue in Grafana (grafana/grafana#54535) that makes it impossible to use any input fields in certain browsers with certain versions.

This requires rancher/image-mirror#299 to be merged and the Image to be published to the Repository.