### PR TITLE
Add hardcoded folder name for clone in pull-scripts

### DIFF
--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -31,7 +31,7 @@ if ! [[ -f bin/charts-build-scripts ]] || [[ $(cat bin/charts-build-scripts) == 
     # Fall back to old process
     echo "Building binary locally..."
     rm -rf charts-build-scripts
-    git clone --depth 1 --branch $CHARTS_BUILD_SCRIPT_VERSION $CHARTS_BUILD_SCRIPTS_REPO 2>/dev/null
+    git clone --depth 1 --branch $CHARTS_BUILD_SCRIPT_VERSION $CHARTS_BUILD_SCRIPTS_REPO charts-build-scripts 2>/dev/null
 
     cd charts-build-scripts
     VERSION_OVERRIDE=${CHARTS_BUILD_SCRIPT_VERSION} ./scripts/build


### PR DESCRIPTION
### Changes
* Clone `rancher/charts-build-scripts` to a hardcoded folder name to make sure it always works regardless of the name of the fork.