### PR TITLE
fix(dependencies): correct gh download URL to fix checksum mismatch

### DIFF
--- a/.github/actions/dependencies/action.yaml
+++ b/.github/actions/dependencies/action.yaml
@@ -233,7 +233,7 @@ runs:
         INSTALL_PATH: "/usr/bin/gh"
       run: |
         echo "install gh (pinned version)"
-        curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
+        curl -sL "https://github.com/cli/cli/releases/download/${GH_VERSION}/gh_${GH_VERSION#v}_linux_amd64.tar.gz" -o /tmp/gh.tar.gz
 
         echo "verify checksum"
         ACTUAL_CHECKSUM=$(sha256sum /tmp/gh.tar.gz | cut -d' ' -f1)
@@ -248,9 +248,9 @@ runs:
 
         echo "extract and install to $INSTALL_PATH"
         tar -xzf /tmp/gh.tar.gz -C /tmp
-        mv "/tmp/gh_${GH_VERSION}_linux_amd64/bin/gh" "$INSTALL_PATH"
+        mv "/tmp/gh_${GH_VERSION#v}_linux_amd64/bin/gh" "$INSTALL_PATH"
         chmod +x "$INSTALL_PATH"
-        rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION}_linux_amd64"
+        rm -rf /tmp/gh.tar.gz "/tmp/gh_${GH_VERSION#v}_linux_amd64"
 
         echo "verify version"
         gh --version

--- a/scripts/update-dependencies.sh
+++ b/scripts/update-dependencies.sh
@@ -99,7 +99,7 @@ for pkg in "${!GITHUB_PACKAGES[@]}"; do
     asset_name=$(echo "$asset_pattern" | sed "s/{VERSION}/$version_number/g")
 
     # Download asset and calculate checksum
-    docker run --rm registry.suse.com/bci/bci-base:latest bash -c "
+    docker run --rm --name "github-release_$pkg" registry.suse.com/bci/bci-base:latest bash -c "
       curl -sL https://github.com/$repo/releases/download/${latest_version}/${asset_name} -o /tmp/${pkg}_asset
       echo \"$latest_version\"
       sha256sum /tmp/${pkg}_asset | cut -d' ' -f1


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/817

## Summary
- Fix gh installation URL construction bug causing checksum verification failure
- GH_VERSION includes 'v' prefix (v2.89.0) but tarball filename uses version without 'v' (gh_2.89.0_linux_amd64.tar.gz)
- Use ${GH_VERSION#v} bash parameter expansion to strip 'v' prefix from filename and extraction paths
- Add --name flag to docker containers in update-dependencies.sh for github-release packages (yq, gh)