### PR TITLE
[dev-v2.11] Fix remotedialer-proxy upstream URL in package.yaml

### DIFF
--- a/packages/remotedialer-proxy/package.yaml
+++ b/packages/remotedialer-proxy/package.yaml
@@ -1,3 +1,3 @@
-url: https://github.com/rancher/remotedialer/releases/download/v0.4.5-rc.2/remotedialer-proxy-0.4.5-rc.2.tgz
+url: https://github.com/rancher/remotedialer-proxy/releases/download/v0.4.5-rc.2/remotedialer-proxy-0.4.5-rc.2.tgz
 version: 106.0.1
 doNotRelease: false


### PR DESCRIPTION
Point remotedialer-proxy package.yaml at `rancher/remotedialer-proxy` instead of `rancher/remotedialer`. The proxy was split to its own repo but this URL was never updated.