### PR TITLE
[dev-v2.8] Sync up dev 2.8.5 emergency

### DIFF
--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1793,6 +1793,7 @@ sync:
     - v0.2.9
     - v0.3.0
     - v0.3.10
+    - v0.3.11
     - v0.3.2
     - v0.3.3
     - v0.3.4
@@ -1805,6 +1806,7 @@ sync:
     - v0.4.3
     - v0.4.5
     - v0.4.6
+    - v0.4.7
 - source: docker.io/rancher/security-scan
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/security-scan'
   type: repository


### PR DESCRIPTION
Release PR:
- https://github.com/rancher/charts/pull/4085