### PR TITLE
Fixing regsync action

### DIFF
--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -70,9 +70,10 @@ jobs:
 
       - name: Sync Images to Registry
         run: |
+          export PATH=$PATH:$(pwd)
           head regsync.yaml
           ruby ./regsync-split.rb
-          time find regsync -type f -name split-regsync.yaml -print -exec time regsync once --config '{}' ';'
+          time find split-regsync -type f -name split-regsync.yaml -print -exec time regsync once --config '{}' ';'
         env:
           REGISTRY_ENDPOINT: ${{ secrets.REGISTRY_ENDPOINT }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}


### PR DESCRIPTION
- Adds the current working directory to the path so that the regsync executable is visible to the OS;
- changesfind command to loop through the split-regsync folder.