### PR TITLE
[dev-v2.10] rancher-logging 105.0.0-rc.3+up4.8.0 fix seLinuxOptions for Fluentbit

### DIFF
--- a/charts/rancher-logging/104.1.0+up4.8.0/templates/_generic_fluentbitagent.yaml
+++ b/charts/rancher-logging/104.1.0+up4.8.0/templates/_generic_fluentbitagent.yaml
@@ -26,8 +26,8 @@ spec:
   {{- end }}
   {{- if .Values.global.seLinux.enabled }}
     securityContext:
-    seLinuxOptions:
-      type: rke_logreader_t
+      seLinuxOptions:
+        type: rke_logreader_t
   {{- end }}
   {{- if or .Values.fluentbit.inputTail.Buffer_Chunk_Size .Values.fluentbit.inputTail.Buffer_Max_Size .Values.fluentbit.inputTail.Mem_Buf_Limit .Values.fluentbit.inputTail.Multiline_Flush .Values.fluentbit.inputTail.Skip_Long_Lines }}
   inputTail:

--- a/charts/rancher-logging/104.1.1+up4.8.0/templates/_generic_fluentbitagent.yaml
+++ b/charts/rancher-logging/104.1.1+up4.8.0/templates/_generic_fluentbitagent.yaml
@@ -26,8 +26,8 @@ spec:
   {{- end }}
   {{- if .Values.global.seLinux.enabled }}
     securityContext:
-    seLinuxOptions:
-      type: rke_logreader_t
+      seLinuxOptions:
+        type: rke_logreader_t
   {{- end }}
   {{- if or .Values.fluentbit.inputTail.Buffer_Chunk_Size .Values.fluentbit.inputTail.Buffer_Max_Size .Values.fluentbit.inputTail.Mem_Buf_Limit .Values.fluentbit.inputTail.Multiline_Flush .Values.fluentbit.inputTail.Skip_Long_Lines }}
   inputTail:

--- a/charts/rancher-logging/104.1.2+up4.8.0/templates/_generic_fluentbitagent.yaml
+++ b/charts/rancher-logging/104.1.2+up4.8.0/templates/_generic_fluentbitagent.yaml
@@ -26,8 +26,8 @@ spec:
   {{- end }}
   {{- if .Values.global.seLinux.enabled }}
     securityContext:
-    seLinuxOptions:
-      type: rke_logreader_t
+      seLinuxOptions:
+        type: rke_logreader_t
   {{- end }}
   {{- if or .Values.fluentbit.inputTail.Buffer_Chunk_Size .Values.fluentbit.inputTail.Buffer_Max_Size .Values.fluentbit.inputTail.Mem_Buf_Limit .Values.fluentbit.inputTail.Multiline_Flush .Values.fluentbit.inputTail.Skip_Long_Lines }}
   inputTail:

--- a/charts/rancher-logging/105.0.0+up4.8.0/templates/_generic_fluentbitagent.yaml
+++ b/charts/rancher-logging/105.0.0+up4.8.0/templates/_generic_fluentbitagent.yaml
@@ -26,8 +26,8 @@ spec:
   {{- end }}
   {{- if .Values.global.seLinux.enabled }}
     securityContext:
-    seLinuxOptions:
-      type: rke_logreader_t
+      seLinuxOptions:
+        type: rke_logreader_t
   {{- end }}
   {{- if or .Values.fluentbit.inputTail.Buffer_Chunk_Size .Values.fluentbit.inputTail.Buffer_Max_Size .Values.fluentbit.inputTail.Mem_Buf_Limit .Values.fluentbit.inputTail.Multiline_Flush .Values.fluentbit.inputTail.Skip_Long_Lines }}
   inputTail:


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
[SURE-9028](https://jira.suse.com/browse/SURE-9028)
https://github.com/rancher/rancher/issues/47146

## Problem


## Solution
Fix indention in helm template for below charts versions:
104.1.0+up4.8.0
104.1.1+up4.8.0
104.1.2+up4.8.0
105.0.0+up4.8.0


## Testing


## Engineering Testing
### Manual Testing

### Automated Testing

## QA Testing Considerations

### Regressions Considerations

## Backporting considerations
