### PR TITLE
[dev-v2.11] fixes for CODEOWNERS, autobump

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,69 +7,96 @@
 /_config.yml @rancher/release-team
 /index.html @rancher/release-team
 
-config/ @rancher/release-team
+config/version_rules.json @rancher/release-team
+config/regsync.yaml @rancher/release-team
+config/configuration.yaml @rancher/release-team
 
+#----------------------------------------------------
 
 # Elemental
 packages/elemental @rancher/elemental
+assets/elemental @rancher/elemental
 
 # Fleet
 packages/fleet @rancher/fleet
+assets/fleet @rancher/fleet
 
 # Harvester
 packages/harvester @rancher/harvester
+assets/harvester @rancher/harvester
 
 # Longhorn
 packages/longhorn @rancher/longhorn
+assets/longhorn @rancher/longhorn
 packages/longhorn-crd @rancher/longhorn
+assets/longhorn-crd @rancher/longhorn
 
 # Neuvector
 packages/neuvector @rancher/neuvector
+assets/neuvector @rancher/neuvector
 packages/neuvector-monitor @rancher/neuvector
+assets/neuvector-monitor @rancher/neuvector
 
 # Rancher AKS EKS GKE
 packages/rancher-aks-operator @rancher/highlander @rancher/infracloud-team
+assets/rancher-aks-operator @rancher/highlander @rancher/infracloud-team
 packages/rancher-eks-operator @rancher/highlander @rancher/infracloud-team
+assets/rancher-eks-operator @rancher/highlander @rancher/infracloud-team
 packages/rancher-gke-operator @rancher/highlander @rancher/infracloud-team
+assets/rancher-gke-operator @rancher/highlander @rancher/infracloud-team
 
 # Rancher Alerting
 packages/rancher-alerting @rancher/observation-backup
+assets/rancher-alerting @rancher/observation-backup
 
 # Rancher Backup
 packages/rancher-backup @rancher/observation-backup
+assets/rancher-backup @rancher/observation-backup
 
 # Rancher CIS Benchmark
 packages/rancher-cis-benchmark @rancher/infracloud-team
+assets/rancher-cis-benchmark @rancher/infracloud-team
 tests/rancher-cis-benchmark @rancher/infracloud-team
 
 # Rancher CSP Adapter
 packages/rancher-csp-adapter @rancher/socket
+assets/rancher-csp-adapter @rancher/socket
 
 # Rancher Istio
 packages/rancher-istio @rancher/observation-backup
+assets/rancher-istio @rancher/observation-backup
 tests/rancher-istio @rancher/observation-backup
 
 # Rancher Logging
 packages/rancher-logging @rancher/observation-backup
+assets/rancher-logging @rancher/observation-backup
 
 # Rancher Monitoring
 packages/rancher-monitoring @rancher/observation-backup
+assets/rancher-monitoring @rancher/observation-backup
 
 # Rancher SRIOV
 packages/rancher-sriov @rancher/rke1-team
+assets/rancher-sriov @rancher/rke1-team
 packages/rancher-nfd @rancher/rke1-team
+assets/rancher-nfd @rancher/rke1-team
 
 # Rancher Provisioning CAPI
 packages/rancher-provisioning-capi @rancher/rancher-team-2-hostbusters-dev
+assets/rancher-provisioning-capi @rancher/rancher-team-2-hostbusters-dev
 
 # Rancher VSphere
 packages/rancher-vsphere @rancher/rancher-team-2-hostbusters-dev
+assets/rancher-vsphere @rancher/rancher-team-2-hostbusters-dev
 
 # Rancher Windows GSMA
 packages/rancher-windows-gsma @rancher/rancher-team-2-hostbusters-dev
+assets/rancher-windows-gsma @rancher/rancher-team-2-hostbusters-dev
 
 # Rancher Webhook
 packages/rancher-webhook @rancher/rancher-squad-frameworks
+assets/rancher-webhook @rancher/rancher-squad-frameworks
 
 # System Upgrade Controller
 packages/system-upgrade-controller @rancher/rancher-team-2-hostbusters-dev
+assets/system-upgrade-controller @rancher/rancher-team-2-hostbusters-dev

--- a/.github/workflows/auto-bump-manual-trigger.yaml
+++ b/.github/workflows/auto-bump-manual-trigger.yaml
@@ -12,13 +12,18 @@ on:
         required: true
         default: "dev-v2.11"
       version-override:
