### PR TITLE
[prod-v2.9] adding make validate options 

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,7 +29,7 @@ jobs:
         run: sudo make check-release-yaml
 
       - name: Validate
-        run: sudo make validate
+        run: sudo make validate remote=true
 
   check-images:
     name: Check Container Images

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,12 @@ lifecycle-assets:
 	@./scripts/pull-scripts
 	@./bin/charts-build-scripts lifecycle-assets --branch-version=$(BRANCH_VERSION) --debugFlag=$(DEBUG) --chart=$(CHART)
 
-TARGETS := prepare patch clean clean-cache charts list index unzip zip standardize validate template regsync check-images check-rc
+
+validate:
+	@./scripts/pull-scripts
+	@./bin/charts-build-scripts validate $(if $(filter true,$(remote)),--remote) $(if $(filter true,$(local)),--local)
+
+TARGETS := prepare patch clean clean-cache charts list index unzip zip standardize template regsync check-images check-rc
 
 $(TARGETS):
 	@./scripts/pull-scripts

--- a/docs/makefile.md
+++ b/docs/makefile.md
@@ -37,6 +37,13 @@ Please see [`docs/developing.md`](developing.md) for more information on how to 
 
 `make validate`: Checks whether all generated assets used to serve a Helm repository (`charts/`, `assets/`, and `index.yaml`) are up-to-date. If `validate.url` and `validate.branch` are provided in the configuration.yaml, it will also ensure that any additional changes introduced only modify chart or package versions specified in the `release.yaml`; otherwise it will output the expected `release.yaml` based on assets it detected changes in.
 
+3 operating modes for `make validate`:
+- `default` - `make validate`: Executes internally `make prepare` and `make charts`, generates a new charts folder from all packages and compare them with the current `/charts folder`. In the end will compare `/charts folder` and the new generated `assets`.
+- `remote` - `make validate remote=true`: Skips generating charts locally, compares the current local charts against the upstream assets.
+- `local` - `make validate local=true`: Skips pulling the upstream charts assets, compares only the local assets and local charts.
+
+The `remote` and `local` options are mutually exclusive, you can't set both to true at the same time.
+
 Please see [`docs/validation.md`](validation.md) for more information on how CI is performed.
 
 ### Docs and Scripts Commands


### PR DESCRIPTION
Adding 2 more options for `make validate`:
- `remote=<true_or_false>`
- `local=<true_or_false>`

Both of these options did exist previously but were not being used. 
To avoid misunderstandings I am adding these options and using the `remote=true` option for the CI jobs that will be executed in the production branches. 

The development branches will still use the `default` option (when `remote=false` && `local=false`).
This way we know the checks have passed before reaching the release phase. 