### PR TITLE
[dev-v2.8] Fix validations script to loop over all required annotations

### DIFF
--- a/scripts/release-validation/validate-annotations.sh
+++ b/scripts/release-validation/validate-annotations.sh
@@ -12,7 +12,7 @@ git fetch ${UPSTREAM_REMOTE}
 
 # may need to use parenthesis instead of double quotes in some systems for it to work as an array
 # requiredAnnotations="catalog.cattle.io/rancher-version catalog.cattle.io/kube-version catalog.cattle.io/permits-os"
-requiredAnnotations=(catalog.cattle.io/rancher-version catalog.cattle.io/kube-version catalog.cattle.io/permits-os)
+declare -a requiredAnnotations=(catalog.cattle.io/rancher-version catalog.cattle.io/kube-version catalog.cattle.io/permits-os)
 
 for asset in $(find $ASSETS_DIR -mindepth 2 -maxdepth 2 -name "*.tgz" | sort | xargs); do
   if printf '%s\n' "${exclude[@]}" | grep -F -x ${asset} 1>/dev/null; then
@@ -62,7 +62,7 @@ for asset in $(find $ASSETS_DIR -mindepth 2 -maxdepth 2 -name "*.tgz" | sort | x
     if [[ ${key} != "annotations" ]]; then
       continue
     fi
-    for requiredAnnotation in $requiredAnnotations; do
+    for requiredAnnotation in "${requiredAnnotations[@]}"; do
       if echo ${chartContent} | grep "catalog.cattle.io/hidden" 1>/dev/null; then
         echo "Skipping checking annotation on chart with hidden annotation ${chart}"
         break


### PR DESCRIPTION
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Forward-porting [rancher/charts#2778](https://github.com/rancher/charts/pull/2778)

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

- Export the PACKAGE variable with the chart chosen to be tested. Should be an unreleased chart that's present on `release.yaml`
- Run `make prepare`
- Delete all the required annotations
- Run `make patch`
- Run `make clean`
- Run `make chart``
- Run the `validate-annotation` script
- Verify the warnings about the missing annotations that were deleted.
  - `WARN: Chart.yaml missing 'catalog.cattle.io/rancher-version'`
  - `WARN: Chart.yaml missing 'catalog.cattle.io/kube-version'`
  - `WARN: Chart.yaml missing 'catalog.cattle.io/permits-os'`