### PR TITLE
[dev-v2.13] infra propagation

### DIFF
--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -170,7 +170,7 @@ detect_platform() {
 }
 
 # Wipes bin/, then downloads the release binary from CHARTS_BUILD_SCRIPTS_REPO.
-# Exits 1 on non-200 HTTP response.
+# Exits 1 on non-200 HTTP response or checksum mismatch.
 download_binary() {
     log_function "download_binary"
     local url="${CHARTS_BUILD_SCRIPTS_REPO%.git}/releases/download/${CHARTS_BUILD_SCRIPT_VERSION}/${BINARY_NAME}"
@@ -188,6 +188,23 @@ download_binary() {
         exit 1
     fi
     log "Downloaded ${BINARY_NAME} to ${REPO_ROOT}/bin/charts-build-scripts}"
+
+    # Verify checksum (only for linux_amd64, others not supported yet)
+    if [[ "$OS" == "linux" && "$ARCH" == "amd64" ]]; then
+        log "Verifying checksum"
+        local actual_checksum
+        actual_checksum=$(sha256sum "${REPO_ROOT}/bin/charts-build-scripts" | awk '{print $1}')
+
+        if [[ "$actual_checksum" != "$CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64" ]]; then
+            echo "Error: Checksum verification failed for ${BINARY_NAME}" >&2
+            echo "  Expected: ${CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64}" >&2
+            echo "  Actual:   ${actual_checksum}" >&2
+            exit 1
+        fi
+        log "Checksum verified successfully"
+    else
+        log "WARNING: Checksum verification not implemented for ${OS}/${ARCH}"
+    fi
 }
 
 # Sanity-checks the downloaded binary with file(1), makes it executable, and runs --version.

--- a/scripts/version
+++ b/scripts/version
@@ -2,4 +2,7 @@
 set -e
 
 CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
-CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-latest}"
+# renovate: datasource=github-releases depName=rancher/charts-build-scripts
+CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.9.18}"
+# renovate: datasource=github-release-attachments depName=rancher/charts-build-scripts digestVersion=v1.9.18
+CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64="091251c2bdd5e43d61489c6a74ec9ac0d75d8287096f527d68bd3468ebabf60a"


### PR DESCRIPTION
## Summary

Automated propagation Sync from `automation-core` branch:

- .gitignore
- Makefile
- .github/workflows
- scripts/pull-scripts

---

Built for charts-build-scripts version: 1.9.18

2026-04-23