### PR TITLE
[dev-v2.13] Remove pull request target and harden validation comment action

### DIFF
--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -10,12 +10,15 @@ on:
       - 'charts/**'
       - 'packages/**'
 
+permissions: {}
+
 jobs:
   validation-comment:
     name: Make validation comment on PR
     runs-on: ubuntu-latest
-    permissions: 
-      pull-requests: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Make validation comment
         uses: actions/github-script@v7

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -19,11 +19,11 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
+    permissions:
+        pull-requests: write # necessary to add the comment to the PR
     steps:
       - name: Make validation comment
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8
-        permissions:
-          pull-requests: write # necessary to add the comment to the PR
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -1,7 +1,7 @@
 name: Validation Comment
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - dev-v*
       - release-v*

--- a/.github/workflows/validation-comment.yaml
+++ b/.github/workflows/validation-comment.yaml
@@ -21,7 +21,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Make validation comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd #v8
+        permissions:
+          pull-requests: write # necessary to add the comment to the PR
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
* `pull_request_target` is unsafe and it's use is banned.
* Permissions at the top level are discouraged
* github scripts action was pinned and bumped to v8
* adding concurrency limits prevents resource waste as an attack vector 
