### PR TITLE
[dev-v2.14] infra propagation

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -18,13 +18,13 @@ jobs:
       uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
 
     - name: Read FOSSA token
-      uses: rancher-eio/read-vault-secrets@main
+      uses: rancher-eio/read-vault-secrets@7282bf97898cd1c16c89f837e0bb442e6d384c89 # main
       with:
         secrets: |
           secret/data/github/org/rancher/fossa/push token | FOSSA_API_KEY_PUSH_ONLY
 
     - name: FOSSA scan
-      uses: fossas/fossa-action@main
+      uses: fossas/fossa-action@29693cc50323968e039056be419b32989fc5880c # main
       with:
         api-key: ${{ env.FOSSA_API_KEY_PUSH_ONLY }}
         run-tests: false


### PR DESCRIPTION
## Summary

Automated propagation Sync from `automation-core` branch:

- .gitignore
- Makefile
- .github/workflows
- scripts/pull-scripts

---

Built for charts-build-scripts version: 1.9.18

2026-04-23