### PR TITLE
Add github action for regsync config generation

### DIFF
--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -1,0 +1,38 @@
+# Generate-Regsync-Config action will checkout release-v2.7 branch, run make regsync target and
+# creates a pull request from rancherbot/charts or rancher/charts release-v2.7 branch with any image additions
+# to regsync config file. This action is triggered whenever something is pushed into release-v2.7 branch.
+
+name: Generate-Regsync-Config
+
+on:
+  push:
+    branches:
+      - release-v2.7
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: release-v2.7
+
+      # Need to remove export version once rancher/charts gets the latest version 
+      # of charts-build-script binary.
+      - name: Generate Regsync
+        run: |
+          export CHARTS_BUILD_SCRIPT_VERSION=v0.4.2 
+          make pull-scripts
+          make regsync
+      
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          add-paths: |
+            regsync.yaml
+          token: ${{secrets.PUSH_TO_FORKS_SUBMIT_PRS}}
+          push-to-fork: rancherbot/charts
+          title: 'Update regsync config images file'
+          branch-suffix: timestamp
+

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ remove:
 forward-port:
 	./scripts/forward-port
 
-TARGETS := prepare patch clean clean-cache charts list index unzip zip standardize validate template
+TARGETS := prepare patch clean clean-cache charts list index unzip zip standardize validate template regsync
 
 $(TARGETS):
 	@./scripts/pull-scripts

--- a/scripts/version
+++ b/scripts/version
@@ -2,4 +2,4 @@
 set -e
 
 CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
-CHARTS_BUILD_SCRIPT_VERSION=v0.3.3
+CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v0.3.3}"


### PR DESCRIPTION
This PR adds a github action to automatically generate a regsync config file and create a PR for it.

The idea is whenever we do an OOB release or a general release, the github action gets triggered and creates a PR for regsync config file additions. We approve it and then merge it.

Updated Documentation - https://confluence.suse.com/display/RMI/Chart+Releases+and+Responsibilities
Section - Cleanup and sync-up branches post-chart release
Point - 4