### PR TITLE
Adding pull_request_target trigger to pull request workflow

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,7 +1,7 @@
 name: CI-pullrequest
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - dev-v*
       - release-v*
@@ -11,7 +11,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout base branch
+        uses: actions/checkout@v3
+
+      - name: Checkout PR
+        run: gh pr checkout ${{ github.event.pull_request.number }}
+        env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checkout into branch
         run: git checkout -b staging-pr-workflow


### PR DESCRIPTION
The pull_request_target workflow makes the actions/checkout step checkout the PR base branch. That's why checking out the PR is necessary so I created an extra step to do that.