### PR TITLE
Empty release.yaml for 2.6.10 release

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -1,4 +1,0 @@
-longhorn:
-- 100.1.4+up1.2.6
-longhorn-crd:
-- 100.1.4+up1.2.6


### PR DESCRIPTION
Equivalent of running `rm release.yaml; touch release.yaml`