### PR TITLE
[v2.7] Remove already already released operators

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -45,16 +45,12 @@ rancher-cis-benchmark-crd:
   - 4.2.0-rc7
   - 4.2.0-rc8
 rancher-eks-operator:
-  - 102.1.1+up1.2.0
   - 102.1.4+up1.2.2
 rancher-eks-operator-crd:
-  - 102.1.1+up1.2.0
   - 102.1.4+up1.2.2
 rancher-gke-operator:
-  - 102.0.0+up1.1.5
   - 102.0.2+up1.1.6
 rancher-gke-operator-crd:
-  - 102.0.0+up1.1.5
   - 102.0.2+up1.1.6
 rancher-istio:
   - 102.3.0+up1.18.2


### PR DESCRIPTION
## Problem

Remove obsolete operators (already released) from release.yml
