### PR TITLE
removing prometheus-version on index.yaml which has no chart generated

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -10696,38 +10696,6 @@ entries:
       catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
       catalog.cattle.io/release-name: prometheus-federator
     apiVersion: v2
-    appVersion: v3.1.0-rc.3
-    created: "2025-05-12T13:48:11.771824-04:00"
-    description: Prometheus Federator - installs rancher-project-monitoring in project
-      namespaces.
-    digest: dbf8389ab1343d2b06a596dad9c8ef2dcc8cce812ffc42c293626aced6515e92
-    icon: file://assets/logos/prometheus-federator.svg
-    keywords:
-    - prometheus
-    - monitoring
-    - project-monitoring
-    maintainers:
-    - email: alexandre.lamarre@suse.com
-      name: Alexandre
-    - email: dan.pock@suse.com
-      name: Dan
-    - email: julia.suriano@suse.com
-      name: Julia
-    name: prometheus-federator
-    urls:
-    - assets/prometheus-federator/prometheus-federator-106.1.0+up3.1.0-rc.3.tgz
-    version: 106.1.0+up3.1.0-rc.3
-  - annotations:
-      catalog.cattle.io/certified: rancher
-      catalog.cattle.io/display-name: Prometheus Federator
-      catalog.cattle.io/kube-version: '>= 1.30.0-0 < 1.33.0-0'
-      catalog.cattle.io/namespace: cattle-monitoring-system
-      catalog.cattle.io/os: linux,windows
-      catalog.cattle.io/permits-os: linux,windows
-      catalog.cattle.io/provides-gvr: helm.cattle.io.projecthelmchart/v1alpha1
-      catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
-      catalog.cattle.io/release-name: prometheus-federator
-    apiVersion: v2
     appVersion: v3.0.1
     created: "2025-04-23T08:54:47.528413-04:00"
     description: Prometheus Federator - installs rancher-project-monitoring in project


### PR DESCRIPTION
Removing a forgotten RC entry for prometheus-federator in the index.yaml

The chart and .tgz file had been previously removed already. 