### PR TITLE
[dev-v2.12] manually changing rc version order of webhook

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -32574,14 +32574,14 @@ entries:
       catalog.cattle.io/rancher-version: '>= 2.12.0-0 < 2.13.0-0'
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
-    appVersion: 0.8.1-rc.1
-    created: "2025-08-08T19:28:37.946634173Z"
+    appVersion: 0.8.1-rc.3
+    created: "2025-08-21T22:58:05.528245359Z"
     description: ValidatingAdmissionWebhook for Rancher types
-    digest: a329fa84858a36aaeeb23237293fcf8cc62a415734709bb0f4808f62e1830707
+    digest: 499fdf89e8025c47f04deae753e243822cf24fcd64c16dc7af789574a45ef15b
     name: rancher-webhook
     urls:
-    - assets/rancher-webhook/rancher-webhook-107.0.1+up0.8.1-rc.1.tgz
-    version: 107.0.1+up0.8.1-rc.1
+    - assets/rancher-webhook/rancher-webhook-107.0.1+up0.8.1-rc.3.tgz
+    version: 107.0.1+up0.8.1-rc.3
   - annotations:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"
@@ -32593,14 +32593,14 @@ entries:
       catalog.cattle.io/rancher-version: '>= 2.12.0-0 < 2.13.0-0'
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
-    appVersion: 0.8.1-rc.3
-    created: "2025-08-21T22:58:05.528245359Z"
+    appVersion: 0.8.1-rc.1
+    created: "2025-08-08T19:28:37.946634173Z"
     description: ValidatingAdmissionWebhook for Rancher types
-    digest: 499fdf89e8025c47f04deae753e243822cf24fcd64c16dc7af789574a45ef15b
+    digest: a329fa84858a36aaeeb23237293fcf8cc62a415734709bb0f4808f62e1830707
     name: rancher-webhook
     urls:
-    - assets/rancher-webhook/rancher-webhook-107.0.1+up0.8.1-rc.3.tgz
-    version: 107.0.1+up0.8.1-rc.3
+    - assets/rancher-webhook/rancher-webhook-107.0.1+up0.8.1-rc.1.tgz
+    version: 107.0.1+up0.8.1-rc.1
   - annotations:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/637

The RC order might be affecting the `rancher-images.txt` generation. 

Quickly changing and testing it. 