### PR TITLE
[chart rancher-monitoring/102.0.0+up40.1.2] fix indentation in `servicemonitorThanosSidecar.yaml`

### DIFF
--- a/charts/rancher-monitoring/102.0.0+up40.1.2/Chart.yaml
+++ b/charts/rancher-monitoring/102.0.0+up40.1.2/Chart.yaml
@@ -125,4 +125,4 @@ sources:
 - https://github.com/prometheus-community/helm-charts
 - https://github.com/prometheus-operator/kube-prometheus
 type: application
-version: 102.0.0+up40.1.2
+version: 102.0.1+up40.1.2

--- a/charts/rancher-monitoring/102.0.0+up40.1.2/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/102.0.0+up40.1.2/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -39,12 +39,12 @@ spec:
         replacement: {{ .Values.global.cattle.clusterId }}
     {{- end }}
 {{ else }}
-      {{ if .Values.global.cattle.clusterId }}
-      metricRelabelings:
+    {{ if .Values.global.cattle.clusterId }}
+    metricRelabelings:
       - sourceLabels: [__address__]
         targetLabel: cluster_id
         replacement: {{ .Values.global.cattle.clusterId }}
-      {{- end }}
+    {{- end }}
 {{- end }}
 {{- if .Values.prometheus.thanosServiceMonitor.relabelings }}
     relabelings:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->



Deploying via FluxCD revealed an issue in manifest generation:

`YAML parse error on rancher-monitoring/templates/prometheus/servicemonitorThanosSidecar.yaml: error converting YAML to JSON: yaml: line 27: did not find expected key`

I pulled the chart manually and tried to reproduce with my values.yaml file and found the culprit which would only happen if the following conditions were present:
`.Values.prometheus.thanosService.enabled .Values.prometheus.thanosServiceMonitor.enabled`
`.Values.prometheus.thanosServiceMonitor.metricRelabelings` not defined
`.Values.global.cattle.clusterId` was present.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

## Backporting considerations
<!-- Does this change need to be backported to other versions? If so, which versions should it be backported to? -->
No, this only came apparent in the chart version based on version 40 of upstream