### PR TITLE
[dev-v2.9] Update scripts/pull-scripts to use new release scheme

### DIFF
--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -12,35 +12,42 @@ if ls ../bin/charts-build-scripts 1>/dev/null 2>/dev/null; then
     fi
 fi
 
-echo "Pulling in charts-build-scripts version ${CHARTS_BUILD_SCRIPTS_REPO}@${CHARTS_BUILD_SCRIPT_VERSION}"
+echo "Downloading charts-build-scripts version ${CHARTS_BUILD_SCRIPTS_REPO}@${CHARTS_BUILD_SCRIPT_VERSION}"
 
 rm -rf ../bin
 cd ..
 
 mkdir -p bin
-ARCH=$(go version | cut -d' ' -f4 | cut -d'/' -f1)
-if [[ ${ARCH} == "linux" ]]; then
-    BINARY_NAME=charts-build-scripts
+OS=$(go version | cut -d' ' -f4 | cut -d'/' -f1)
+ARCH=$(go version | cut -d' ' -f4 | cut -d'/' -f2)
+
+if [[ "$OS" == "windows" ]]; then
+    BINARY_NAME="charts-build-scripts_${OS}_${ARCH}.exe"
 else
-    BINARY_NAME=charts-build-scripts-${ARCH}
+    BINARY_NAME="charts-build-scripts_${OS}_${ARCH}"
 fi
 curl -s -L ${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME} --output bin/charts-build-scripts
-if ! [[ -f bin/charts-build-scripts ]] || [[ $(cat bin/charts-build-scripts) == "Not Found" ]]; then 
-    rm bin/charts-build-scripts; 
-    
-    # Fall back to old process
-    echo "Building binary locally..."
-    rm -rf charts-build-scripts
-    git clone --depth 1 --branch $CHARTS_BUILD_SCRIPT_VERSION $CHARTS_BUILD_SCRIPTS_REPO charts-build-scripts 2>/dev/null
 
-    cd charts-build-scripts
-    VERSION_OVERRIDE=${CHARTS_BUILD_SCRIPT_VERSION} ./scripts/build
-    mv bin ..
-    cd ..
-    rm -rf charts-build-scripts
-else
-    echo "${BINARY_NAME} => ./bin/charts-build-scripts"
+# Fall back to binary name format from old release scheme
+if ! [[ -f bin/charts-build-scripts ]] || [[ $(cat bin/charts-build-scripts) == "Not Found" ]]; then 
+    echo "Falling back to old binary name format..."
+    rm bin/charts-build-scripts; 
+    if [[ ${OS} == "linux" ]]; then
+        BINARY_NAME=charts-build-scripts
+    else
+        BINARY_NAME=charts-build-scripts-${ARCH}
+    fi
+    curl -s -L ${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME} --output bin/charts-build-scripts
 fi
+
+# If falling back to old binary name format did not work, fail
+if ! [[ -f bin/charts-build-scripts ]] || [[ $(cat bin/charts-build-scripts) == "Not Found" ]]; then
+    echo "Failed to find charts-build-scripts binary"
+    rm bin/charts-build-scripts;
+    exit 1
+fi
+
+echo "${BINARY_NAME} => ./bin/charts-build-scripts"
 
 chmod +x ./bin/charts-build-scripts
 ./bin/charts-build-scripts --version


### PR DESCRIPTION
In https://github.com/rancher/charts-build-scripts/pull/128 we simplified the tooling for `charts-build-scripts`. Part of this involved improving the naming format of the binaries uploaded to `charts-build-scripts` releases. This necessitates an update to `scripts/pull-scripts` in this repo, since this script expects names of the old format.

This PR contains that update. I will need to make other PRs to update `scripts/pull-scripts` on other branches in addition to this one (`dev-v2.7`, `dev-v2.8`, `release-v2.7`, `release-v2.8`, and `release-v2.9`). I will link those PRs here.