### PR TITLE
Regsync workflow and dependencies refactor

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -5,43 +5,74 @@
 name: Generate-Regsync-Config
 
 on:
-  pull_request_review:
-    types: [submitted, edited]
+  pull_request_target:
+    types:
+      - labeled
 
 jobs:
+  onLabelAndApproval:
+    if: github.event.label.name == 'regsync-ready' && startsWith(github.event.pull_request.base.ref, 'release-v')
+    runs-on: ubuntu-latest
+    outputs:
+      is_approved: ${{ steps.check-approval.outputs.approved }}
+    steps:
+      - name: Check if PR is approved
+        id: check-approval
+        run: |
+          IS_APPROVED=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --jq '[.[] | select(.state == "APPROVED")] | length')
+          if [[ "$IS_APPROVED" -gt 0 ]]; then
+            echo "::set-output name=approved::true"
+          else
+            echo "::set-output name=approved::false"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
-    if: github.event.review.state == 'approved' && github.event.pull_request.base.ref == 'release-v2.7'
+    needs: onLabelAndApproval
+    if: needs.onLabelAndApproval.outputs.is_approved == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout 
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PUSH_TOKEN }} 
+
+      - name: Set-up Ruby 3.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2' # Not needed with a .ruby-version file
 
       # Need to remove export version once rancher/charts gets the latest version 
-      # of charts-build-script binary.   
-      - name: Generate RegSync & Commit
+      # of charts-build-script binary.
+      # Test removal of regsync.yaml, commit and push before regenerating it
+      - name: Generate RegSync
         run: |
+          echo ${{ secrets.PUSH_TOKEN }} | gh auth login --with-token
           gh pr checkout ${{ github.event.pull_request.number }}
+          git config --global user.email "${{ secrets.USER_GITHUB }}"
+          git config --global user.name "rancherbot"
           export CHARTS_BUILD_SCRIPT_VERSION=v0.4.2 
           make pull-scripts
           make regsync
-          git add regsync.yaml
-          git config --global user.name "Github Action RegSync"
-          git config --global user.email "github@action.com"
-          git commit -m "Updating regsync.yaml"
-          git push
-        env:
-          GH_TOKEN: ${{ github.token }}
-   
+
+      - name: Commit files
+        run: |
+            git add regsync.yaml
+            git commit -m "Updating resync.yaml"
+            git branch
+            git push
+
       - name: Install Regsync
         run: |
           curl --silent --fail --location --output regsync https://github.com/regclient/regclient/releases/download/v0.5.1/regsync-linux-amd64
           chmod +x regsync
 
       - name: Sync Images to Registry
-          # time ./regsync once --config regsync.yaml
         run: |
           head regsync.yaml
           ruby ./regsync-split.rb
-          time find regsync -type f -name regsync.yaml -print -exec time regsync once --config '{}' ';'
+          time find regsync -type f -name split-regsync.yaml -print -exec time regsync once --config '{}' ';'
         env:
           REGISTRY_ENDPOINT: ${{ secrets.REGISTRY_ENDPOINT }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}

--- a/regsync-split.rb
+++ b/regsync-split.rb
@@ -1,24 +1,24 @@
 #! /usr/bin/env ruby
-​
+
 require "json"
 require "pathname"
 require "yaml"
-​
+
 pwd = Pathname(Dir.pwd)
-​
+
 regsync = YAML.load((pwd + "regsync.yaml").read)
-​
+
 regsync["sync"].sum do |sync|
   sync["tags"]["allow"].count
 end.then do |sum|
   puts "total tags to consider: #{sum}"
 end
-​
+
 regsync["sync"].each do |sync|
   regsync.merge("sync" => [sync]).then do |regsync|
-    (pwd + "regsync" + sync["source"]).then do |dir|
+    (pwd + "split-regsync" + sync["source"]).then do |dir|
       dir.mkpath
-      (dir + "regsync.yaml").write(YAML.dump(regsync))
+      (dir + "split-regsync.yaml").write(YAML.dump(regsync))
     end
   end
 end

--- a/scripts/check-release-yaml
+++ b/scripts/check-release-yaml
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if the file is empty
+if [[ ! -s release.yaml ]]; then
+  echo "release.yaml is empty!"
+  exit 0
+fi
+
 yq -i release.yaml
 
 if [[ -n $(git status --porcelain release.yaml) ]]; then


### PR DESCRIPTION
- Moves regsync-split to the root folder and changes the split file prefix;
- Adds a check for an empty release.yaml before checking the style;
- Changes the regsync workflow trigger to protect stored credentials;
- Standardizes the pull request workflow.