### PR TITLE
[dev-v2.11] Use the same fleet-crd dir as before

### DIFF
--- a/packages/fleet/package.yaml
+++ b/packages/fleet/package.yaml
@@ -4,7 +4,7 @@ chartRepoBranch: charts/v0.12
 subdirectory: charts/fleet
 workingDir: fleet
 additionalCharts:
-  - workingDir: charts/crds
+  - workingDir: fleet-crd
     upstreamOptions:
       url: https://github.com/rancher/fleet.git
       chartRepoBranch: charts/v0.12


### PR DESCRIPTION
auto bump package.yaml.