### PR TITLE
[dev-v2.9] adding paths filtering code to validation-check

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout PR
         run: gh pr checkout ${{ github.event.pull_request.number }}
@@ -28,7 +28,7 @@ jobs:
       - name: Check release.yaml
         run: sudo make check-release-yaml
 
-      - name: Validate 
+      - name: Validate
         run: sudo make validate
 
   check-images:
@@ -36,14 +36,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout PR
         run: gh pr checkout ${{ github.event.pull_request.number }}
         env:
             GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check container images 
+      - name: Check container images
         run: make check-images
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout PR
         run: gh pr checkout ${{ github.event.pull_request.number }}
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout base branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Checkout PR
         run: gh pr checkout ${{ github.event.pull_request.number }}

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -1,5 +1,5 @@
-# Generate-Regsync-Config action will run for every PR into release-v* branch only after an approval is given 
-# It will run make target to generate regsync file and add a commit to the PR updating the regsync file. 
+# Generate-Regsync-Config action will run for every PR into release-v2.9 branch only after an approval is given
+# It will run make target to generate regsync file and add a commit to the PR updating the regsync file.
 # It will then install and run regsync client and do the prime image mirroring.
 
 name: Generate-Regsync-Config
@@ -33,10 +33,10 @@ jobs:
     if: needs.onLabelAndApproval.outputs.is_approved == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout 
-        uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.PUSH_TOKEN }} 
+          token: ${{ secrets.PUSH_TOKEN }}
 
       - name: Set-up Ruby 3.2
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/validation-check.yaml
+++ b/.github/workflows/validation-check.yaml
@@ -12,12 +12,12 @@ jobs:
     steps:
       - name: Check for modifications in specified folders
         id: check-modifications
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Get the list of files modified in the PR
-            const files = await github.pulls.listFiles({
+            const files = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number
@@ -30,12 +30,12 @@ jobs:
 
       - name: Check for positive reaction on bot's latest validation comment
         if: steps.check-modifications.outputs.result == 'true'
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             // Get comments on the PR
-            const comments = await github.issues.listComments({
+            const comments = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
@@ -48,7 +48,7 @@ jobs:
             const latestValidationComment = sortedComments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.startsWith("## Validation steps"));
 
             if (latestValidationComment) {
-              const reactions = await github.reactions.listForIssueComment({
+              const reactions = await github.rest.reactions.listForIssueComment({
                 comment_id: latestValidationComment.id,
                 owner: context.repo.owner,
                 repo: context.repo.repo

--- a/.github/workflows/validation-check.yaml
+++ b/.github/workflows/validation-check.yaml
@@ -10,7 +10,26 @@ jobs:
     if: startsWith(github.event.pull_request.base.ref, 'dev-v') || startsWith(github.event.pull_request.base.ref, 'release-v')
     runs-on: ubuntu-latest
     steps:
+      - name: Check for modifications in specified folders
+        id: check-modifications
+        uses: actions/github-script@v4
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            // Get the list of files modified in the PR
+            const files = await github.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            // Check if any of the modified files are in the specified folders
+            const modifiedSpecifiedFolders = files.data.some(file => file.filename.startsWith('assets/') || file.filename.startsWith('charts/') || file.filename.startsWith('packages/'));
+
+            return modifiedSpecifiedFolders;
+
       - name: Check for positive reaction on bot's latest validation comment
+        if: steps.check-modifications.outputs.result == 'true'
         uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -17,11 +17,11 @@ jobs:
     permissions: write-all
     steps:
       - name: Make validation comment
-        uses: actions/github-script@v4
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Problem

Our previous solution created another problem for the `validation-check workflow`. Sometimes the validation was required but the previous `validation-comment workflow` was not run because of the filters.

## Solution

Add the same filters for (`assets/`, `packages/`, `charts/`) directories to `validation-check workflow`. This workflow uses a different type of `github event` so the `paths` directive was not enabled for use. The solution implements the same functionality with `javascript` injected code in the workflow. 

## Updated Scope of PR

As discussed below we updated:
- `actions/github-script@v4` → `actions/github-script@v7`
- `actions/checkout@v3` → `actions/checkout@v4`

The main reason:  Warnings about the deprecation of old Node.js versions being used since Github Actions is now using an updated version. 

### Manual Testing

All changes were manually tested by:

1. On Forked Repository merging a branch with the changes
2. Creating a new `release-v-test` branch from the recently created one. 
3. Creating a Pull Request with changes (branch: `cicd-test`) that will trigger the workflows and ensure it is working. 

One of the closed Pull Requests in the forked repository used for testing: https://github.com/nicholasSUSE/charts/pull/14

#### Some needed changes after the update:

- https://github.com/marketplace/actions/github-script
- https://octokit.github.io/rest.js/v20

Javascript code like the following example: 
```
            const files = await github.pulls.listFiles({
```

Was updated to:
```
            const files = await github.rest.pulls.listFiles({
```

Because of changes in the `octokit` stated above in the bullet points. 