### PR TITLE
[dev-v2.11] Fix remotedialer-proxy upstream URL in package.yaml

### DIFF
--- a/packages/remotedialer-proxy/package.yaml
+++ b/packages/remotedialer-proxy/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/rancher/remotedialer/releases/download/v0.4.4/remotedialer-proxy-0.4.4.tgz
+url: https://github.com/rancher/remotedialer-proxy/releases/download/v0.4.4/remotedialer-proxy-0.4.4.tgz
 version: 106.0.0
 doNotRelease: false


### PR DESCRIPTION
Point remotedialer-proxy package.yaml at `rancher/remotedialer-proxy` instead of `rancher/remotedialer`. The proxy was split to its own repo but this URL was never updated.