### PR TITLE
Fix spelling error in the servicemonitor template

### DIFF
--- a/charts/rancher-monitoring/102.0.0+up40.1.2/charts/prometheus-node-exporter/templates/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.0+up40.1.2/charts/prometheus-node-exporter/templates/servicemonitor.yaml
@@ -50,7 +50,7 @@ spec:
         {{ if .Values.global.cattle.clusterId }}
         - sourceLabels: [__address__]
           targetLabel: cluster_id
-          eplacement: {{ .Values.global.cattle.clusterId }}
+          replacement: {{ .Values.global.cattle.clusterId }}
         {{- end }}
     {{ else }}
       {{ if .Values.global.cattle.clusterId }}


### PR DESCRIPTION
## Issue:
Fixes rancher/rancher#43411

## Problem
Rancher monitoring 102.0.0+up40.1.2/charts/prometheus-node-exporter/templates/servicemonitor.yaml has a spelling error which makes metricRelabelings fail.

## Solution
Adding an "r". :)

## Testing
Tested applying it to our cluster with a bunch of metricRelabelings and without any. Both works.

## Engineering Testing
### Manual Testing
Tested applying it to our cluster with a bunch of metricRelabelings and without any. Both works.

### Automated Testing
N/A

## QA Testing Considerations
N/A

### Regressions Considerations
N/A

## Backporting considerations
N/A
