### PR TITLE
[release-v2.9] Restrict when to show the validation suggestion 

### DIFF
--- a/.github/workflows/validation-check.yaml
+++ b/.github/workflows/validation-check.yaml
@@ -10,7 +10,26 @@ jobs:
     if: startsWith(github.event.pull_request.base.ref, 'dev-v') || startsWith(github.event.pull_request.base.ref, 'release-v')
     runs-on: ubuntu-latest
     steps:
+      - name: Check for modifications in specified folders
+        id: check-modifications
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Get the list of files modified in the PR
+            const files = await github.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            // Check if any of the modified files are in the specified folders
+            const modifiedSpecifiedFolders = files.data.some(file => file.filename.startsWith('assets/') || file.filename.startsWith('charts/') || file.filename.startsWith('packages/'));
+
+            return modifiedSpecifiedFolders;
+
       - name: Check for positive reaction on bot's latest validation comment
+        if: steps.check-modifications.outputs.result == 'true'
         uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - dev-v*
       - release-v*
+    paths:
+      - 'assets/**'
+      - 'charts/**'
+      - 'packages/**'
 
 jobs:
   validation-comment:
@@ -25,7 +29,7 @@ jobs:
               `## Validation steps
               - Ensure all container images have repository and tag on the same level to ensure that all container images are included in rancher-images.txt which are used by airgap customers.
               <pre>
-              Ex:- 
+              Ex:-
                 longhorn-controller:
                   repository: rancher/hardened-sriov-cni
                   tag: v2.6.3-build20230913


### PR DESCRIPTION
This was just a `cherry-pick` from Pull Request: https://github.com/rancher/charts/pull/3441

- Realized an extra step was needed since we can't use the `paths` filter on `pull_request_review` events. 
- Added extra logic using JavaScript to check the modified files and halt job execution. 
