### PR TITLE
[release-v2.11] fixing regsync-split ruby script

### DIFF
--- a/scripts/regsync-split.rb
+++ b/scripts/regsync-split.rb
@@ -3,10 +3,21 @@
 require "json"
 require "pathname"
 require "yaml"
+require 'pp'
 
-pwd = Pathname(Dir.pwd)
+script_dir = Pathname(__dir__)
+repo_root = script_dir.parent
+config_file_path = repo_root + "config/regsync.yaml"
 
-regsync = YAML.load((pwd + "/config/regsync.yaml").read)
+pp script_dir
+pp repo_root
+pp config_file_path
+
+unless config_file_path.exist?
+  abort "Error: Config file not found at calculated path: #{config_file_path}"
+end
+
+regsync = YAML.load(config_file_path.read)
 
 regsync["sync"].sum do |sync|
   allow_tags = sync.dig("tags", "allow") || []
@@ -17,7 +28,7 @@ end
 
 regsync["sync"].each do |sync|
   regsync.merge("sync" => [sync]).then do |regsync|
-    (pwd + "split-regsync" + sync["source"]).then do |dir|
+    (repo_root + "split-regsync" + sync["source"]).then do |dir|
       dir.mkpath
       (dir + "split-regsync.yaml").write(YAML.dump(regsync))
     end


### PR DESCRIPTION
Forcing absolute path references