### PR TITLE
Bump grafana image

### DIFF
--- a/packages/rancher-monitoring/rancher-grafana/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-monitoring/rancher-grafana/generated-changes/patch/values.yaml.patch
@@ -18,7 +18,7 @@
 +  repository: rancher/mirrored-grafana-grafana
    # Overrides the Grafana image tag whose default is the chart appVersion
 -  tag: ""
-+  tag: 9.1.5
++  tag: 10.1.0
    sha: ""
    pullPolicy: IfNotPresent
  


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

Monitoring uses an older version of the grafana image than we should be (`9.1.5` instead of `10.1.0`)

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

Monitoring still works as expected and metrics flow and are displayed as expected.

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

## Backporting considerations
<!-- Does this change need to be backported to other versions? If so, which versions should it be backported to? -->

Should backport to 2.8