### PR TITLE
[dev-v2.7] update rancher-logging upstream specification

### DIFF
--- a/packages/rancher-logging/package.yaml
+++ b/packages/rancher-logging/package.yaml
@@ -1,4 +1,6 @@
-url: https://kubernetes-charts.banzaicloud.com/charts/logging-operator-3.17.10.tgz
+url: github.coim/kube-logging/logging-operator.git
+commit: ebf7ec008e8c1d5dbc7a8454d4a209153a4ccca7
+subdirectory: charts/logging-operator
 version: 102.0.3
 additionalCharts:
   - workingDir: charts-crd


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Old banzaicloud upstream for rancher logging < 104.x.x has been completely removed breaking CI for all charts.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

Fix the upstream to point to existing github repo with the same chart.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->

### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->

## Backporting considerations
<!-- Does this change need to be backported to other versions? If so, which versions should it be backported to? -->