### PR TITLE
[release-v2.9] production branch is now release-v2.9 with the new branching strategy…

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - dev-v*
-      - prod-v*
+      - release-v*
 
 jobs:
   build:
@@ -63,4 +63,4 @@ jobs:
 
       - name: Check RC images and charts
         run: make check-rc
-        if: startsWith(github.ref, 'refs/heads/prod-v')
+        if: startsWith(github.ref, 'refs/heads/release-v')

--- a/.github/workflows/regsync-config.yaml
+++ b/.github/workflows/regsync-config.yaml
@@ -1,4 +1,4 @@
-# Generate-Regsync-Config action will run for every PR into prod-v2.9 branch only after an approval is given
+# Generate-Regsync-Config action will run for every PR into release-v2.9 branch only after an approval is given
 # It will run make target to generate regsync file and add a commit to the PR updating the regsync file.
 # It will then install and run regsync client and do the prime image mirroring.
 
@@ -11,7 +11,7 @@ on:
 
 jobs:
   onLabelAndApproval:
-    if: github.event.label.name == 'regsync-ready' && startsWith(github.event.pull_request.base.ref, 'prod-v')
+    if: github.event.label.name == 'regsync-ready' && startsWith(github.event.pull_request.base.ref, 'release-v')
     runs-on: ubuntu-latest
     outputs:
       is_approved: ${{ steps.check-approval.outputs.approved }}

--- a/.github/workflows/validation-check.yaml
+++ b/.github/workflows/validation-check.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check-reaction:
     name: Check for positive reaction on bot's latest validation comment
-    if: startsWith(github.event.pull_request.base.ref, 'dev-v') || startsWith(github.event.pull_request.base.ref, 'prod-v')
+    if: startsWith(github.event.pull_request.base.ref, 'dev-v') || startsWith(github.event.pull_request.base.ref, 'release-v')
     runs-on: ubuntu-latest
     steps:
       - name: Check for modifications in specified folders

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -4,7 +4,7 @@ on:
   pull_request_target:
     branches:
       - dev-v*
-      - prod-v*
+      - release-v*
     paths:
       - 'assets/**'
       - 'charts/**'

--- a/README.md
+++ b/README.md
@@ -26,20 +26,20 @@ This repository contains Helm charts served by Rancher Apps & Marketplace.
 ### New Out Of Band Release Process
 Starting on `17/May/2024`.
 
-This is only valid for `prod-v2.*` branches.
+This is only valid for `release-v2.*` branches.
 Since this implementation, all teams may release each chart when they want.
 
 ##### Overview of the process:
 1. Assuming you have a chart ready and merged on `dev-v2.*` branch.
-2. On your local machine: `fetch`, `pull` and `checkout` to `prod-v2.*`
-3. Create a new branch from `prod-v2.*`
+2. On your local machine: `fetch`, `pull` and `checkout` to `release-v2.*`
+3. Create a new branch from `release-v2.*`
 4. Execute `make forward-port`
 5. Clear your `release.yaml` file, leave only your chart that will be released
 6. Add, Commit and push your changes to your forked repository
 
 **Attention**: If you have a CRD that must be released with the chart, you should repeat `Step 4.` until `Step 6.` for the CRD chart.
 
-7. Create a Pull Request from your forked repository to `rancher/charts` pointing to `prod-v2.*`
+7. Create a Pull Request from your forked repository to `rancher/charts` pointing to `release-v2.*`
 
 
 ##### How to use `forward-port`:
@@ -63,7 +63,7 @@ Script Arguments Reference:
 make forward-port CHART=rancher-istio VERSION=103.3.0+up1.21.1 BRANCH=dev-v2.8 UPSTREAM=upstream
 ```
 
-In this case, we are at branch `prod-v2.8`, we have a new version of Istio at `dev-v2.8`.
+In this case, we are at branch `release-v2.8`, we have a new version of Istio at `dev-v2.8`.
 
 The script will get all necessary changes for `assets`, `charts`, `release.yaml` and `index.yaml` and handle them all automatically.
 
@@ -87,9 +87,9 @@ We will keep only the relevant assets in the corresponding branch.
 This means a cycle of always 3 active branches, with each branch always holding up to 2 previous versions before it.
 
 In a nutshell:
-- prod-v2.7 hold chart versions for Rancher: (2.5; 2.6; 2.7)
-- prod-v2.8 hold chart versions for Rancher: (2.6; 2.7; 2.8)
-- prod-v2.9 hold chart versions for Rancher: (2.7; 2.8; 2.9)
+- release-v2.7 hold chart versions for Rancher: (2.5; 2.6; 2.7)
+- release-v2.8 hold chart versions for Rancher: (2.6; 2.7; 2.8)
+- release-v2.9 hold chart versions for Rancher: (2.7; 2.8; 2.9)
 
 ![Assets Lifecycle](./docs/assets_lifecycle.png)
 

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -3,4 +3,4 @@ helmRepo:
 
 validate:
   url: https://github.com/rancher/charts.git
-  branch: prod-v2.9
+  branch: release-v2.9


### PR DESCRIPTION
Changing from `prod-v2.9` to `release-v2.9` github action jobs and documentation