### PR TITLE
add missing annotation for harvester-cloud-provider

### DIFF
--- a/charts/harvester-cloud-provider/102.0.2+up0.2.3/Chart.yaml
+++ b/charts/harvester-cloud-provider/102.0.2+up0.2.3/Chart.yaml
@@ -4,6 +4,7 @@ annotations:
   catalog.cattle.io/kube-version: '>= 1.23.0-0 < 1.28.0-0'
   catalog.cattle.io/namespace: kube-system
   catalog.cattle.io/os: linux
+  catalog.cattle.io/permits-os: linux
   catalog.cattle.io/rancher-version: '>= 2.7.0-0 < 2.8.0-0'
   catalog.cattle.io/release-name: harvester-cloud-provider
   catalog.cattle.io/ui-component: harvester-cloud-provider


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

## Problem
catalog.cattle.io/permits-os annotation is missing in harvester-cloud-provider 102.0.2+up0.2.3
## Solution
added it

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

## Backporting considerations
<!-- Does this change need to be backported to other versions? If so, which versions should it be backported to? -->