### PR TITLE
[dev-v2.11] fix: Remove rancher-turtles package.yaml

### DIFF
--- a/packages/rancher-turtles/package.yaml
+++ b/packages/rancher-turtles/package.yaml
@@ -1,5 +1,0 @@
-auto: true
-url: https://github.com/rancher/turtles.git
-chartRepoBranch: release-0.23
-subdirectory: charts/rancher-turtles
-workingDir: charts


### PR DESCRIPTION
Removing rancher-turtles from `dev-v2.11` since it was added as a test.