### PR TITLE
Fix typo clsuter to cluster in rancher charts in dev-v2.8 branch

### DIFF
--- a/charts/neuvector/100.0.0+up2.2.0/README.md
+++ b/charts/neuvector/100.0.0+up2.2.0/README.md
@@ -101,7 +101,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `ingress.kubernetes.io/protocol: https ingress.kubernetes.io/rewrite-target: /` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/blob/5.0.0/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |
 `controller.federation.managedsvc.route.termination` | Specify TLS termination for OpenShift route for Multi-cluster managed cluster service. Possible passthrough, edge, reencrypt | `passthrough` |

--- a/charts/neuvector/100.0.0+up2.2.0/questions.yaml
+++ b/charts/neuvector/100.0.0+up2.2.0/questions.yaml
@@ -204,7 +204,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and Ingress
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and Ingress
   type: enum
   label: Fed Managed service type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.1+up2.2.2/README.md
+++ b/charts/neuvector/100.0.1+up2.2.2/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.2/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.1+up2.2.2/questions.yaml
+++ b/charts/neuvector/100.0.1+up2.2.2/questions.yaml
@@ -296,7 +296,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.2+up2.2.3/README.md
+++ b/charts/neuvector/100.0.2+up2.2.3/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.2+up2.2.3/questions.yaml
+++ b/charts/neuvector/100.0.2+up2.2.3/questions.yaml
@@ -296,7 +296,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.3+up2.2.4/README.md
+++ b/charts/neuvector/100.0.3+up2.2.4/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.4/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.3+up2.2.4/questions.yaml
+++ b/charts/neuvector/100.0.3+up2.2.4/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.4+up2.4.3/README.md
+++ b/charts/neuvector/100.0.4+up2.4.3/README.md
@@ -73,7 +73,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.4+up2.4.3/questions.yaml
+++ b/charts/neuvector/100.0.4+up2.4.3/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/101.0.0+up2.2.3/README.md
+++ b/charts/neuvector/101.0.0+up2.2.3/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/101.0.0+up2.2.3/questions.yaml
+++ b/charts/neuvector/101.0.0+up2.2.3/questions.yaml
@@ -296,7 +296,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/101.0.1+up2.2.4/README.md
+++ b/charts/neuvector/101.0.1+up2.2.4/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.4/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/101.0.1+up2.2.4/questions.yaml
+++ b/charts/neuvector/101.0.1+up2.2.4/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.0+up2.4.2/README.md
+++ b/charts/neuvector/102.0.0+up2.4.2/README.md
@@ -72,7 +72,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.2/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.0+up2.4.2/questions.yaml
+++ b/charts/neuvector/102.0.0+up2.4.2/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.1+up2.4.3/README.md
+++ b/charts/neuvector/102.0.1+up2.4.3/README.md
@@ -73,7 +73,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.1+up2.4.3/questions.yaml
+++ b/charts/neuvector/102.0.1+up2.4.3/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.2+up2.4.5/README.md
+++ b/charts/neuvector/102.0.2+up2.4.5/README.md
@@ -73,7 +73,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.5/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.2+up2.4.5/questions.yaml
+++ b/charts/neuvector/102.0.2+up2.4.5/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.3+up2.6.0/README.md
+++ b/charts/neuvector/102.0.3+up2.6.0/README.md
@@ -75,7 +75,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.0/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.3+up2.6.0/questions.yaml
+++ b/charts/neuvector/102.0.3+up2.6.0/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.4+up2.6.2/README.md
+++ b/charts/neuvector/102.0.4+up2.6.2/README.md
@@ -72,7 +72,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.4+up2.6.2/questions.yaml
+++ b/charts/neuvector/102.0.4+up2.6.2/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/103.0.0+up2.6.2/README.md
+++ b/charts/neuvector/103.0.0+up2.6.2/README.md
@@ -72,7 +72,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/103.0.0+up2.6.2/questions.yaml
+++ b/charts/neuvector/103.0.0+up2.6.2/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/rancher-monitoring/9.4.200/values.yaml
+++ b/charts/rancher-monitoring/9.4.200/values.yaml
@@ -1915,7 +1915,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/charts/rancher-monitoring/9.4.201/values.yaml
+++ b/charts/rancher-monitoring/9.4.201/values.yaml
@@ -1891,7 +1891,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/charts/rancher-monitoring/9.4.202/values.yaml
+++ b/charts/rancher-monitoring/9.4.202/values.yaml
@@ -1893,7 +1893,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/charts/rancher-monitoring/9.4.203/values.yaml
+++ b/charts/rancher-monitoring/9.4.203/values.yaml
@@ -1893,7 +1893,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/packages/neuvector/generated-changes/overlay/questions.yaml
+++ b/packages/neuvector/generated-changes/overlay/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/packages/neuvector/generated-changes/patch/README.md.patch
+++ b/packages/neuvector/generated-changes/patch/README.md.patch
@@ -25,7 +25,7 @@
  `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 -`controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](values.yaml)
 +`controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
- `controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+ `controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
  `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
  `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 @@ -90,14 +87,14 @@


### PR DESCRIPTION
Fix typo in Rancher charts, "clsuter" to "cluster" in dev-v2.8 branch
Used gsed (macos) to find and replace `grep -RiIl 'clsuter' | xargs gsed -i 's/clsuter/cluster/g'`
