### PR TITLE
 [release-v2.8] hiding prometheus-fedarator that was not released 

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -1,2 +1,2 @@
-rancher-webhook:
-  - 103.0.16+up0.4.17
+prometheus-federator:
+  - 103.0.1+up0.4.1


### PR DESCRIPTION
To resolve issue: https://github.com/rancher/charts-build-scripts/issues/100

I detected this never-released wrong version. 
Removing all traces of it. 