### PR TITLE
[automation-core] fix(deps): remove stderr redirect in update-dependencies

### DIFF
--- a/.github/actions/dependencies/action.yaml
+++ b/.github/actions/dependencies/action.yaml
@@ -91,7 +91,7 @@ runs:
       shell: bash
       env:
         PACKAGE_VERSION: "go-1.25-150000.3.46.1.x86_64"
-        EXPECTED_CHECKSUM: "cc6ce78d0a0fe951eb453e0626cfca0d9323c0f1bfffd670d561e3aaf1c869a8"
+        EXPECTED_CHECKSUM: "ed654c0f73370e7482c9de774f73b454ea832c405ea4eaff55934c3d7f325d62"
         BINARY_PATH: "/usr/bin/go"
       run: |
         echo "::group::Installing ${PACKAGE_VERSION}"

--- a/scripts/automation/update-dependencies
+++ b/scripts/automation/update-dependencies
@@ -162,7 +162,7 @@ fetch_zypper_package() {
     zypper --non-interactive install $pkg &>/dev/null
     rpm -q $pkg
     sha256sum $binary_path | cut -d' ' -f1
-  " > "$TEMP_DIR/$pkg.txt" 2>&1
+  " > "$TEMP_DIR/$pkg.txt"
 
   # Read results
   local version


### PR DESCRIPTION
Issue: https://github.com/rancher/ecm-distro-tools/issues/912

## Summary
- Removed `2>&1` stderr redirect in `update-dependencies` script that captured Docker pull messages into package version fields when BCI image not cached
- Updated go checksum after running fixed script (SUSE package rebuild)