### PR TITLE
Update README.md with new steps to support `rancher-image-origins.txt` release artifact 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ Since this repository uses [`rancher/charts-build-scripts`](https://github.com/r
 2. Running `make charts` to automatically generate assets used to serve a Helm repository (`charts/`, `assets/`, and `index.yaml`) based on the contents of `packages/`.
 3. [CI] Running `make validate` to ensure that all generated assets are up-to-date and ready to be merged.
 
+
+#### Adding Net-New dependencies to dev-2.7
+A new build artifact was introduced in v2.7.0 of Rancher, titled `rancher-image-origins.txt`, which denotes the source code repository (github repository) of each image used in Charts and System-Charts.
+When adding new dependencies to dev-2.7, a PR must first be raised and merged in the Rancher repository with the required changes to the `pkg/image/origins.go` file. This ensures that the artifact is up-to-date
+with the latest images, and will prevent build failures within Rancher when attempting to generate the artifact. Changes to this file are **not** required when updating versions of existing dependencies.
+
 #### Versioning Charts
 
 In this repository, all packages specify the `version` field in the `package.yaml`.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -167,6 +167,8 @@ Once declared, `make prepare` will automatically pull in your dependency under `
 
 *Note: if you manage a dependency as a separate package, it's often a good idea to set `doNotRelease: true` on that dependency package's `package.yaml` to indicate that the dependency should not be independently released. This prevents `make charts` from generating assets for the dependency, since it will already be packaged directly into your main chart.*
 
+*Note: When adding net-new dependencies, a PR must first be raised and merged in the `rancher/Rancher` repository with the required updates to the `rancher/pkg/image/origins.go` file. This file must be updated with the name of the dependency (without any version information) and the Github repository URL from where the image originates from. This information is used to generate an artifact during Rancher releases, and failure to provide it will interfere with Rancher's CI. This file does not need to be updated when bumping versions of released dependencies.*
+
 #### Known Issue: Managed Files
 
 In any Helm chart managed by these scripts, we consider the `Chart.yaml` / `requirements.yaml` to be `Managed Files` since they are the only files that end up going through a three-way merge. 


### PR DESCRIPTION
This update is related to https://github.com/rancher/rancher/pull/39191, and includes additional instructions on how to introduce new dependencies to `dev-2.7`. At the moment, these additional instructions are not required when merging into `dev-2.6`. 

As apart of the upcoming trusted registry work introduced in `v2.7.0` of Rancher, a new build artifact was introduced, named `rancher-image-origins.txt`. This artifact denotes the source code repository of each image introduced via Charts, System Charts, and KDM. This mapping of images to source code URL's is maintained in `rancher/Rancher`, within the `rancher/pkg/image/origins.go` file. When introducing net-new dependencies in Charts, this file should first be updated so that the release artifact is up to date. If this file is not updated before the new image is introduced, Rancher CI will fail and report the missing images. 

I'm happy to answer any questions about this in this PR, I mainly just want to ensure that there is visibility of this new requirement and to have it documented early on in the process of releasing new charts and dependencies. Any improvements / suggestions are welcome as well. 