### PR TITLE
[dev-v2.15] centralized build workflow from automation-core branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>rancher/renovate-config#release"
+  ],
+  "enabledManagers": ["github-actions"],
+  "includePaths": [
+    ".github/workflows/build.yaml"
+  ],
+  "github-actions": {
+    "fileMatch": ["\\.github/workflows/build\\.yaml$"],
+    "pinDigests": true
+  },
+  "packageRules": [
+    {
+      "description": "Group all GitHub Actions updates together",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true,
+      "automergeType": "pr",
+      "requiredStatusChecks": ["Validate"]
+    },
+    {
+      "description": "Ignore internal composite actions (they reference automation-core branch)",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^rancher/charts$"],
+      "enabled": false
+    }
+  ],
+  "prConcurrentLimit": 2,
+  "prHourlyLimit": 2,
+  "semanticCommits": "enabled",
+  "commitMessagePrefix": "renovate(deps):"
+}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -156,3 +156,4 @@ jobs:
           app_token: ${{ steps.app_token.outputs.token }}
           docker_username: ${{ steps.secrets.outputs.docker_username }}
           docker_password: ${{ steps.secrets.outputs.docker_password }}
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,9 @@
+# TEMPLATE: Copy this file to active branches as .github/workflows/build.yaml
+# Adjust the branch pattern in 'on.pull_request.branches' to match the target branch
+#
+# This workflow keeps vault/checkout steps local (for OIDC context),
+# then delegates all validation logic to the centralized composite action.
+
 name: Build
 
 on:
@@ -13,31 +19,37 @@ jobs:
     container: registry.suse.com/bci/bci-base:latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write  # Required for OIDC authentication with Vault
     steps:
-      - name: Install Dependencies
-        continue-on-error: false
-        env:
-          GH_VERSION: 2.63.2
-          YQ_VERSION: "v4.44.2"
+      # ====================================================================
+      # WORKFLOW CONTEXT
+      # ====================================================================
+      - name: Display PR Context
         run: |
-          echo "installing docker, jq, git, make, go, awk and patch through zypper"
-          zypper --non-interactive install docker jq git make go awk patch
-          echo "installing gh"
-          mkdir -p /tmp/gh
-          curl -fsL https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz | tar xvzf - --strip-components=1 -C /tmp/gh
-          mv /tmp/gh/bin/gh /usr/bin/gh
-          chmod +x /usr/bin/gh
+          echo "================================================================="
+          echo "Build Validation Workflow"
+          echo "================================================================="
+          echo "PR Number:       ${{ github.event.pull_request.number }}"
+          echo "Target Branch:   ${{ github.base_ref }}"
+          echo "Source Branch:   ${{ github.head_ref }}"
+          echo "Author:          ${{ github.event.pull_request.user.login }}"
+          echo "Repository:      ${{ github.repository }}"
+          echo "Commit SHA:      ${{ github.event.pull_request.head.sha }}"
+          echo "================================================================="
 
-          echo "installing yq"
-          curl -fsL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/bin/yq
-          chmod +x /usr/bin/yq
-          echo "yq version:"
-          yq --version
+      # ====================================================================
+      # DEPENDENCY INSTALLATION
+      # ====================================================================
+      - name: Install Dependencies
+        uses: rancher/charts/.github/actions/dependencies@automation-core
 
+      # ====================================================================
+      # SECRETS MANAGEMENT (OIDC vault authentication)
+      # ====================================================================
       - name: Load Secrets from Vault
         continue-on-error: true
-        uses: rancher-eio/read-vault-secrets@main
+        id: vault
+        uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
         with:
           secrets: |
             secret/data/github/repo/${{ github.repository }}/dockerhub/rancher/credentials username | DOCKER_USERNAME ;
@@ -45,86 +57,102 @@ jobs:
             secret/data/github/repo/${{ github.repository }}/github/app-credentials appId | APP_ID ;
             secret/data/github/repo/${{ github.repository }}/github/app-credentials privateKey | PRIVATE_KEY ;
 
