### PR TITLE
Restrict when to show the validation suggestion

### DIFF
--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev-v*
       - release-v*
+    paths:
+      - 'assets/**'
+      - 'charts/**'
+      - 'packages/**'
 
 jobs:
   validation-comment:
@@ -25,7 +29,7 @@ jobs:
               `## Validation steps
               - Ensure all container images have repository and tag on the same level to ensure that all container images are included in rancher-images.txt which are used by airgap customers.
               <pre>
-              Ex:- 
+              Ex:-
                 longhorn-controller:
                   repository: rancher/hardened-sriov-cni
                   tag: v2.6.3-build20230913


### PR DESCRIPTION
## Problem
The `rancher/charts` repository has some [CI pipelines](https://github.com/rancher/charts/tree/dev-v2.9/.github/workflows) defined. At this moment, when someone pushes a commit, there is a checker (Validation Comment) to remind of some manual actions.

This checker should be enabled only if the pull request modifies the `/packages`, `/assets` and `/charts` folder.

## Solution
Add "Checkout code" step to check out the repository code so that it can be examined in the next step.

The "Check if /packages has been modified" step lists all the modified files in all commits.
If any of these files has the prefix with the names of the targeted folders, that is because we are editing  `/packages`, `/assets` or `/charts`  folder. 

## Manual testing

I tested with simulated events using an `events.json` file and **act** package that is not defined in this PR.
These are the values that I tested:

`events.json for this PR`: 
- this should not create an automatic comment) (OK)
```json
{
    "pull_request": {
        "number": 3441,
        "head": {
            "ref": "cicd-restriction-validation-suggestion",
            "sha": "ac670b061d60e31fb56757f3f0d594588d667c5a"
        }
    },
    "repository": {
        "owner": {
            "login": "nicholasSUSE"
        },
        "name": "charts"
    }
}
```

`events.json for the following PR`: https://github.com/rancher/charts/pull/3453
- This should create an automatic comment (OK)
- The comment was deleted after the test was concluded.
```json
{
    "pull_request": {
        "number": 3453,
        "head": {
            "ref": "emergency-fleet-bump-for-qa",
            "sha": "4d535ff39364e8e964fa9a067aae26e4ccf84cb7"
        }
    },
    "repository": {
        "owner": {
            "login": "nicholasSUSE"
        },
        "name": "charts"
    }
}