### PR TITLE
Fix the syntax: the 'and' was missing.:

### DIFF
--- a/packages/rancher-monitoring/rancher-node-exporter/generated-changes/patch/templates/psp-clusterrole.yaml.patch
+++ b/packages/rancher-monitoring/rancher-node-exporter/generated-changes/patch/templates/psp-clusterrole.yaml.patch
@@ -2,7 +2,7 @@
 +++ charts/templates/psp-clusterrole.yaml
 @@ -1,4 +1,4 @@
 -{{- if and .Values.rbac.create .Values.rbac.pspEnabled (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
-+{{- if and (or .Values.global.cattle.psp.enable (.Values.rbac.create .Values.rbac.pspEnabled)) (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
++{{- if and (or .Values.global.cattle.psp.enable (and .Values.rbac.create .Values.rbac.pspEnabled)) (.Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy") }}
  kind: ClusterRole
  apiVersion: rbac.authorization.k8s.io/v1
  metadata:


### PR DESCRIPTION
See issue [#47092](https://github.com/rancher/rancher/issues/47092)

This typo is in rancher-monitoring charts for v2.8 and v2.9