### PR TITLE
Fix typo clsuter to cluster in dev-v2.7 branch

### DIFF
--- a/charts/neuvector/100.0.0+up2.2.0/README.md
+++ b/charts/neuvector/100.0.0+up2.2.0/README.md
@@ -101,7 +101,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `ingress.kubernetes.io/protocol: https ingress.kubernetes.io/rewrite-target: /` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/blob/5.0.0/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |
 `controller.federation.managedsvc.route.termination` | Specify TLS termination for OpenShift route for Multi-cluster managed cluster service. Possible passthrough, edge, reencrypt | `passthrough` |

--- a/charts/neuvector/100.0.0+up2.2.0/questions.yaml
+++ b/charts/neuvector/100.0.0+up2.2.0/questions.yaml
@@ -204,7 +204,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and Ingress
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and Ingress
   type: enum
   label: Fed Managed service type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.1+up2.2.2/README.md
+++ b/charts/neuvector/100.0.1+up2.2.2/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.2/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.1+up2.2.2/questions.yaml
+++ b/charts/neuvector/100.0.1+up2.2.2/questions.yaml
@@ -296,7 +296,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.2+up2.2.3/README.md
+++ b/charts/neuvector/100.0.2+up2.2.3/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.2+up2.2.3/questions.yaml
+++ b/charts/neuvector/100.0.2+up2.2.3/questions.yaml
@@ -296,7 +296,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.3+up2.2.4/README.md
+++ b/charts/neuvector/100.0.3+up2.2.4/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.4/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.3+up2.2.4/questions.yaml
+++ b/charts/neuvector/100.0.3+up2.2.4/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/100.0.4+up2.4.3/README.md
+++ b/charts/neuvector/100.0.4+up2.4.3/README.md
@@ -73,7 +73,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/100.0.4+up2.4.3/questions.yaml
+++ b/charts/neuvector/100.0.4+up2.4.3/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/101.0.0+up2.2.3/README.md
+++ b/charts/neuvector/101.0.0+up2.2.3/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/101.0.0+up2.2.3/questions.yaml
+++ b/charts/neuvector/101.0.0+up2.2.3/questions.yaml
@@ -296,7 +296,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/101.0.1+up2.2.4/README.md
+++ b/charts/neuvector/101.0.1+up2.2.4/README.md
@@ -112,7 +112,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.2.4/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/101.0.1+up2.2.4/questions.yaml
+++ b/charts/neuvector/101.0.1+up2.2.4/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.0+up2.4.2/README.md
+++ b/charts/neuvector/102.0.0+up2.4.2/README.md
@@ -72,7 +72,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.2/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.0+up2.4.2/questions.yaml
+++ b/charts/neuvector/102.0.0+up2.4.2/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/neuvector/102.0.1+up2.4.3/README.md
+++ b/charts/neuvector/102.0.1+up2.4.3/README.md
@@ -73,7 +73,7 @@ Parameter | Description | Default | Notes
 `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 `controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
-`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
+`controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
 `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
 `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 `controller.federation.managedsvc.route.host` | Set OpenShift route host for manageed service | `nil` |

--- a/charts/neuvector/102.0.1+up2.4.3/questions.yaml
+++ b/charts/neuvector/102.0.1+up2.4.3/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/charts/rancher-monitoring/9.4.200/values.yaml
+++ b/charts/rancher-monitoring/9.4.200/values.yaml
@@ -1915,7 +1915,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/charts/rancher-monitoring/9.4.201/values.yaml
+++ b/charts/rancher-monitoring/9.4.201/values.yaml
@@ -1891,7 +1891,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/charts/rancher-monitoring/9.4.202/values.yaml
+++ b/charts/rancher-monitoring/9.4.202/values.yaml
@@ -1893,7 +1893,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/charts/rancher-monitoring/9.4.203/values.yaml
+++ b/charts/rancher-monitoring/9.4.203/values.yaml
@@ -1893,7 +1893,7 @@ prometheus:
     minAvailable: 1
     maxUnavailable: ""
 
