### PR TITLE
[dev-v2.7.12] Un-rc rancher-backup 102.0.3+up3.1.3-rc6

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -10,10 +10,6 @@ rancher-gke-operator:
   - 102.1.0+up1.1.7-rc1
 rancher-gke-operator-crd:
   - 102.1.0+up1.1.7-rc1
-rancher-backup:
-  - 102.0.3+up3.1.3-rc6
-rancher-backup-crd:
-  - 102.0.3+up3.1.3-rc6
 rancher-cis-benchmark:
   - 4.4.0-rc2
 rancher-cis-benchmark-crd:


### PR DESCRIPTION
The rancher-backup version didn't change going from the previous release (2.7.11) to this one, so the relevant lines need to be removed from `release.yaml`.

There's no need to actually `un-rc` anything, as the final versions were released in 2.7.11.