### PR TITLE
Update chart-bump to require override argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,12 +18,12 @@ validate:
 	@./bin/charts-build-scripts validate $(if $(filter true,$(remote)),--remote) $(if $(filter true,$(local)),--local)
 
 chart-bump:
-	@if [ -z "$(package)" ] || [ -z "$(branch)" ]; then \
-		echo "Error: package and branch arguments are required."; \
+	@if [ -z "$(package)" ] || [ -z "$(branch)" ] || [ -z "$(override)" ]; then \
+		echo "Error: package, branch and override arguments are required."; \
 		exit 1; \
 	fi
 	@./scripts/pull-scripts
-	@./bin/charts-build-scripts chart-bump --package="$(package)" --branch="$(branch)"
+	@./bin/charts-build-scripts chart-bump --package="$(package)" --branch="$(branch)" --override="$(override)" $(if $(multirc),--multirc="$(multirc)")
 
 TARGETS := prepare patch clean clean-cache charts list index unzip zip standardize template regsync check-images check-rc enforce-lifecycle lifecycle-status auto-forward-port icon
 


### PR DESCRIPTION
to prevent failure of charts-build-script.

And also add support for multiarch.

This fixes the following [issue](https://github.com/rancher/fleet/actions/runs/18009357656/job/51237469562).