-# Ingress exposes thanos sidecar outside the clsuter
+# Ingress exposes thanos sidecar outside the cluster
   thanosIngress:
     enabled: false
     annotations: {}

--- a/packages/neuvector/generated-changes/overlay/questions.yaml
+++ b/packages/neuvector/generated-changes/overlay/questions.yaml
@@ -290,7 +290,7 @@ questions:
     - "LoadBalancer"
 - variable: controller.federation.managedsvc.type
   default: ""
-  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master clsuter. Possible values include NodePort, LoadBalancer and ClusterIP
+  description: Multi-cluster managed cluster service type. If specified, the deployment will be managed by the master cluster. Possible values include NodePort, LoadBalancer and ClusterIP
   type: enum
   label: Fed Managed Service Type
   group: "Service Configuration"

--- a/packages/neuvector/generated-changes/patch/README.md.patch
+++ b/packages/neuvector/generated-changes/patch/README.md.patch
@@ -5,7 +5,7 @@
  `controller.affinity` | controller affinity rules  | ... | spread controllers to different nodes |
  `controller.tolerations` | List of node taints to tolerate | `nil` |
 -`controller.resources` | Add resources requests and limits to controller deployment | `{}` | see examples in [values.yaml](values.yaml)
-+`controller.resources` | Add resources requests and limits to controller deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`controller.resources` | Add resources requests and limits to controller deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `controller.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
  `controller.disruptionbudget` | controller PodDisruptionBudget. 0 to disable. Recommended value: 2. | `0` |
  `controller.priorityClassName` | controller priorityClassName. Must exist prior to helm deployment. Leave empty to disable. | `nil` |
@@ -14,8 +14,8 @@
  `controller.federation.mastersvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
  `controller.federation.mastersvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 -`controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](values.yaml)
-+`controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
- `controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed clsuter. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
++`controller.federation.mastersvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
+ `controller.federation.managedsvc.type` | Multi-cluster managed cluster service type. If specified, the deployment will be managed by the managed cluster. Possible values include NodePort, LoadBalancer and ClusterIP. | `nil` |
  `controller.federation.managedsvc.annotations` | Add annotations to Multi-cluster managed cluster REST API service | `{}` |
  `controller.federation.managedsvc.route.enabled` | If true, create a OpenShift route to expose the Multi-cluster managed cluster service | `false` |
 @@ -88,14 +88,14 @@
@@ -23,7 +23,7 @@
  `controller.federation.managedsvc.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
  `controller.federation.managedsvc.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 -`controller.federation.managedsvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](values.yaml)
-+`controller.federation.managedsvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`controller.federation.managedsvc.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `controller.ingress.enabled` | If true, create ingress for rest api, must also set ingress host value | `false` | enable this if ingress controller is installed
  `controller.ingress.tls` | If true, TLS is enabled for controller rest api ingress service |`false` | If set, the tls-host used is the one set with `controller.ingress.host`.
  `controller.ingress.host` | Must set this host value if ingress is enabled | `nil` |
