### PR TITLE
[dev-v2.12] Fix remotedialer-proxy upstream URL in package.yaml

### DIFF
--- a/packages/remotedialer-proxy/package.yaml
+++ b/packages/remotedialer-proxy/package.yaml
@@ -1,2 +1,2 @@
-url: https://github.com/rancher/remotedialer/releases/download/v0.5.1-rc.1/remotedialer-proxy-0.5.1-rc.1.tgz
+url: https://github.com/rancher/remotedialer-proxy/releases/download/v0.5.1-rc.1/remotedialer-proxy-0.5.1-rc.1.tgz
 version: 106.0.2


### PR DESCRIPTION
Point remotedialer-proxy package.yaml at `rancher/remotedialer-proxy` instead of `rancher/remotedialer`. The proxy was split to its own repo but this URL was never updated.