### PR TITLE
Add support for SA annotations for fluentd

### DIFF
--- a/packages/rancher-logging/generated-changes/overlay/templates/_generic_logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/_generic_logging.yaml
@@ -90,6 +90,9 @@ spec:
     {{- with .Values.fluentd.livenessProbe }}
     livenessProbe: {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.fluentd.serviceAccount }}
+    serviceAccount: {{- toYaml . | nindent 6 }}
+    {{- end }}
 {{- end -}}
 
 {{- define "logging-operator.util.merge.logging" -}}

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -36,7 +36,7 @@
  rbac:
    enabled: true
    psp:
-@@ -98,3 +106,139 @@
+@@ -98,3 +106,140 @@
  
  serviceAccount:
    annotations: {}
@@ -146,6 +146,7 @@
 +  nodeSelector: {}
 +  resources: {}
 +  tolerations: {}
++  serviceAccount: {}
 +fluentbit:
 +  inputTail:
 +    Buffer_Chunk_Size: ""


### PR DESCRIPTION
When running on EKS it is supper handful to be able to annotate ServiceAccount with AWS role arns

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>