### PR TITLE
Bump wrangler to version 1.0.1

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/rancher/hull v0.0.0-20230424152137-627ef5347afd
-	github.com/rancher/wrangler v1.0.0
+	github.com/rancher/wrangler v1.0.1
 	github.com/stretchr/testify v1.8.1
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -651,6 +651,8 @@ github.com/rancher/lasso v0.0.0-20220303220127-8cf5555ec03c h1:TyDYClPPCN2rWM97g
 github.com/rancher/lasso v0.0.0-20220303220127-8cf5555ec03c/go.mod h1:T6WoUopOHBWTGjnphruTJAgoZ+dpm6llvn6GDYaa7Kw=
 github.com/rancher/wrangler v1.0.0 h1:K+GHMhkpgcGIfYgOX9RKdEEiM8o3WjFpI2U0ljxy+bg=
 github.com/rancher/wrangler v1.0.0/go.mod h1:TR0R07P5oU6T2bO+6eOX0jcFvKy+zoDd6u+PZ2mHJKg=
+github.com/rancher/wrangler v1.0.1 h1:toavOGC1+eaZufcOJD6UyIf+aGM4rlJjPqm511Ls4sI=
+github.com/rancher/wrangler v1.0.1/go.mod h1:Blhan9LdaIJjC9w+xGteSrHHEiIFIdPEHEMrtx82dPk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
No testing was done. This is because the changes going from `v1.0.0` to `v1.0.1` in wrangler only concern `pkg/apply` and `pkg/git`, and we only use `pkg/relatedresource`.


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
Unless I'm missing something, the probability of a regression is zero.

## Backporting considerations
<!-- Does this change need to be backported to other versions? If so, which versions should it be backported to? -->

- Backports are not necessary because `tests/` does not exist on `*-v2.6` branches.
- Forward ports are not necessary because `tests/` uses wrangler v1.1.1 on `*-v2.8` and `*-v2.9` branches.