### PR TITLE
use gh api instead of gh pr view

### DIFF
--- a/.github/actions/image-verify/action.yaml
+++ b/.github/actions/image-verify/action.yaml
@@ -191,7 +191,7 @@ runs:
         echo "Detecting changed chart packages under assets/ ..."
 
         CHARTS_FILE=$(mktemp)
-        gh pr view "${PR_NUMBER}" -R "${GITHUB_REPOSITORY}" --json files --jq '.files[] | select(.status != "removed") | .path' \
+        gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[] | select(.status != "removed") | .filename' \
           | grep -E '^assets/[^/]+/[^/]+\.tgz$' \
           | while IFS= read -r path; do
               chart_name=$(echo "$path" | cut -d'/' -f2)


### PR DESCRIPTION
It looks like `gh pr view` does not return if a file was deleted

example:
````
{"additions":0,"deletions":0,"path":"assets/rancher-backup/rancher-backup-110.0.0+up11.0.0-rc.5.tgz"}
{"additions":0,"deletions":0,"path":"assets/rancher-backup/rancher-backup-110.0.0+up11.0.0-rc.6.tgz"}
````