-        description: "disable the bump version auto calculation with a version to override it"
+        description: "Optional: disable the bump version auto calculation, forcing it to be a patch or minor version bump"
         required: false
-        default: ""
+        type: choice
+        options:
+          - auto
+          - patch
+          - minor
+        default: 'auto'
 
 
 jobs:
   auto-bump:
     uses: ./.github/workflows/auto-bump.yaml
     with:
-      eventPayload: '{"chart": "${{ github.event.inputs.chart }}", "branch": "${{ github.event.inputs.branch }}"}'
+      eventPayload: '{"chart": "${{ github.event.inputs.chart }}", "branch": "${{ github.event.inputs.branch }}", "version-override": "${{ github.event.inputs.version-override }}"}'

--- a/.github/workflows/auto-bump.yaml
+++ b/.github/workflows/auto-bump.yaml
@@ -35,10 +35,6 @@ jobs:
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
 
-      - name: Checkout to new branch
-        run: |
-          git checkout -b "auto-bump_${{ env.CHART }}"
-
       - name: make pull-scripts
         run: |
           echo "make pull-scripts"
@@ -46,7 +42,7 @@ jobs:
 
       - name: chart-bump
         run: |
-          LOG="DEBUG" ./bin/charts-build-scripts chart-bump --package="${{ env.CHART }}" --branch="${{ env.BRANCH }}" --version="${{ env.VERSION_OVERRIDE }}"
+          LOG="DEBUG" ./bin/charts-build-scripts chart-bump --package="${{ env.CHART }}" --branch="${{ env.BRANCH }}" --override="${{ env.VERSION_OVERRIDE }}"
 
       - name: read bump version from json file
         id: read_bump_version
@@ -64,11 +60,14 @@ jobs:
             echo "Error: Could not read '.new_version' or value is null/empty in $JSON_FILE"
             exit 1
           fi
-
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "New version: $NEW_VERSION"
+          cat "$JSON_FILE"
 
           CHARTS_ARRAY_JSON=$(jq -c '.charts' "$JSON_FILE")
           echo $CHARTS_ARRAY_JSON
+
+          echo "BUMP_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
 
       - name: Git status
         run: |
@@ -92,14 +91,31 @@ jobs:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.PRIVATE_KEY }}
 
+      - name: Set Branch Name Output
+        id: set_branch # Give step an id
+        run: |
+          echo 'NEW_BRANCH="auto-bump_${{ env.CHART }}_${{ env.BUMP_VERSION }}"' >> $GITHUB_ENV
+
+      - name: Echo Job Outputs (for debugging)
+        run: |
+          echo "BRANCH: ${{ env.BRANCH}}"
+          echo "CHART: ${{ env.CHART}}"
+          echo "NEW_BRANCH: ${{ env.NEW_BRANCH}}"
+          echo "BUMP_VERSION: ${{ env.BUMP_VERSION}}"
+
+
+      - name: Checkout to new branch
+        run: |
+          git checkout -b "${{ env.NEW_BRANCH}}"
+
       - name: Git Add, Commit, Push Changes
         run: |
           git add .
-          git commit -m "auto bump chart: ${{ env.CHART }} version: ${{ env.new_version }}"
-          git push origin "auto-bump_${{ env.CHART }}"
+          git commit -m "auto bump chart: ${{ env.CHART }} version: ${{ env.BUMP_VERSION }}"
+          git push origin "${{ env.NEW_BRANCH}}"
 
       - name: Create Pull Request
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          gh pr create --base ${{ env.BRANCH }} --head "auto-bump_${{ env.CHART }}" --title "[${{ env.BRANCH }}] auto: ${{ env.CHART }} ${{ steps.read_bump_version.outputs.version }}" --body-file '.github/auto_bump_template.md'
+          gh pr create --base ${{ env.BRANCH }} --head "${{ env.NEW_BRANCH}}" --title "[${{ env.BRANCH }}] auto: ${{ env.CHART }} ${{ env.BUMP_VERSION }}" --body-file '.github/auto_bump_template.md'

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ bin
 *.swp
 .vscode
 *.log
-config/bump_version.json
 config/state.json


### PR DESCRIPTION
#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [ ] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [ ] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->