### PR TITLE
Removing exported script version in regsync-config.yaml

### DIFF
--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -14,13 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      # TODO: Need to remove export version once rancher/charts gets the latest version 
-      # of charts-build-script binary.
       
       - name: Generate Regsync Config
         run: |
-          export CHARTS_BUILD_SCRIPT_VERSION=v0.4.4
           make pull-scripts
           make regsync
    


### PR DESCRIPTION
## Issue: https://github.com/rancher/charts-build-scripts/issues/96

## Problem
There was an old to-do task to remove this comment and the export command for the charts build script version. Now that the script is running in the latest version, this command is not needed anymore.
