### PR TITLE
Fixing regsync-config action

### DIFF
--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -68,6 +68,7 @@ jobs:
           export PATH=$PATH:$(pwd)
           head regsync.yaml
           ruby ./regsync-split.rb
+          tree ./split-regsync
           time find split-regsync -type f -name split-regsync.yaml -print -exec time regsync once --config '{}' ';'
         env:
           REGISTRY_ENDPOINT: ${{ secrets.REGISTRY_ENDPOINT }}

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -43,16 +43,12 @@ jobs:
         with:
           ruby-version: '3.2' # Not needed with a .ruby-version file
 
-      # Need to remove export version once rancher/charts gets the latest version 
-      # of charts-build-script binary.
-      # Test removal of regsync.yaml, commit and push before regenerating it
       - name: Generate RegSync
         run: |
           echo ${{ secrets.PUSH_TOKEN }} | gh auth login --with-token
           gh pr checkout ${{ github.event.pull_request.number }}
           git config --global user.email "${{ secrets.USER_GITHUB }}"
           git config --global user.name "rancherbot"
-          export CHARTS_BUILD_SCRIPT_VERSION=v0.4.2 
           make pull-scripts
           make regsync
 

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -70,9 +70,10 @@ jobs:
 
       - name: Sync Images to Registry
         run: |
+          export PATH=$PATH:$(pwd)
           head regsync.yaml
           ruby ./regsync-split.rb
-          time find regsync -type f -name split-regsync.yaml -print -exec time regsync once --config '{}' ';'
+          time find split-regsync -type f -name split-regsync.yaml -print -exec time regsync once --config '{}' ';'
         env:
           REGISTRY_ENDPOINT: ${{ secrets.REGISTRY_ENDPOINT }}
           REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -56,7 +56,6 @@ jobs:
         run: |
             git add regsync.yaml
             git commit -m "Updating resync.yaml"
-            git branch
             git push
 
       - name: Install Regsync

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -52,11 +52,22 @@ jobs:
           make pull-scripts
           make regsync
 
+      - name: Check for modifications in regsync.yaml
+        id: check_changes
+        run: |
+            git diff --quiet regsync.yaml || echo "::set-output name=changed::true"
+
       - name: Commit files
+        if: steps.check_changes.outputs.changed == 'true'
         run: |
             git add regsync.yaml
             git commit -m "Updating resync.yaml"
             git push
+
+      - name: No changes in regsync.yaml
+        if: steps.check_changes.outputs.changed != 'true'
+        run: |
+            echo "regsync.yaml is the same"
 
       - name: Install Regsync
         run: |

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -4,6 +4,8 @@ creds:
 - registry: '{{ env "REGISTRY_ENDPOINT" }}'
   user: '{{ env "REGISTRY_USERNAME" }}'
   pass: '{{ env "REGISTRY_PASSWORD" }}'
+  reqConcurrent: 10
+  reqPerSec: 50
 defaults:
   mediaTypes:
   - application/vnd.docker.distribution.manifest.v2+json
@@ -535,7 +537,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v1.18.0
     - v1.19.0
     - v1.2.1
@@ -560,7 +561,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v2.1.0
     - v2.2.1
     - v2.3.0
@@ -578,7 +578,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v2.1.0
     - v2.2.1
     - v2.3.0
@@ -1344,7 +1343,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v3.2.0
     - v3.3.0
     - v3.4.0
@@ -1355,7 +1353,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v2.3.0
     - v2.5.0
     - v2.5.1
@@ -1366,7 +1363,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v2.2.0
     - v3.0.0
     - v3.1.0
@@ -1378,7 +1374,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v1.3.0
     - v1.4.0
     - v1.6.0
@@ -1388,7 +1383,6 @@ sync:
   type: repository
   tags:
     allow:
-    - latest
     - v2.4.0
     - v2.6.0
     - v2.7.0


### PR DESCRIPTION
- Adds the current working directory to the path so that the regsync executable is visible to the OS;
- Changes find command to loop through the split-regsync folder;
- Let CI grab the latest version of build scripts while running the regsync-config action.