### PR TITLE
Adding per logging overrides

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -17786,9 +17786,9 @@ entries:
       catalog.cattle.io/upstream-version: 4.8.0
     apiVersion: v2
     appVersion: 4.8.0
-    created: "2024-09-23T18:55:05.39708727Z"
+    created: "2024-09-23T19:17:19.504054719Z"
     description: Logging operator for Kubernetes based on Fluentd and Fluentbit.
-    digest: 0b3fffd46ba3aa8a6f4476c668d61ffbd3fb28f09d1e429ed3d29d899f9308e6
+    digest: 12a8e035b888871d942888c03d043aa533e9b392d91b4d7b0d6ecad1c4c38957
     home: https://kube-logging.github.io
     icon: file://assets/logos/rancher-logging.svg
     keywords:

--- a/index.yaml
+++ b/index.yaml
@@ -17786,6 +17786,40 @@ entries:
       catalog.cattle.io/upstream-version: 4.8.0
     apiVersion: v2
     appVersion: 4.8.0
+    created: "2024-09-23T18:55:05.39708727Z"
+    description: Logging operator for Kubernetes based on Fluentd and Fluentbit.
+    digest: 0b3fffd46ba3aa8a6f4476c668d61ffbd3fb28f09d1e429ed3d29d899f9308e6
+    home: https://kube-logging.github.io
+    icon: file://assets/logos/rancher-logging.svg
+    keywords:
+    - logging
+    - fluentd
+    - fluentbit
+    kubeVersion: '>=1.26.0-0'
+    name: rancher-logging
+    sources:
+    - https://github.com/kube-logging/logging-operator
+    - https://github.com/kube-logging/helm-charts/tree/main/charts/logging-operator
+    type: application
+    urls:
+    - assets/rancher-logging/rancher-logging-104.1.2+up4.8.0.tgz
+    version: 104.1.2+up4.8.0
+  - annotations:
+      catalog.cattle.io/auto-install: rancher-logging-crd=match
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/deploys-on-os: windows
+      catalog.cattle.io/display-name: Logging
+      catalog.cattle.io/kube-version: '>= 1.26.0-0 < 1.31.0-0'
+      catalog.cattle.io/namespace: cattle-logging-system
+      catalog.cattle.io/permits-os: linux,windows
+      catalog.cattle.io/provides-gvr: logging.banzaicloud.io.clusterflow/v1beta1
+      catalog.cattle.io/rancher-version: '>= 2.9.0-0 < 2.10.0-0'
+      catalog.cattle.io/release-name: rancher-logging
+      catalog.cattle.io/type: cluster-tool
+      catalog.cattle.io/ui-component: logging
+      catalog.cattle.io/upstream-version: 4.8.0
+    apiVersion: v2
+    appVersion: 4.8.0
     created: "2024-09-16T11:48:36.969456191-04:00"
     description: Logging operator for Kubernetes based on Fluentd and Fluentbit.
     digest: 6646dbca557e25a3be79224a337dd5ad2b64a0adb825201a9b049a44d66ba511
@@ -18552,6 +18586,20 @@ entries:
     - assets/rancher-logging/rancher-logging-3.6.000.tgz
     version: 3.6.000
   rancher-logging-crd:
+  - annotations:
+      catalog.cattle.io/certified: rancher
+      catalog.cattle.io/hidden: "true"
+      catalog.cattle.io/namespace: cattle-logging-system
+      catalog.cattle.io/release-name: rancher-logging-crd
+    apiVersion: v1
+    created: "2024-09-23T18:43:19.231876312Z"
+    description: Installs the CRDs for rancher-logging.
+    digest: cba98e94e5448d966a19f0a188ac30fbbb2257d895fa947a341b3a1b0ec993f6
+    name: rancher-logging-crd
+    type: application
+    urls:
+    - assets/rancher-logging-crd/rancher-logging-crd-104.1.2+up4.8.0.tgz
+    version: 104.1.2+up4.8.0
   - annotations:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"

--- a/packages/rancher-logging/generated-changes/overlay/templates/_generic_fluentbitagent.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/_generic_fluentbitagent.yaml
@@ -74,7 +74,7 @@ spec:
 {{/* figure out which logger we are working on */}}
 {{- $logger := (index . 1) | replace "logging-operator.logging." "" -}}
 
-{{/* ovalues are the logger specific overlay values /*}}
+{{/* ovalues are the logger specific overlay values */}}
 {{- $ovalues := (dig $logger dict $top.Values.fluentbitAgentOverlays) -}}
 
 ####### {{$generic}}

