### PR TITLE
[dev-v2.11] quick unblock 

### DIFF
--- a/release.yaml
+++ b/release.yaml
@@ -105,11 +105,5 @@ rancher-webhook:
   - 106.0.6+up0.7.6-rc.3
   - 106.0.7+up0.7.7-rc.1
   - 106.0.8+up0.7.8-rc.1
-neuvector-crd:
-  - 105.0.10+up2.8.13
-neuvector-monitor:
-  - 105.0.10+up2.8.13
-neuvector:
-  - 105.0.10+up2.8.13
 rancher-csp-adapter:
   - 106.0.1+up6.0.1


### PR DESCRIPTION
Somehow, the release.yaml was in an invalid state because of this PR: https://github.com/rancher/charts/pull/7528

However, my CI validation should have picked it up, but it did not. 
This blocked the following GHA: https://github.com/rancher/charts/actions/runs/26160622213/job/76953580711


Unblocking quickly and creating an issue to quickly resolve this later