### PR TITLE
Monitoring Chart fixed endpoints definition

### DIFF
--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/core-dns/servicemonitor.yaml
@@ -28,8 +28,8 @@ spec:
     proxyUrl: {{ .Values.coreDns.serviceMonitor.proxyUrl}}
     {{- end }}
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-api-server/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-api-server/servicemonitor.yaml
@@ -21,8 +21,8 @@ spec:
     {{- end }}
     port: https
     scheme: https
-  - metricRelabelings:
     {{- if .Values.kubeApiServer.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
 {{ tpl (toYaml .Values.kubeApiServer.serviceMonitor.metricRelabelings | indent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -39,8 +39,8 @@ spec:
       serverName: {{ .Values.kubeControllerManager.serviceMonitor.serverName }}
       {{- end }}
     {{- end }}
-    metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-dns/servicemonitor.yaml
@@ -28,8 +28,8 @@ spec:
     {{- if .Values.kubeDns.serviceMonitor.proxyUrl }}
     proxyUrl: {{ .Values.kubeDns.serviceMonitor.proxyUrl}}
     {{- end }}
-  - metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -45,8 +45,8 @@ spec:
       {{- end}}
       insecureSkipVerify: {{ .Values.kubeEtcd.serviceMonitor.insecureSkipVerify }}
     {{- end }}
-  - metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -33,8 +33,8 @@ spec:
     tlsConfig:
       caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     {{- end}}
-  - metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -39,8 +39,8 @@ spec:
       serverName: {{ .Values.kubeScheduler.serviceMonitor.serverName }}
       {{- end}}
     {{- end}}
-  - metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}

--- a/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kubelet/servicemonitor.yaml
+++ b/charts/rancher-monitoring/102.0.1+up40.1.2/templates/exporters/kubelet/servicemonitor.yaml
@@ -32,8 +32,8 @@ spec:
       insecureSkipVerify: true
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     honorLabels: true
-  - metricRelabelings:
     {{- if .Values.kubelet.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
     {{ tpl (toYaml .Values.kubelet.serviceMonitor.metricRelabelings | indent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}


### PR DESCRIPTION
additional hypen at metricRelabeling
started new list item on some ServiceMonitor Definitions.

moved metricRelabeling key into if structure

## Issue: rancher/rancher#43408


## Problem
After installing rancher-monitoring some Prometheus Target are not found. For example the Kube-API target.
The Reason for this is a wrong ServiceMonitor definition for some Services breaking the endpoints List.

## Solution
Fixed typo on ServiceMonitoring Ressources 

## Engineering Testing
### Manual Testing
Fixed ServiceMonitors on Cluster and Target was available and could be scraped