--- a/packages/rancher-logging/generated-changes/overlay/templates/_generic_fluentbitagent.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/_generic_fluentbitagent.yaml
@@ -71,10 +71,16 @@ spec:
 {{/* values are from the values.yaml */}}
 {{- $values := $top.Values.fluentbitAgentOverlay | default (dict ) -}}
 
+{{/* figure out which logger we are working on */}}
+{{- $logger := (index . 1) | replace "logging-operator.logging." "" -}}
+
+{{/* ovalues are the logger specific overlay values /*}}
+{{- $ovalues := (dig $logger dict $top.Values.fluentbitAgentOverlays) -}}
+
 ####### {{$generic}}
 
 {{/* the sources are merge right to left meaning tpl is the highest prcedence and values is the lowest */}}
-{{- toYaml (merge $tpl $values $generic) -}}
+{{- toYaml (merge $tpl $ovalues $values $generic) -}}
 {{- end -}}
 
 {{- define "logging-operator.fluentbitagent" -}}

--- a/packages/rancher-logging/generated-changes/overlay/templates/_generic_logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/_generic_logging.yaml
@@ -64,7 +64,7 @@ spec:
 {{/* figure out which logger we are working on */}}
 {{- $logger := (index . 1) | replace "logging-operator.logging." "" -}}
 
-{{/* ovalues are the logger specific overlay values /*}}
+{{/* ovalues are the logger specific overlay values */}}
 {{- $ovalues := (dig $logger dict $top.Values.loggingOverlays) -}}
 
 ####### {{$generic}}

--- a/packages/rancher-logging/generated-changes/overlay/templates/_generic_logging.yaml
+++ b/packages/rancher-logging/generated-changes/overlay/templates/_generic_logging.yaml
@@ -61,10 +61,16 @@ spec:
 {{/* values are from the values.yaml */}}
 {{- $values := $top.Values.loggingOverlay | default (dict ) -}}
 
+{{/* figure out which logger we are working on */}}
+{{- $logger := (index . 1) | replace "logging-operator.logging." "" -}}
+
+{{/* ovalues are the logger specific overlay values /*}}
+{{- $ovalues := (dig $logger dict $top.Values.loggingOverlays) -}}
+
 ####### {{$generic}}
 
 {{/* the sources are merge right to left meaning tpl is the highest prcedence and values is the lowest */}}
-{{- toYaml (merge $tpl $values $generic) -}}
+{{- toYaml (merge $tpl $ovalues $values $generic) -}}
 {{- end -}}
 
 {{- define "logging-operator.logging" -}}

--- a/packages/rancher-logging/generated-changes/patch/values.yaml.patch
+++ b/packages/rancher-logging/generated-changes/patch/values.yaml.patch
@@ -202,7 +202,7 @@
  
  # -- Extra manifests to deploy as an array
  extraManifests: []
-@@ -324,3 +473,12 @@
+@@ -324,3 +473,24 @@
    #     name: extra-manifest
    #   data:
    #     extra-data: "value"
@@ -215,3 +215,15 @@
 +# this object will be merged with every logging CR created by this chart. Any fields that collide with fields from the
 +# settings above will be overridden. Any fields that collide with fields set in the files in `templates/loggings` will
 +# be ignored.
++
++# Just like loggingOverlay but allows per logging overrides
++loggingOverlays: {}
++## Syntax ##
++#  <logging-name>:
++#    <key>: <value>
++
++# Just like fluentbitAgentOverlay but allows per logging overrides
++fluentbitAgentOverlays: {}
++## Syntax ##
++#  <logging-name>:
++#    <key>: <value>

--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,5 +1,5 @@
 url: oci://ghcr.io/kube-logging/helm-charts/logging-operator:4.8.0
-version: 104.1.1
+version: 104.1.2
 additionalCharts:
   - workingDir: charts-crd
     crdOptions:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The rancher-logging chart is very inflexible in per logging tweaks.  There is generic overlay to change settings not exposed by the chart.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
Added two new keys loggingOverlays and fluentbitAgentOverlays to the values that allows per logging overlays per logger.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
Deploying with a values like this allows me to scale up the fluentd replicas for root logger only.
```
loggingOverlays:
  root:
   spec:
    fluentd:
      scaling:
        replicas: 6
```


### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

## Backporting considerations
<!-- Does this change need to be backported to other versions? If so, which versions should it be backported to? -->