### PR TITLE
[automation-core] new blocked chart versions for rancher-monitoring 

### DIFF
--- a/config/blocklist.yaml
+++ b/config/blocklist.yaml
@@ -2,8 +2,12 @@
 # Charts remain in index.yaml for existing deployments (upgrades/rollbacks)
 rancher-monitoring:
   - 109.0.1+up80.9.1-rancher.7
+  - 109.0.1+up80.9.1-rancher.8
+  - 109.0.2+up80.9.1-rancher.8
 rancher-monitoring-crd:
   - 109.0.1+up80.9.1-rancher.7
+  - 109.0.1+up80.9.1-rancher.8
+  - 109.0.2+up80.9.1-rancher.8
 rancher-backup:
   - 109.0.2+up10.0.2
 rancher-backup-crd:


### PR DESCRIPTION
Chart versions got their image dependencies deleted in the eve of the release without prior warning