### PR TITLE
[dev-v2.10] rancher-vsphere-csi 105.0.1+up3.3.1-rancher7 Add option priority class for csi node daemonset

### DIFF
--- a/charts/rancher-vsphere-csi/105.0.1+up3.3.1-rancher7/templates/node/daemonset.yaml
+++ b/charts/rancher-vsphere-csi/105.0.1+up3.3.1-rancher7/templates/node/daemonset.yaml
@@ -30,6 +30,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- else }}
+      {{- if .Values.csiNode.priorityClassName }}
+      priorityClass: {{ .Values.csiNode.priorityClassName }}
+      {{- end }}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/rancher-vsphere-csi/105.0.1+up3.3.1-rancher7/values.yaml
+++ b/charts/rancher-vsphere-csi/105.0.1+up3.3.1-rancher7/values.yaml
@@ -180,7 +180,8 @@ csiNode:
   ## Optional additional labels to add to pods
   podLabels: {}
   prefixPath: ""
-  prefixPathWindows: ""
+  prefixPathWindows: "" 
+  priorityClassName: "system-node-critical"
   image:
     repository: rancher/mirrored-cloud-provider-vsphere-csi-release-driver
     tag: latest


### PR DESCRIPTION
##### Checkpoints for Chart Bumps

`release.yaml`:
- [ ] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [ ] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:
- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---


##### Issue:
Nodes under memory pressure may evict the csi-node daemonset pods. Which in turn prevents pods depending on PVCs from starting.

##### Solution
My suggestion is to add a priority class option to the helm chart

##### QA Testing Considerations
Induce memory pressure on a node by creating a pod which uses upp all memory available for pods.