### PR TITLE
[dev-v2.12] rancher-monitoring - 106 and 107 - Fixed indentation issue with metricRelabelings in multiple servicemonitor manifests

### DIFF
--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.0+up66.7.1-rancher.2/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.1+up66.7.1-rancher.10/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.0.2+up66.7.1-rancher.14/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.0+up69.8.2-rancher.4/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/106.1.2+up69.8.2-rancher.7/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.0.0+up69.8.2-rancher.8/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.1.0+up69.8.2-rancher.15/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.0+up69.8.2-rancher.20/templates/rancher-monitoring/exporters/ingress-nginx/servicemonitor.yaml
@@ -30,7 +30,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.ingressNginx.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.ingressNginx.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/core-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/core-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     metricRelabelings:
     {{- if .Values.coreDns.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.coreDns.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
     - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-controller-manager/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-controller-manager/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if.Values.kubeControllerManager.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeControllerManager.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-dns/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-dns/servicemonitor.yaml
@@ -43,7 +43,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings }}
-    {{ tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeDns.serviceMonitor.dnsmasqMetricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-etcd/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-etcd/servicemonitor.yaml
@@ -60,7 +60,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.kubeEtcd.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeEtcd.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-proxy/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-proxy/servicemonitor.yaml
@@ -48,7 +48,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeProxy.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeProxy.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-scheduler/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/exporters/kube-scheduler/servicemonitor.yaml
@@ -54,7 +54,7 @@ spec:
     {{- end}}
     metricRelabelings:
     {{- if .Values.kubeScheduler.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | indent 4) . }}
+    {{- tpl (toYaml .Values.kubeScheduler.serviceMonitor.metricRelabelings | nindent 4) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/prometheus-operator/servicemonitor.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/prometheus-operator/servicemonitor.yaml
@@ -31,7 +31,7 @@ spec:
     {{- end }}
     metricRelabelings:
     {{- if .Values.prometheusOperator.serviceMonitor.metricRelabelings }}
-    {{ tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheusOperator.serviceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]

--- a/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/prometheus/servicemonitorThanosSidecar.yaml
+++ b/charts/rancher-monitoring/107.2.1-rc.1+up69.8.2-rancher.23/templates/prometheus/servicemonitorThanosSidecar.yaml
@@ -36,7 +36,7 @@ spec:
     path: "/metrics"
     metricRelabelings:
     {{- if .Values.prometheus.thanosServiceMonitor.metricRelabelings}}
-    {{ tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | indent 6) . }}
+    {{- tpl (toYaml .Values.prometheus.thanosServiceMonitor.metricRelabelings | nindent 6) . }}
     {{- end }}
     {{ if .Values.global.cattle.clusterId }}
       - sourceLabels: [__address__]


### PR DESCRIPTION
Signed-off-by: Mohamed Belgaied <mohamed.belgaied@suse.com>

#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [X] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [X] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: 
https://github.com/rancher/rancher/issues/43392
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
The `metricRelabelings` attribute in `ServiceMonitor` takes in a list of maps coming from the `values.yaml`.
In order to template that in helm, the previous implementation did the following :\
```
  {{ tpl (toYaml .Values.XXX.metricRelabelings ) . | indent 4 }}
```
This does not work with multiline relabelings, such as:
```
  - action: keep
    sourceLabels: [__name__]
    regex: <some_regex>
```
which would generate:
```
  metricRelabelings:
      - action: keep
    sourceLabels: [__name__]
    regex: <some_regex>
```
AND throw an error!

We need to remove first space characters using `{{- tpl ...` and do multiline indentation using `nindent` instead of `indent`.

That's what this PR does for each location of `metricRelabelings` in versions 106 and 107 of the `rancher-monitoring` chart.
  
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
Add automatic testing for multiline indentations, specifically around `metricRelabelings` which is a VERY frequent use case.

