### PR TITLE
[release-v2.12] infra propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ pull-scripts:
 	./scripts/pull-scripts
 
 remove:
-	./scripts/remove-asset
+	@./scripts/pull-scripts
+	@./bin/charts-build-scripts remove --chart="$(CHART)" --version="$(VERSION)"
 
 forward-port:
 	./scripts/forward-port

--- a/scripts/pull-scripts
+++ b/scripts/pull-scripts
@@ -102,7 +102,6 @@ AUTOMATION_CORE_SCRIPTS=(
   "forward-port"
   "import-workflows"
   "package-ci"
-  "remove-asset"
   "release-validation/diff-with-released"
   "release-validation/last-released"
   "release-validation/pr-review-template.md"

--- a/scripts/version
+++ b/scripts/version
@@ -6,7 +6,3 @@ CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
 CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.9.20}"
 # renovate: datasource=github-release-attachments depName=rancher/charts-build-scripts digestVersion=v1.9.19
 CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64="4935603ca72fff6599bc02a7d251f8bc030d6bf9681e5dccea2c7a3ae2d51b01"
-
-# Branch configuration
-UPSTREAM_BRANCH=release-v2.12
-OLD_UPSTREAM_BRANCH=release-v2.11


### PR DESCRIPTION
## Summary

Automated propagation Sync from `automation-core` branch:

- .gitignore
- Makefile
- .github/workflows
- scripts/pull-scripts

---

Built for charts-build-scripts version: 1.9.20

2026-06-15