### PR TITLE
Place kube-api-server serviceMonitor in kube-system namespace

### DIFF
--- a/packages/rancher-monitoring/rancher-monitoring/generated-changes/patch/templates/exporters/kube-api-server/servicemonitor.yaml.patch
+++ b/packages/rancher-monitoring/rancher-monitoring/generated-changes/patch/templates/exporters/kube-api-server/servicemonitor.yaml.patch
@@ -5,7 +5,7 @@
  metadata:
    name: {{ template "kube-prometheus-stack.fullname" . }}-apiserver
 -  namespace: {{ template "kube-prometheus-stack.namespace" . }}
-+  namespace: default
++  namespace: kube-system
    labels:
      app: {{ template "kube-prometheus-stack.name" . }}-apiserver
    {{- with .Values.kubeApiServer.serviceMonitor.additionalLabels }}


### PR DESCRIPTION
The kube-api-server serviceMonitor doesn't need to be in the `default` namespace to be able to monitor the Kubernetes API server. The reason why I'm proposing this change is that in our gitops pipelines we tend to ignore the default namespace as we have hundreds of thousands of customer objects over there and it would otherwise significantly humper the delivery of changes.

The `namespaceSelector` makes it perfectly possible to monitor the API server through the `kubernetes` service in the default namespace anyway, see attached screenshot placing the serviceMonitor in the cattle-monitoring-namesppace.

```
  namespaceSelector:
    matchNames:
    - default
```

![image](https://user-images.githubusercontent.com/8708247/206425791-dd5ba210-7b63-4af3-8ff6-ea5e9933fe5e.png)

