### PR TITLE
[v2.12] Keep RCs by default with Auto Chart Bump

### DIFF
--- a/.github/workflows/auto-bump-manual-trigger.yaml
+++ b/.github/workflows/auto-bump-manual-trigger.yaml
@@ -21,10 +21,10 @@ on:
           - minor
         default: 'auto'
       multi-rc:
-        description: "Multi-RC (optional): allow multiple-RC versions for this bump, the default behavior is to remove the previous RC version"
+        description: "Multi-RC (optional): allow multiple-RC versions for this bump, the default behavior is to keep the previous RC version"
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   auto-bump:


### PR DESCRIPTION
to prevent issues with pinned versions.