### PR TITLE
Fix/neuvector double command issue

### DIFF
--- a/charts/neuvector/102.0.1+up2.4.3/templates/updater-cronjob.yaml
+++ b/charts/neuvector/102.0.1+up2.4.3/templates/updater-cronjob.yaml
@@ -52,10 +52,6 @@ spec:
             - name: neuvector-updater-pod
               image: {{ template "system_default_registry" . }}{{ .Values.cve.updater.image.repository }}:{{ .Values.cve.updater.image.tag }}
               imagePullPolicy: Always
-              command:
-              - /bin/sh
-              - -c
-              - sleep 30
           {{- if .Values.cve.scanner.enabled }}
               command:
               - /bin/sh

--- a/packages/neuvector/generated-changes/patch/templates/updater-cronjob.yaml.patch
+++ b/packages/neuvector/generated-changes/patch/templates/updater-cronjob.yaml.patch
@@ -1,6 +1,6 @@
 --- charts-original/templates/updater-cronjob.yaml
 +++ charts/templates/updater-cronjob.yaml
-@@ -50,20 +50,12 @@
+@@ -50,19 +50,7 @@ spec:
            {{- end }}
            containers:
              - name: neuvector-updater-pod
@@ -19,10 +19,5 @@
 -              {{- end }}
 +              image: {{ template "system_default_registry" . }}{{ .Values.cve.updater.image.repository }}:{{ .Values.cve.updater.image.tag }}
                imagePullPolicy: Always
-+              command:
-+              - /bin/sh
-+              - -c
-+              - sleep 30
            {{- if .Values.cve.scanner.enabled }}
                command:
-               - /bin/sh


### PR DESCRIPTION
## Issue: #2604 

## Problem
See the referenced issue.

## Solution
The patch to NeuVector chart which introduces the bug is fixed by avoiding duplicated "command" instruction.

## Testing
Done.

## Engineering Testing
### Manual Testing
Tested on internally deployed clusters.

### Automated Testing
N/A

## QA Testing Considerations
N/A

### Regressions Considerations
N/A

## Backporting considerations
Can be backported to 102.0.0+up2.4.2.
