### PR TITLE
[release-v2.15] infra propagation

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -23764,6 +23764,7 @@ entries:
       catalog.cattle.io/auto-install: rancher-backup-crd=match
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/display-name: Rancher Backups
+      catalog.cattle.io/hidden: "true"
       catalog.cattle.io/kube-version: '>= 1.33.0-0 < 1.36.0-0'
       catalog.cattle.io/namespace: cattle-resources-system
       catalog.cattle.io/os: linux
@@ -38946,6 +38947,7 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/deploys-on-os: windows
       catalog.cattle.io/display-name: Monitoring
+      catalog.cattle.io/hidden: "true"
       catalog.cattle.io/kube-version: '>= 1.33.0-0 < 1.36.0-0'
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/permits-os: linux,windows

--- a/scripts/version
+++ b/scripts/version
@@ -3,6 +3,6 @@ set -e
 
 CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
 # renovate: datasource=github-releases depName=rancher/charts-build-scripts
-CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.9.22}"
-# renovate: datasource=github-release-attachments depName=rancher/charts-build-scripts digestVersion=v1.9.22
-CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64="03119dbd9441c24a10b4b1ab4dfd59a2f5efb9f7c3c67f3756e656360eeeded1"
+CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.9.24}"
+# renovate: datasource=github-release-attachments depName=rancher/charts-build-scripts digestVersion=v1.9.24
+CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64="5064441f081e4a9d1f472ddf5105c74726f5012ab3223081ededa8bc015062de"


### PR DESCRIPTION
## Summary

Automated propagation Sync from `automation-core` branch:

- .gitignore
- Makefile
- .github/workflows
- scripts/pull-scripts
- scripts/version

---

Built for charts-build-scripts version: 1.9.20

2026-06-16