### PR TITLE
[release-v2.7] Updating regsync.yaml

### DIFF
--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1024,6 +1024,7 @@ sync:
     - v1.4.4
     - v1.5.1
     - v1.5.3
+    - v1.5.4
     - v1_20210422
     - v1_20210422_patch1
     - v2_20210820
@@ -1043,6 +1044,7 @@ sync:
     - v3.2.1
     - v3.4.0
     - v4.2.0
+    - v4.4.2
 - source: docker.io/rancher/mirrored-longhornio-csi-node-driver-registrar
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-csi-node-driver-registrar'
   type: repository
@@ -1052,6 +1054,7 @@ sync:
     - v2.3.0
     - v2.5.0
     - v2.7.0
+    - v2.9.2
 - source: docker.io/rancher/mirrored-longhornio-csi-provisioner
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-csi-provisioner'
   type: repository
@@ -1061,6 +1064,7 @@ sync:
     - v1.6.0-lh2
     - v2.1.2
     - v3.4.1
+    - v3.6.2
 - source: docker.io/rancher/mirrored-longhornio-csi-resizer
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-csi-resizer'
   type: repository
@@ -1071,6 +1075,7 @@ sync:
     - v1.2.0
     - v1.3.0
     - v1.7.0
+    - v1.9.2
 - source: docker.io/rancher/mirrored-longhornio-csi-snapshotter
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-csi-snapshotter'
   type: repository
@@ -1081,11 +1086,13 @@ sync:
     - v3.0.3
     - v5.0.1
     - v6.2.1
+    - v6.3.2
 - source: docker.io/rancher/mirrored-longhornio-livenessprobe
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-livenessprobe'
   type: repository
   tags:
     allow:
+    - v2.12.0
     - v2.8.0
     - v2.9.0
 - source: docker.io/rancher/mirrored-longhornio-longhorn-engine
@@ -1113,6 +1120,7 @@ sync:
     - v1.4.4
     - v1.5.1
     - v1.5.3
+    - v1.5.4
 - source: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-longhorn-instance-manager'
   type: repository
@@ -1125,6 +1133,7 @@ sync:
     - v1.4.4
     - v1.5.1
     - v1.5.3
+    - v1.5.4
     - v1_20201216
     - v1_20210621
     - v1_20210731
@@ -1161,6 +1170,7 @@ sync:
     - v1.4.4
     - v1.5.1
     - v1.5.3
+    - v1.5.4
 - source: docker.io/rancher/mirrored-longhornio-longhorn-share-manager
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-longhorn-share-manager'
   type: repository
@@ -1173,6 +1183,7 @@ sync:
     - v1.4.4
     - v1.5.1
     - v1.5.3
+    - v1.5.4
     - v1_20201204
     - v1_20210416
     - v1_20210416_patch1
@@ -1209,6 +1220,7 @@ sync:
     - v1.4.4
     - v1.5.1
     - v1.5.3
+    - v1.5.4
 - source: docker.io/rancher/mirrored-longhornio-support-bundle-kit
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-support-bundle-kit'
   type: repository
@@ -1219,6 +1231,7 @@ sync:
     - v0.0.24
     - v0.0.25
     - v0.0.27
+    - v0.0.33
 - source: docker.io/rancher/mirrored-messagebird-sachet
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-messagebird-sachet'
   type: repository


### PR DESCRIPTION
Because [rancher/charts#3611](https://github.com/rancher/charts/pull/3611) was merged before the regsync action ran, the regsync.yaml update did not happen. This PR fixes it.