### PR TITLE
[dev-v2.9] Update Rancher-monitoring jobs.yaml for error handling

### DIFF
--- a/charts/rancher-monitoring-crd/104.0.2+up45.31.1/templates/jobs.yaml
+++ b/charts/rancher-monitoring-crd/104.0.2+up45.31.1/templates/jobs.yaml
@@ -51,7 +51,7 @@ spec:
             echo "Applying CRDs...";
             mkdir -p /etc/crd;
             base64 -d /etc/config/crd-manifest.tgz.b64 | tar -xzv -C /etc/crd;
-            kubectl replace -Rf /etc/crd || kubectl create -Rf /etc/crd;
+            kubectl replace -Rf /etc/crd || kubectl create -Rf /etc/crd || exit 255;
 
             echo "Waiting for CRDs to be recognized before finishing installation...";
 


### PR DESCRIPTION
## Problem
My problem is that the following line gets an error if the RBAC of the system:serviceaccount:cattle-monitoring-system:rancher-monitoring-crd-manager SA is incorrect:
```
kubectl replace -Rf /etc/crd || kubectl create -Rf /etc/crd;
```
The reason for this is that kubectl replace fails with an error code, but kubectl create can't succeed either:
```
Error from server (Forbidden): error when replacing "/etc/crd/charts/crds/crd-alertmanagerconfigs.yaml": customresourcedefinitions.apiextensions.k8s.io "alertmanagerconfigs.monitoring.coreos.com" is forbidden: User "system:serviceaccount:cattle-monitoring-system:rancher-monitoring-crd-manager" cannot update resource "customresourcedefinitions" in API group "apiextensions.k8s.io" at the cluster scope
Error from server (AlreadyExists): error when creating "/etc/crd/charts/crds/crd-alertmanagerconfigs.yaml": customresourcedefinitions.apiextensions.k8s.io "alertmanagerconfigs.monitoring.coreos.com" already exists
```
In the [earlier chart versions](https://github.com/rancher/charts/blob/1d91526e5721bbd323fdba46936f2894b7a61aa0/charts/rancher-monitoring-crd/102.0.2%2Bup40.1.2/templates/rbac.yaml#L12), the SA didn't have recreate permission. So in this scenario, the helm upgrade succeeds, but you still have the old CRDs.

## Solution
I think the simplest solution is to create another OR condition. With this trick, the pod will fail and the helm upgrade will fail as well. 
Another good approach might be something like this for checking permissions:
```
for verb in 'create' 'get' 'patch' 'delete' 'replace'; do kubectl auth can-i --as system:serviceaccount:cattle-monitoring-system:rancher-monitoring-crd-manager $verb crd || exit 255; done           
```