### PR TITLE
[automation-core] improve pull-scripts and build job

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -234,6 +234,7 @@ runs:
     - name: (./scripts/package-ci) Verify all packages pass build workflow
       shell: bash
       env:
+        SKIP_PS: true
         LOG: "DEBUG"
       run: ./scripts/package-ci
 
@@ -247,6 +248,7 @@ runs:
       shell: bash
       if: contains(inputs.base_ref, 'release-v')
       env:
+        SKIP_PS: true
         GH_TOKEN: ${{ inputs.app_token }}
         BRANCH: ${{ inputs.base_ref }}
         PR_NUMBER: ${{ inputs.pr_number }}
@@ -271,6 +273,7 @@ runs:
     - name: (make check-images) Validate Docker image availability
       shell: bash
       env:
+        SKIP_PS: true
         DOCKER_USERNAME: ${{ inputs.docker_username }}
         DOCKER_PASSWORD: ${{ inputs.docker_password }}
         LOG: "DEBUG"
@@ -280,6 +283,7 @@ runs:
       shell: bash
       if: contains(inputs.base_ref, 'release-v')
       env:
+        SKIP_PS: true
         LOG: "DEBUG"
       run: make check-rc
 

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -284,13 +284,20 @@ runs:
       run: make check-rc
 
     - name: Post build validation summary
-      if: success()
+      if: success() && inputs.github_token != ''
+      continue-on-error: true
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.github_token }}
         PR_NUMBER: ${{ inputs.pr_number }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
+        # Check if token has comment permissions
+        if ! gh pr view ${PR_NUMBER} --json number &>/dev/null; then
+          echo "WARNING: Cannot access PR (expected for fork PRs) - skipping comment"
+          exit 0
+        fi
+
         # Calculate duration
         END_TIME=$(date +%s)
         DURATION=$((END_TIME - BUILD_START_TIME))
@@ -319,9 +326,9 @@ runs:
         - Docker image availability"
 
         if [[ -n "$COMMENT_ID" ]]; then
-          gh api "repos/{owner}/{repo}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$BODY"
+          gh api "repos/{owner}/{repo}/issues/comments/${COMMENT_ID}" -X PATCH -f body="$BODY" || echo "Failed to update comment (expected for fork PRs)"
           echo "Updated existing comment ${COMMENT_ID}"
         else
-          gh pr comment ${PR_NUMBER} --body "$BODY"
+          gh pr comment ${PR_NUMBER} --body "$BODY" || echo "Failed to post comment (expected for fork PRs)"
           echo "Posted new comment"
         fi

--- a/.github/workflows/build-core.yaml
+++ b/.github/workflows/build-core.yaml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: read
       id-token: write  # Required for OIDC authentication with Vault
+      pull-requests: write  # Required for posting build validation summary comment
     steps:
       # ====================================================================
       # WORKFLOW CONTEXT

--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -108,13 +108,14 @@ resolve_version() {
         # Try gh first if available
         if command -v gh &> /dev/null; then
             CHARTS_BUILD_SCRIPT_VERSION=$(gh api /repos/rancher/charts-build-scripts/releases/latest 2>/dev/null | jq -r '.tag_name')
+            if [[ -n "${CHARTS_BUILD_SCRIPT_VERSION}" ]]; then
+                log "Resolved latest version to ${CHARTS_BUILD_SCRIPT_VERSION}"
+                return
+            fi
         fi
 
         # Fallback to curl if gh failed or returned empty
-        if [[ -z "${CHARTS_BUILD_SCRIPT_VERSION}" ]]; then
-            CHARTS_BUILD_SCRIPT_VERSION=$(curl --silent "https://api.github.com/repos/rancher/charts-build-scripts/releases/latest" | jq -r '.tag_name')
-        fi
-
+        CHARTS_BUILD_SCRIPT_VERSION=$(curl --silent "https://api.github.com/repos/rancher/charts-build-scripts/releases/latest" | jq -r '.tag_name')
         log "Resolved latest version to ${CHARTS_BUILD_SCRIPT_VERSION}"
     fi
 }
@@ -247,9 +248,9 @@ main() {
         return
     fi
 
-
-    check_existing_binary
+    # this is the proper order
     resolve_version
+    check_existing_binary
     detect_platform
     download_binary
     verify_binary


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/817

## Summary
- Add SKIP_PS mode to pull-scripts to skip version resolution and binary download when binary already exists
- Set SKIP_PS=true in all build validation steps to prevent rate-limiting from repeated GitHub API calls
- Optimize resolve_version to return immediately after successful gh api call instead of attempting curl fallback
- Restore correct function order (resolve_version before check_existing_binary) so version comparison works
- Add pull-requests write permission to workflow and make PR comment posting fork-safe with graceful error handling
- Improve package-ci error reporting by capturing and displaying stderr when make commands fail
- Add binary existence check in package-ci as safety guard before setting SKIP_PS