### PR TITLE
Changing to --help to test that install of regsync is working.

### DIFF
--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Sync Charts
         run: |
-          time ./regsync  -v debug check --config regsync.yaml
+          time ./regsync --help
         env:
           REGISTRY_ENDPOINT: ${{ secrets.REGISTRY_ENDPOINT }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}


### PR DESCRIPTION
From what we can see so far it looks like the regsync check is not running. I am wanting to try and use the `--help` option to see if we can get any output from regsync. 