### PR TITLE
[dev-v2.11] adding version override to auto-chart-bumps

### DIFF
--- a/.github/workflows/auto-bump-manual-trigger.yaml
+++ b/.github/workflows/auto-bump-manual-trigger.yaml
@@ -11,6 +11,10 @@ on:
         description: "Branch name (only dev branches)"
         required: true
         default: "dev-v2.11"
+      version-override:
+        description: "disable the bump version auto calculation with a version to override it"
+        required: false
+        default: ""
 
 
 jobs:

--- a/.github/workflows/auto-bump.yaml
+++ b/.github/workflows/auto-bump.yaml
@@ -21,13 +21,14 @@ jobs:
 
       - name: Log Event Payload
         run: |
-         echo "Payload: ${{  github.event.inputs.chart  }}; ${{  github.event.inputs.branch  }}"
+         echo "Payload: ${{  github.event.inputs.chart  }}; ${{  github.event.inputs.branch  }}; ${{  github.event.inputs.version-override  }}"
 
       - name: Parse JSON Payload
         id: parse_payload
         run: |
           echo "CHART=${{ github.event.inputs.chart }}" >> $GITHUB_ENV
           echo "BRANCH=${{ github.event.inputs.branch }}" >> $GITHUB_ENV
+          echo "VERSION_OVERRIDE=${{ github.event.inputs.version-override }}" >> $GITHUB_ENV
 
       - name: Configure Git for Commit
         run: |
@@ -47,7 +48,7 @@ jobs:
         run: |
           LOG="DEBUG"
           echo "Running chart-bump with LOG=${LOG}"
-          ./bin/charts-build-scripts chart-bump --package="${{ env.CHART }}" --branch="${{ env.BRANCH }}"
+          ./bin/charts-build-scripts chart-bump --package="${{ env.CHART }}" --branch="${{ env.BRANCH }}" --version="${{ env.VERSION_OVERRIDE }}"
 
       - name: read bump version from json file
         id: read_bump_version


### PR DESCRIPTION
Related PR: https://github.com/rancher/charts-build-scripts/pull/210

Charts repo side implementation of bump version override