### PR TITLE
[dev-v2.8] Sync dev 28 after webhook forward-port

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -23865,7 +23865,7 @@ entries:
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
     appVersion: 0.3.13
-    created: "2024-11-05T15:26:12.857242268-03:00"
+    created: "2024-11-05T15:28:57.805764578-03:00"
     dependencies:
     - condition: capi.enabled
       name: capi

--- a/index.yaml
+++ b/index.yaml
@@ -4479,7 +4479,7 @@ entries:
       catalog.cattle.io/upstream-version: 1.7.2
     apiVersion: v1
     appVersion: v1.7.2
-    created: "2024-10-30T17:10:56.591071715-03:00"
+    created: "2024-10-30T17:13:40.078877165-03:00"
     description: Longhorn is a distributed block storage system for Kubernetes.
     digest: 8fb53cd5cff05a04d52a48d6249de5ba3aa4e397402cf8e7c9f4bcf39bb9ce9a
     home: https://github.com/longhorn/longhorn
@@ -6416,7 +6416,7 @@ entries:
       catalog.cattle.io/release-name: longhorn-crd
     apiVersion: v1
     appVersion: v1.7.2
-    created: "2024-10-30T17:11:38.633531787-03:00"
+    created: "2024-10-30T17:13:58.733149096-03:00"
     description: Installs the CRDs for longhorn.
     digest: 3e1e910cafef23c2eefb4a06b1d2b0e893579714f9cb9553350c0e739838eb45
     name: longhorn-crd

--- a/regsync.yaml
+++ b/regsync.yaml
@@ -1198,6 +1198,7 @@ sync:
     - v1.6.2
     - v1.6.3
     - v1.7.1
+    - v1.7.2
     - v1_20210422
     - v1_20210422_patch1
     - v2_20210820
@@ -1244,6 +1245,7 @@ sync:
     - v3.6.2
     - v3.6.4
     - v4.0.1
+    - v4.0.1-20241007
 - source: docker.io/rancher/mirrored-longhornio-csi-resizer
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-csi-resizer'
   type: repository
@@ -1271,6 +1273,7 @@ sync:
     - v6.3.2
     - v6.3.4
     - v7.0.2
+    - v7.0.2-20241007
 - source: docker.io/rancher/mirrored-longhornio-livenessprobe
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-livenessprobe'
   type: repository
@@ -1311,6 +1314,7 @@ sync:
     - v1.6.2
     - v1.6.3
     - v1.7.1
+    - v1.7.2
 - source: docker.io/rancher/mirrored-longhornio-longhorn-instance-manager
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-longhorn-instance-manager'
   type: repository
@@ -1329,6 +1333,7 @@ sync:
     - v1.6.2
     - v1.6.3
     - v1.7.1
+    - v1.7.2
     - v1_20201216
     - v1_20210621
     - v1_20210731
@@ -1371,6 +1376,7 @@ sync:
     - v1.6.2
     - v1.6.3
     - v1.7.1
+    - v1.7.2
 - source: docker.io/rancher/mirrored-longhornio-longhorn-share-manager
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-longhorn-share-manager'
   type: repository
@@ -1389,6 +1395,7 @@ sync:
     - v1.6.2
     - v1.6.3
     - v1.7.1
+    - v1.7.2
     - v1_20201204
     - v1_20210416
     - v1_20210416_patch1
@@ -1431,6 +1438,7 @@ sync:
     - v1.6.2
     - v1.6.3
     - v1.7.1
+    - v1.7.2
 - source: docker.io/rancher/mirrored-longhornio-openshift-origin-oauth-proxy
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-longhornio-openshift-origin-oauth-proxy'
   type: repository
@@ -1453,6 +1461,7 @@ sync:
     - v0.0.37
     - v0.0.42
     - v0.0.43
+    - v0.0.45
 - source: docker.io/rancher/mirrored-messagebird-sachet
   target: '{{ env "REGISTRY_ENDPOINT" }}/rancher/mirrored-messagebird-sachet'
   type: repository

--- a/release.yaml
+++ b/release.yaml
@@ -22,6 +22,3 @@ fleet-crd:
   - 103.1.10+up0.9.11
 fleet-agent:
   - 103.1.10+up0.9.11
-rancher-webhook:
-  - 103.0.12+up0.4.13-rc.1
-  - 2.0.13+up0.3.13

--- a/release.yaml
+++ b/release.yaml
@@ -22,7 +22,7 @@ fleet-crd:
   - 103.1.10+up0.9.11
 fleet-agent:
   - 103.1.10+up0.9.11
-longhorn:
-  - 103.4.1+up1.7.2
-longhorn-crd:
-  - 103.4.1+up1.7.2
+rancher-backup:
+  - 103.0.4+up4.0.4
+rancher-backup-crd:
+  - 103.0.4+up4.0.4

--- a/release.yaml
+++ b/release.yaml
@@ -26,3 +26,5 @@ rancher-backup:
   - 103.0.4+up4.0.4
 rancher-backup-crd:
   - 103.0.4+up4.0.4
+rancher-webhook:
+  - 103.0.12+up0.4.13-rc.1

--- a/release.yaml
+++ b/release.yaml
@@ -22,3 +22,7 @@ fleet-crd:
   - 103.1.10+up0.9.11
 fleet-agent:
   - 103.1.10+up0.9.11
+longhorn:
+  - 103.4.1+up1.7.2
+longhorn-crd:
+  - 103.4.1+up1.7.2


### PR DESCRIPTION
issue: https://github.com/rancher/ecm-distro-tools/issues/495

After release of 2.7.17, webhook was forward-ported to release-v2.8
Now syncing release-v2.8 into dev-v2.8