### PR TITLE
[dev-v2.8] Removing PR checkout in regsync.yaml

### DIFF
--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -41,14 +41,15 @@ jobs:
       - name: Set-up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2' # Not needed with a .ruby-version file
+          ruby-version: '3.2'
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${{ secrets.USER_GITHUB }}"
+          git config --global user.name "rancherbot"
 
       - name: Generate RegSync
         run: |
-          echo ${{ secrets.PUSH_TOKEN }} | gh auth login --with-token
-          gh pr checkout ${{ github.event.pull_request.number }}
-          git config --global user.email "${{ secrets.USER_GITHUB }}"
-          git config --global user.name "rancherbot"
           make pull-scripts
           make regsync
 


### PR DESCRIPTION
We use `gh pr checkout ${{ github.event.pull_request.number }}` to check out the PR base branch plus the PR changes. After some testing, we found out that the actions/checkout step does exactly that. This PR removes `gh pr checkout ${{ github.event.pull_request.number }}` since `actions/checkout` runs in a previous step.