### PR TITLE
[dev-v2.11] Add net new rancher turtles 2.11

### DIFF
--- a/packages/rancher-turtles/package.yaml
+++ b/packages/rancher-turtles/package.yaml
@@ -1,0 +1,5 @@
+auto: true
+url: https://github.com/rancher/turtles.git
+chartRepoBranch: release-0.23
+subdirectory: charts/rancher-turtles
+workingDir: charts


### PR DESCRIPTION
@furkatgofurov7 

This is how you will add the other versions of `rancher-turtles`.

Attention to the following fields:
```
# branch corresponding to the current version line, i.e, 2.11
chartRepoBranch: release-0.23

# this has to be charts for the automatic make icons work
workingDir: charts
``` 
