### PR TITLE
adding extra options to make lifecycle-assets and inserting functiona…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ check-release-yaml:
 
 lifecycle-assets:
 	@./scripts/pull-scripts
-	@./bin/charts-build-scripts lifecycle-assets --branch-version=$(BRANCH_VERSION)
+	@./bin/charts-build-scripts lifecycle-assets --branch-version=$(BRANCH_VERSION) --debugFlag=$(DEBUG) --chart=$(CHART)
 
 TARGETS := prepare patch clean clean-cache charts list index unzip zip standardize validate template regsync check-images check-rc
 

--- a/scripts/remove-asset
+++ b/scripts/remove-asset
@@ -22,10 +22,13 @@ fi
 
 # Prune empty directories
 set +e
-rmdir charts/${CHART} >/dev/null 2>&1 
-rmdir charts >/dev/null 2>&1 
-rmdir assets/${CHART} >/dev/null 2>&1 
-rmdir assets >/dev/null 2>&1 
+rmdir charts/${CHART} >/dev/null 2>&1
+rmdir charts >/dev/null 2>&1
+rmdir assets/${CHART} >/dev/null 2>&1
+rmdir assets >/dev/null 2>&1
 set -e
+
+touch release.yaml
+yq e -i ".${CHART} = ((.${CHART} + [\"${VERSION}\"]) | unique)" release.yaml
 
 make index


### PR DESCRIPTION
There were some lacking optional argument flags for the script execution. 
- debugFlag
- chart 

Also, there was a mistake that was fixed.
`make remove` needs to add the removed chart to the `release.yaml` otherwise the ci for the PR will break. 