### PR TITLE
[dev-v2.9] Restrict branch creation

### DIFF
--- a/.github/workflows/enforce-branch-creation-policy.yaml
+++ b/.github/workflows/enforce-branch-creation-policy.yaml
@@ -1,0 +1,36 @@
+name: Enforce Branch Creation Policy
+
+on:
+  create:
+
+jobs:
+  enforce-branch-policy:
+    runs-on: ubuntu-latest
+    if: github.event.ref_type == 'branch'
+    steps:
+      - name: Authenticate GitHub CLI
+        run: |
+          echo "${{ secrets.TOKEN }}" | gh auth login --with-token
+
+      - name: Check if branch creator is in the allowed team
+        id: check_user
+        run: |
+          MEMBER_LOGIN_IDS=$(gh api /orgs/${{ vars.ORG_NAME }}/teams/${{ vars.TEAM_SLUG }}/members --jq '.[].login' | tr '\n' ' ')
+          echo "Team members: $MEMBER_LOGIN_IDS"
+          if [[ $MEMBER_LOGIN_IDS =~ (^|[[:space:]])"${{ github.actor }}"($|[[:space:]]) ]]; then
+            echo "User is allowed to create branches."
+            echo "is_allowed=true" >> $GITHUB_OUTPUT
+          else
+            echo "User is not allowed to create branches."
+            echo "is_allowed=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}
+
+      - name: Delete unauthorized branch
+        if: steps.check_user.outputs.is_allowed == 'false'
+        run: |
+          echo "Deleting unauthorized branch (${{ github.ref_name }}) created by ${{ github.actor }}"
+          gh api -X DELETE repos/${{ github.repository }}/git/refs/heads/${{ github.ref_name }}
+        env:
+          GH_TOKEN: ${{ secrets.TOKEN }}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ All issues must be created in the [`rancher/rancher`](https://github.com/rancher
 
 ### Making Changes
 
+General rules:
+- **Fork and Clone**: Start by forking the repository and then cloning it locally to make changes in your own copy of the project.
+- **Branch Naming**: Create a branch for your changes that is descriptive of the feature or fix you're working on. Do not create branches on this repository. There is an automation in place that will remove unauthorized branches.
+- **Commit Messages**: Write meaningful commit messages that describe the changes made in each commit. Check [`docs/validation.md`](docs/validation.md) for more information on commit messages.
+
 Since this repository uses [`rancher/charts-build-scripts`](https://github.com/rancher/charts-build-scripts), making changes to this repository involves three steps:
 1. Adding or modifying an existing `Package` tracked in the `packages/` directory. Usually involves `make prepare`, `make patch`, and `make clean`.
 2. Running `make charts` to automatically generate assets used to serve a Helm repository (`charts/`, `assets/`, and `index.yaml`) based on the contents of `packages/`.


### PR DESCRIPTION
This PR restricts the branch creation in this repository to the members of @rancher/mapps 
If a user outside the Mapps team creates a branch in this repo, it will be removed by the enforce-branch-creation-policy workflow.