### PR TITLE
[dev-v2.10] Add metricRelabelings to rancher-istio ServiceMonitor

### DIFF
--- a/charts/rancher-istio/105.5.0+up1.24.1/templates/service-monitors.yaml
+++ b/charts/rancher-istio/105.5.0+up1.24.1/templates/service-monitors.yaml
@@ -29,6 +29,10 @@ spec:
     - sourceLabels: [__meta_kubernetes_pod_name]
       action: replace
       targetLabel: pod_name
+{{- if .Values.kiali.serviceMonitor.metricRelabelings }}
+    metricRelabelings: 
+{{ toYaml .Values.kiali.serviceMonitor.metricRelabelings | indent 4 }}
+{{- end }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/charts/rancher-istio/105.5.0+up1.24.1/values.yaml
+++ b/charts/rancher-istio/105.5.0+up1.24.1/values.yaml
@@ -105,6 +105,8 @@ kiali:
     grafana:
       in_cluster_url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"
       url: "http://rancher-monitoring-grafana.cattle-monitoring-system.svc:80"
+  serviceMonitor:
+    metricRelabelings: []
 
 tracing:
   enabled: false


### PR DESCRIPTION
## Problem
Istio allows metric relabeling on Prometheus endpoints, for example to drop unused metrics. See:

- [Istio - Observability Best Practices](https://istio.io/latest/docs/ops/best-practices/observability/#federation-using-workload-level-aggregated-metrics). 
- [Prometheus Operator documentation on Dropping metrics](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/user-guides/running-exporters.md)
- [Relevant part of the official prometheus-operator Helm chart](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus-operator/servicemonitor.yaml#L32-L35)

This feature is missing in the Rancher Istio Helm chart.

## Solution
This change adds the ability to define an array of metrics to drop through `values.yaml`. Note that `metricRelabelings` is different from the existing `relabelings` array already defined in the rancher-istio ServiceMonitor.

## Testing
The change can be tested by defining an array of metricRelabelings in `values.yaml`:

```
# Kiali subchart from rancher-kiali-server
kiali:
  enabled: true
  serviceMonitor:
    metricRelabelings:
    - action: drop
      regex: ^envoy_cluster_circuit_breakers_default_cx_open$
      sourceLabels:
      - __name__
    - action: drop
      regex: ^envoy_cluster_circuit_breakers_default_cx_pool_open$
      sourceLabels:
      - __name__
    - action: drop
      regex: ^envoy_cluster_circuit_breakers_default_rq_open$
      sourceLabels:
      - __name__
    - action: drop
      regex: ^envoy_cluster_circuit_breakers_default_rq_pending_open$
      sourceLabels:
      - __name__
    - action: drop
      regex: ^envoy_cluster_circuit_breakers_default_rq_retry_open$
      sourceLabels:
      - __name__
```

Run `helm template rancher-istio ./ -n istio-system` and verify the ServiceMonitor is rendered correctly.

## Engineering Testing
### Manual Testing
I tested this by adding the `metricRelabelings` array manually, installing the rancher-istio chart on a local Rancher cluster, and verified that the listed metrics are no longer available in Prometheus.