### PR TITLE
[dev-v2.11] fixing rc order for webhook in index.yaml

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -32292,14 +32292,14 @@ entries:
       catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
-    appVersion: 0.7.6-rc.1
-    created: "2025-09-09T16:50:16.72674246Z"
+    appVersion: 0.7.6-rc.3
+    created: "2025-09-19T18:30:27.450944196Z"
     description: ValidatingAdmissionWebhook for Rancher types
-    digest: b6e82c86039d8eb510b5304f6258ddada07e32de1c6328a6d34b2c67a7779d70
+    digest: 2c5548c4b1f53590cee5beaa76abb773d3591dbbab31f486e27c2607c9b2de1c
     name: rancher-webhook
     urls:
-    - assets/rancher-webhook/rancher-webhook-106.0.6+up0.7.6-rc.1.tgz
-    version: 106.0.6+up0.7.6-rc.1
+    - assets/rancher-webhook/rancher-webhook-106.0.6+up0.7.6-rc.3.tgz
+    version: 106.0.6+up0.7.6-rc.3
   - annotations:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"
@@ -32311,14 +32311,14 @@ entries:
       catalog.cattle.io/rancher-version: '>= 2.11.0-0 < 2.12.0-0'
       catalog.cattle.io/release-name: rancher-webhook
     apiVersion: v2
-    appVersion: 0.7.6-rc.3
-    created: "2025-09-19T18:30:27.450944196Z"
+    appVersion: 0.7.6-rc.1
+    created: "2025-09-09T16:50:16.72674246Z"
     description: ValidatingAdmissionWebhook for Rancher types
-    digest: 2c5548c4b1f53590cee5beaa76abb773d3591dbbab31f486e27c2607c9b2de1c
+    digest: b6e82c86039d8eb510b5304f6258ddada07e32de1c6328a6d34b2c67a7779d70
     name: rancher-webhook
     urls:
-    - assets/rancher-webhook/rancher-webhook-106.0.6+up0.7.6-rc.3.tgz
-    version: 106.0.6+up0.7.6-rc.3
+    - assets/rancher-webhook/rancher-webhook-106.0.6+up0.7.6-rc.1.tgz
+    version: 106.0.6+up0.7.6-rc.1
   - annotations:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/hidden: "true"


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/639

#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [ ] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [ ] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->