### PR TITLE
adding step before script to check if packages were modified

### DIFF
--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -9,11 +9,25 @@ on:
 jobs:
   validation-comment:
     name: Make validation comment on PR
-    runs-on: ubuntu-latest
+    runs_on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Check if /packages has been modified
+        id: check
+        run: |
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep '^packages/'
+          then
+            echo "::set-output name=modified::true"
+          else
+            echo "::set-output name=modified::false"
+          fi
+
       - name: Make validation comment
         uses: actions/github-script@v4
+        if: steps.check.outputs.modified == 'true'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -25,7 +39,7 @@ jobs:
               `## Validation steps
               - Ensure all container images have repository and tag on the same level to ensure that all container images are included in rancher-images.txt which are used by airgap customers.
               <pre>
-              Ex:- 
+              Ex:-
                 longhorn-controller:
                   repository: rancher/hardened-sriov-cni
                   tag: v2.6.3-build20230913


### PR DESCRIPTION
## Problem
The rancher/charts repository has some [CI pipelines](https://github.com/rancher/charts/tree/dev-v2.9/.github/workflows) defined. At this moment, when someone pushes a commit, there is a checker (Validation Comment) to remind of some manual actions.

This checker should be enabled only if the pull request modifies the `/packages` folder.

## Solution
Add "Checkout code" step to check out the repository code so that it can be examined in the next step.

The "Check if /packages has been modified" step uses git diff to get a list of files that have been modified in the pull request. It then uses grep to check if any of the modified files are in the /packages directory. If they are, it sets an output variable modified to true.