-      - name: Create App Token
-        continue-on-error: true
-        uses: actions/create-github-app-token@v1
-        id: app-token
-        with:
-          app-id: ${{ env.APP_ID }}
-          private-key: ${{ env.PRIVATE_KEY }}
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Git Checkout PR and into new branch
-        continue-on-error: false
-        env:
-          BASE_REF: ${{ github.base_ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Check Vault Status
         run: |
-          echo "git global configuration"
-          git config --global --add safe.directory "$PWD"
-          echo $PATH >> $GITHUB_PATH
-          echo "fetch the pull request"
-          git fetch origin "${BASE_REF}"
-          git fetch origin "pull/${PR_NUMBER}/head:pr-${PR_NUMBER}"
-          echo "checkout the PR"
-          git checkout "pr-${PR_NUMBER}"
-          echo "checkout into a new branch for safety"
-          git checkout -b staging-pr-workflow
-
-      - name: Pull scripts
-        continue-on-error: false
-        run: make pull-scripts
-
-      - name: Check release.yaml format with yq
-        continue-on-error: false
-        env:
-          LOG: "DEBUG"
-        run: make check-release-yaml
-
-      - name: Lint image tags
-        env:
-          BASE_BRANCH: ${{ github.base_ref }}
-        run: ./bin/charts-build-scripts lint-images
-
-      - name: Release PR Validation Chekpoints
-        continue-on-error: false
-        if: contains(github.base_ref, 'release-v')
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          BRANCH: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          LOG: "DEBUG"
-        run: make validate-release-charts
-
-      - name: Validate index.yaml Vs assets/ dir
-        continue-on-error: false
-        env:
-          LOG: "DEBUG"
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          echo "github.base_ref: ${BASE_REF}"
-          if [[ "${BASE_REF}" == *release-v* ]]; then
-            echo "Validating remote release branch"
-            make validate remote=true
+          if [[ "${{ steps.vault.outcome }}" == "failure" ]]; then
+            echo "================================================================="
+            echo "WARNING: Vault authentication failed"
+            echo "================================================================="
+            echo ""
+            echo "This is expected if you are opening a PR from a fork."
+            echo ""
+            echo "Impact:"
+            echo "  - Docker image checks may be rate-limited (slower)"
+            echo "  - Some validation features may be limited"
+            echo "  - Build will still run and validate your changes"
+            echo ""
+            echo "Recommendation for fork contributors:"
+            echo "  Open PRs against upstream using feature branch names that"
+            echo "  do NOT match dev-v* or release-v* patterns to avoid triggering"
+            echo "  this workflow. Branches are auto-deleted after merge."
+            echo ""
+            echo "================================================================="
           else
-            echo "Validating local branch"
-            make validate
+            echo "Vault authentication successful"
           fi
 
-      - name: Check Images
-        continue-on-error: false
-        env:
-          DOCKER_USERNAME: ${{ env.DOCKER_USERNAME }}
-          DOCKER_PASSWORD: ${{ env.DOCKER_PASSWORD }}
-          LOG: "DEBUG"
-        run: make check-images
+      - name: Export Vault Secrets as Outputs
+        id: secrets
+        run: |
+          # Check if secrets were loaded (will be empty for fork PRs)
+          if [[ -z "${{ env.DOCKER_USERNAME }}" ]] || [[ -z "${{ env.DOCKER_PASSWORD }}" ]]; then
+            echo "WARNING: Docker credentials not available from Vault"
+            echo "  This is expected for fork PRs (no Vault access)"
+            echo "  Docker image checks may be rate-limited"
+          else
+            echo "Docker credentials loaded successfully"
+            echo "::add-mask::${{ env.DOCKER_USERNAME }}"
+            echo "::add-mask::${{ env.DOCKER_PASSWORD }}"
+          fi
 
-      - name: Check RC's
-        continue-on-error: false
-        if: contains(github.base_ref, 'release-v')
-        env:
-          LOG: "DEBUG"
-        run: make check-rc
+          if [[ -z "${{ env.APP_ID }}" ]] || [[ -z "${{ env.PRIVATE_KEY }}" ]]; then
+            echo "WARNING: GitHub App credentials not available from Vault"
+            echo "  This is expected for fork PRs (no Vault access)"
+            echo "  Some validation features may be limited"
+          else
+            echo "GitHub App credentials loaded successfully"
+            echo "::add-mask::${{ env.APP_ID }}"
+            echo "::add-mask::${{ env.PRIVATE_KEY }}"
+          fi
 
+          # Export as step outputs (empty values are OK for fork PRs)
+          echo "docker_username=${{ env.DOCKER_USERNAME }}" >> $GITHUB_OUTPUT
+          echo "docker_password=${{ env.DOCKER_PASSWORD }}" >> $GITHUB_OUTPUT
+          echo "app_id=${{ env.APP_ID }}" >> $GITHUB_OUTPUT
+          echo "private_key=${{ env.PRIVATE_KEY }}" >> $GITHUB_OUTPUT
+
+      - name: Create App Token
+        continue-on-error: true
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        id: app_token
+        with:
+          app-id: ${{ steps.secrets.outputs.app_id }}
+          private-key: ${{ steps.secrets.outputs.private_key }}
+
+      - name: Check App Token Status
+        run: |
+          if [[ "${{ steps.app_token.outcome }}" == "failure" ]]; then
+            echo "================================================================="
+            echo "WARNING: GitHub App token creation failed"
+            echo "================================================================="
+            echo ""
+            echo "This is expected if Vault authentication failed (fork PRs)."
+            echo ""
+            echo "Impact:"
+            echo "  - Some GitHub API-based validation features may be limited"
+            echo "  - Build will still run and validate your changes"
+            echo ""
+            echo "================================================================="
+          else
+            echo "GitHub App token created successfully"
+          fi
+
+      # ====================================================================
+      # REPOSITORY SETUP
+      # ====================================================================
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      # ====================================================================
+      # VALIDATION
+      # ====================================================================
+      - name: Build Validation
+        uses: rancher/charts/.github/actions/build@automation-core
+        with:
+          base_ref: ${{ github.base_ref }}
+          pr_number: ${{ github.event.pull_request.number }}
+          app_token: ${{ steps.app_token.outputs.token }}
+          docker_username: ${{ steps.secrets.outputs.docker_username }}
+          docker_password: ${{ steps.secrets.outputs.docker_password }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Export Vault Secrets as Outputs
         id: secrets
+        continue-on-error: false
         run: |
           # Check if secrets were loaded (will be empty for fork PRs)
           if [[ -z "${{ env.DOCKER_USERNAME }}" ]] || [[ -z "${{ env.DOCKER_PASSWORD }}" ]]; then
@@ -109,7 +110,13 @@ jobs:
           echo "docker_username=${{ env.DOCKER_USERNAME }}" >> $GITHUB_OUTPUT
           echo "docker_password=${{ env.DOCKER_PASSWORD }}" >> $GITHUB_OUTPUT
           echo "app_id=${{ env.APP_ID }}" >> $GITHUB_OUTPUT
-          echo "private_key=${{ env.PRIVATE_KEY }}" >> $GITHUB_OUTPUT
+
+          # Use heredoc format for private_key (multi-line PEM certificate)
+          {
+            echo "private_key<<EOF"
+            echo "${{ env.PRIVATE_KEY }}"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
       - name: Create App Token
         continue-on-error: true

--- a/scripts/import-build-workflow.sh
+++ b/scripts/import-build-workflow.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -e
+
+echo "================================================================="
+echo "Import Build Workflow from automation-core"
+echo "================================================================="
+echo ""
+
+# Configuration
+REMOTE="upstream"
+AUTOMATION_BRANCH="automation-core"
+SOURCE_FILE=".github/workflows/build-core.yaml"
+TARGET_FILE=".github/workflows/build.yaml"
+
+# Validate we're in a git repository
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+  echo "ERROR: Not in a git repository"
+  exit 1
+fi
+
+# Check if target file exists
+if [[ ! -f "$TARGET_FILE" ]]; then
+  echo "WARNING: $TARGET_FILE does not exist"
+  echo "It will be created"
+fi
+
+# Fetch latest automation-core
+echo "Fetching latest $AUTOMATION_BRANCH from $REMOTE..."
+git fetch "$REMOTE" "$AUTOMATION_BRANCH"
+
+# Extract build-core.yaml from automation-core
+echo "Extracting $SOURCE_FILE from $REMOTE/$AUTOMATION_BRANCH..."
+git show "$REMOTE/$AUTOMATION_BRANCH:$SOURCE_FILE" > "$TARGET_FILE"
+
+echo ""
+echo "================================================================="
+echo "✓ Import completed successfully"
+echo "================================================================="
+echo ""
+echo "Changes:"
+echo "  Imported: $SOURCE_FILE"
+echo "  To:       $TARGET_FILE"
+echo ""
+echo "Next steps:"
+echo "  Review changes:  git diff $TARGET_FILE"
+echo "  Stage changes:   git add $TARGET_FILE"
+echo "  Commit:          git commit -m 'feat(ci): update build workflow from automation-core'"
+echo ""


### PR DESCRIPTION
Issue: https://github.com/rancher/charts/issues/817

## Summary
- Migrate build workflow to use centralized composite actions from automation-core branch
- Add import-build-workflow.sh script to sync build-core.yaml from automation-core
- Add renovate config scoped to build.yaml for automated GHA updates with CI-gated automerge
- Pin all external GitHub Actions to commit SHAs for security
- Support fork PRs with graceful degradation when vault credentials unavailable

## Tests
- PR #7214 validation passing with centralized workflow