### PR TITLE
Adding workflow to check for positive reactions to the github-actions [bot] comment

### DIFF
--- a/.github/workflows/validation-check.yaml
+++ b/.github/workflows/validation-check.yaml
@@ -1,0 +1,50 @@
+name: Validation Check
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  check-reaction:
+    name: Check for positive reaction on bot's latest validation comment from PR author
+    if: startsWith(github.event.pull_request.base.ref, 'dev-v') || startsWith(github.event.pull_request.base.ref, 'release-v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for positive reaction on bot's latest validation comment
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Get comments on the PR
+            const comments = await github.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+
+            // Sort comments based on their creation datetime in descending order
+            const sortedComments = comments.data.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            // Find the latest validation comment by github-actions[bot]
+            const latestValidationComment = sortedComments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.startsWith("## Validation steps"));
+
+            if (latestValidationComment) {
+              const reactions = await github.reactions.listForIssueComment({
+                comment_id: latestValidationComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo
+              });
+
+              // Check if the PR author gave a thumbs-up reaction on the bot's validation comment
+              const authorReaction = reactions.data.find(reaction => reaction.user.login === context.payload.pull_request.user.login && reaction.content === '+1');
+
+              if (authorReaction) {
+                console.log("The latest validation comment by github-actions[bot] has the required thumbs-up reaction from the PR author.");
+              } else {
+                const createdAt = new Date(latestValidationComment.created_at).toLocaleString('en-US', { timeZoneName: 'short' });
+                console.error("Failed Check - Comment Created At:", createdAt);
+                core.setFailed("The latest validation comment by github-actions[bot] does not have the required thumbs-up reaction from the PR author!");
+              }
+            } else {
+              console.warn("No validation comments by github-actions[bot] found.");
+            }

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -21,14 +21,15 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## Validation steps [CI won't pass without adding a 👍 (thumbs up) reaction to this comment]
-              - Ensure all container images have repository and tag on the same level to ensure that all container images are included in rancher-images.txt which are used by airgap customers.
-              Add a 👍 (thumbs up) reaction to this comment once done.
-              
-              <pre>
-              Ex:- 
-                longhorn-controller:
-                  repository: rancher/hardened-sriov-cni
-                  tag: v2.6.3-build20230913
-              </pre>`,
+              body: `## Validation steps
+                - Ensure all container images have repository and tag on the same level to ensure that all container images are included in rancher-images.txt which are used by airgap customers.
+                - Add a 👍 (thumbs up) reaction to this comment once done. CI won't pass without this reaction to the github-action bot's latest validation comment. The thumbs up reaction must be from the PR's author.
+                - Approve the PR to run the CI check.
+                
+                <pre>
+                Ex:- 
+                  longhorn-controller:
+                    repository: rancher/hardened-sriov-cni
+                    tag: v2.6.3-build20230913
+                </pre>`,
             })

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -1,4 +1,4 @@
-name: Require Checklist
+name: Validation Comment
 
 on:
   pull_request_target:
@@ -7,7 +7,7 @@ on:
       - release-v*
 
 jobs:
-  review-checklist:
+  validation-comment:
     name: Make validation comment on PR
     runs-on: ubuntu-latest
     permissions: write-all


### PR DESCRIPTION
- Renames require-checklist.yaml to validation-comment.yaml;
- Adds detailed instructions for users on how the validation check works in the github-action bot's comment;
- Adds validation-check.yaml to check for a positive reaction from the PR author on the github-action bot's latest validation comment upon submitting a PR review.