### PR TITLE
Converting checks to jobs and running them in parallel

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Check RC images and charts
         run: make check-rc
-        if: startsWith(github.ref, 'refs/heads/upstream/release-v')
+        if: startsWith(github.ref, 'refs/heads/release-v')

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -34,6 +34,12 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
+  check-rc:
+    name: Check RC Images and Charts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
       - name: Check RC images and charts
         run: make check-rc
         if: startsWith(github.ref, 'refs/heads/release-v')

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -28,6 +28,12 @@ jobs:
       - name: Run Hull tests
         run: cd tests && go test -v ./...
 
+  check-images:
+    name: Check Container Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
       - name: Check container images 
         run: make check-images
         env:


### PR DESCRIPTION
- Converting Check RC Images and Tags to a job and running it in parallel
- Converting Check Container Images to a job and running it in parallel