### PR TITLE
QA signoff for rancher-backup-restore charts

### DIFF
--- a/release/2.11.16.yaml
+++ b/release/2.11.16.yaml
@@ -132,7 +132,7 @@ rancher-backup:
     Released: false
   106.0.10+up7.0.9:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-backup-crd:
@@ -143,7 +143,7 @@ rancher-backup-crd:
     Released: false
   106.0.10+up7.0.9:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-cis-benchmark:

--- a/release/2.12.12.yaml
+++ b/release/2.12.12.yaml
@@ -137,7 +137,7 @@ rancher-backup:
     Released: false
   107.1.7+up8.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-backup-crd:
@@ -148,7 +148,7 @@ rancher-backup-crd:
     Released: false
   107.1.7+up8.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-cis-benchmark:

--- a/release/2.13.8.yaml
+++ b/release/2.13.8.yaml
@@ -137,7 +137,7 @@ rancher-backup:
     Released: false
   108.0.6+up9.0.6:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-backup-crd:
@@ -148,7 +148,7 @@ rancher-backup-crd:
     Released: false
   108.0.6+up9.0.6:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-cis-benchmark:

--- a/release/2.14.4.yaml
+++ b/release/2.14.4.yaml
@@ -125,7 +125,7 @@ rancher-backup:
     Released: false
   109.0.7+up10.0.8:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-backup-crd:
@@ -136,7 +136,7 @@ rancher-backup-crd:
     Released: false
   109.0.7+up10.0.8:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-cis-benchmark:

--- a/release/2.15.0.yaml
+++ b/release/2.15.0.yaml
@@ -120,13 +120,13 @@ rancher-alerting-drivers:
 rancher-backup:
   110.0.0+up11.0.0:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-backup-crd:
   110.0.0+up11.0.0:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 rancher-cis-benchmark:


### PR DESCRIPTION
#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [ ] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [ ] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->