@@ -31,7 +31,7 @@
  `controller.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
  `controller.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations.
 -`controller.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](values.yaml)
-+`controller.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`controller.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `controller.configmap.enabled` | If true, configure NeuVector global settings using a ConfigMap | `false`
  `controller.configmap.data` | NeuVector configuration in YAML format | `{}`
  `controller.secret.enabled` | If true, configure NeuVector global settings using secrets | `false`
@@ -40,7 +40,7 @@
  `enforcer.env` | User-defined environment variables for enforcers. | `[]` |
  `enforcer.tolerations` | List of node taints to tolerate | `- effect: NoSchedule`<br>`key: node-role.kubernetes.io/master` | other taints can be added after the default
 -`enforcer.resources` | Add resources requests and limits to enforcer deployment | `{}` | see examples in [values.yaml](values.yaml)
-+`enforcer.resources` | Add resources requests and limits to enforcer deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`enforcer.resources` | Add resources requests and limits to enforcer deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `manager.enabled` | If true, create manager | `true` |
  `manager.image.repository` | manager image repository | `neuvector/manager` |
  `manager.image.hash` | manager image hash in the format of sha256:xxxx. If present it overwrites the image tag value. | |
@@ -49,7 +49,7 @@
  `manager.svc.type` | set manager service type for native Kubernetes | `NodePort`;<br>if it is OpenShift platform or ingress is enabled, then default is `ClusterIP` | set to LoadBalancer if using cloud providers, such as Azure, Amazon, Google
  `manager.svc.loadBalancerIP` | if manager service type is LoadBalancer, this is used to specify the load balancer's IP | `nil` |
 -`manager.svc.annotations` | Add annotations to manager service | `{}` | see examples in [values.yaml](values.yaml)
-+`manager.svc.annotations` | Add annotations to manager service | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`manager.svc.annotations` | Add annotations to manager service | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `manager.route.enabled` | If true, create a OpenShift route to expose the management console service | `true` |
  `manager.route.host` | Set OpenShift route host for management console service | `nil` |
  `manager.route.termination` | Specify TLS termination for OpenShift route for management console service. Possible passthrough, edge, reencrypt | `passthrough` |
@@ -58,11 +58,11 @@
  `manager.ingress.ingressClassName` | To be used instead of the ingress.class annotation if an IngressClass is provisioned | `""` |
  `manager.ingress.path` | Set ingress path |`/` | If set, it might be necessary to set a rewrite rule in annotations. Currently only supports `/`
 -`manager.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](values.yaml)
-+`manager.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`manager.ingress.annotations` | Add annotations to ingress to influence behavior | `nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `manager.ingress.tls` | If true, TLS is enabled for manager ingress service |`false` | If set, the tls-host used is the one set with `manager.ingress.host`.
  `manager.ingress.secretName` | Name of the secret to be used for TLS-encryption | `nil` | Secret must be created separately (Let's encrypt, manually)
 -`manager.resources` | Add resources requests and limits to manager deployment | `{}` | see examples in [values.yaml](values.yaml)
-+`manager.resources` | Add resources requests and limits to manager deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml)
++`manager.resources` | Add resources requests and limits to manager deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml)
  `manager.affinity` | manager affinity rules  | `{}` |
  `manager.tolerations` | List of node taints to tolerate | `nil` |
  `manager.nodeSelector` | Enable and specify nodeSelector labels | `{}` |
@@ -71,7 +71,7 @@
  `cve.scanner.replicas` | external scanner replicas | `3` |
  `cve.scanner.dockerPath` | the remote docker socket if CI/CD integration need scan images before they are pushed to the registry | `nil` |
 -`cve.scanner.resources` | Add resources requests and limits to scanner deployment | `{}` | see examples in [values.yaml](values.yaml) |
-+`cve.scanner.resources` | Add resources requests and limits to scanner deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.4.3/charts/core/values.yaml) |
++`cve.scanner.resources` | Add resources requests and limits to scanner deployment | `{}` | see examples in [values.yaml](https://github.com/neuvector/neuvector-helm/tree/2.6.2/charts/core/values.yaml) |
  `cve.scanner.affinity` | scanner affinity rules  | `{}` |
  `cve.scanner.tolerations` | List of node taints to tolerate | `nil` |
  `cve.scanner.nodeSelector` | Enable and specify nodeSelector labels | `{}` |


### PR DESCRIPTION
Fix typo "clsuter" to "cluster" in rancher/charts in the dev-v2.7 branch
Used gsed (macos) `grep -RiIl 'clsuter' | xargs gsed -i 's/clsuter/cluster/g'`