### PR TITLE
[automation-core] Release-track neuvector5.6 charts for 2.11-2.15

### DIFF
--- a/release/2.11.16.yaml
+++ b/release/2.11.16.yaml
@@ -83,22 +83,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  106.0.11+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  106.0.11+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  106.0.11+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   106.2.0+up3.3.0:

--- a/release/2.12.12.yaml
+++ b/release/2.12.12.yaml
@@ -88,22 +88,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  107.0.9+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  107.0.9+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  107.0.9+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   107.2.0+up4.2.2:

--- a/release/2.13.8.yaml
+++ b/release/2.13.8.yaml
@@ -88,22 +88,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  108.0.7+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  108.0.7+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  108.0.7+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   108.0.2+up5.0.2:

--- a/release/2.14.4.yaml
+++ b/release/2.14.4.yaml
@@ -76,22 +76,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  109.0.4+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  109.0.4+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  109.0.4+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   109.1.0+up6.0.1:

--- a/release/2.15.0.yaml
+++ b/release/2.15.0.yaml
@@ -76,22 +76,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  110.0.0+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  110.0.0+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  110.0.0+up2.10.4:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   110.0.0+up7.0.0:


### PR DESCRIPTION
#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [ ] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [ ] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->