### PR TITLE
Bump Grafana Version to 7.5.11

### DIFF
--- a/charts/rancher-monitoring/100.1.3+up19.0.3/charts/grafana/values.yaml
+++ b/charts/rancher-monitoring/100.1.3+up19.0.3/charts/grafana/values.yaml
@@ -84,7 +84,7 @@ livenessProbe:
 
 image:
   repository: rancher/mirrored-grafana-grafana
-  tag: 7.5.11
+  tag: 7.5.17
   sha: ""
   pullPolicy: IfNotPresent
 

--- a/index.yaml
+++ b/index.yaml
@@ -6702,7 +6702,7 @@ entries:
       catalog.cattle.io/upstream-version: 19.0.3
     apiVersion: v2
     appVersion: 0.50.0
-    created: "2022-07-25T11:15:12.454389-07:00"
+    created: "2022-10-08T00:11:24.72335088+02:00"
     dependencies:
     - condition: grafana.enabled
       name: grafana
@@ -6773,7 +6773,7 @@ entries:
     description: Collects several related Helm charts, Grafana dashboards, and Prometheus
       rules combined with documentation and scripts to provide easy to operate end-to-end
       Kubernetes cluster monitoring with Prometheus using the Prometheus Operator.
-    digest: afcb2bf1dc3874426d473c630cd5c82a017c9eab37c1cc99963e03a66b0a5f10
+    digest: 70629b64ec7d74592ece7fb72fd62af09ffbdc0b1069c7f7c472c178975c9b8a
     home: https://github.com/prometheus-operator/kube-prometheus
     icon: https://raw.githubusercontent.com/prometheus/prometheus.github.io/master/assets/prometheus_logo-cb55bb5c346.png
     keywords:

--- a/packages/rancher-monitoring/rancher-grafana/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/rancher-grafana/generated-changes/patch/values.yaml.patch
@@ -32,7 +32,7 @@
 -  repository: grafana/grafana
 -  tag: 8.2.1
 +  repository: rancher/mirrored-grafana-grafana
-+  tag: 7.5.11
++  tag: 7.5.17
    sha: ""
    pullPolicy: IfNotPresent
  


### PR DESCRIPTION
This version fixes an issue in Grafana (grafana/grafana#54535) that makes it impossible to use any input fields in certain browsers with certain versions.

This requires rancher/image-mirror#299 to be merged and the Image to be published to the Repository.