### PR TITLE
[release-v2.14] infra propagation

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -40689,6 +40689,7 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/deploys-on-os: windows
       catalog.cattle.io/display-name: Monitoring
+      catalog.cattle.io/hidden: "true"
       catalog.cattle.io/kube-version: '>= 1.33.0-0 < 1.36.0-0'
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/permits-os: linux,windows
@@ -40851,6 +40852,7 @@ entries:
       catalog.cattle.io/certified: rancher
       catalog.cattle.io/deploys-on-os: windows
       catalog.cattle.io/display-name: Monitoring
+      catalog.cattle.io/hidden: "true"
       catalog.cattle.io/kube-version: '>= 1.33.0-0 < 1.36.0-0'
       catalog.cattle.io/namespace: cattle-monitoring-system
       catalog.cattle.io/permits-os: linux,windows

--- a/scripts/version
+++ b/scripts/version
@@ -3,6 +3,6 @@ set - e
 
 CHARTS_BUILD_SCRIPTS_REPO=https://github.com/rancher/charts-build-scripts.git
 # renovate: datasource=github-releases depName=rancher/charts-build-scripts
-CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.9.26}"
-# renovate: datasource=github-release-attachments depName=rancher/charts-build-scripts digestVersion=v1.9.26
-CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64="ecb90d1ba0ef367923eeddc6b912c2a55370a95192e3e4796b40d12ea51b36e0"
+CHARTS_BUILD_SCRIPT_VERSION="${CHARTS_BUILD_SCRIPT_VERSION:-v1.9.27}"
+# renovate: datasource=github-release-attachments depName=rancher/charts-build-scripts digestVersion=v1.9.27
+CHARTS_BUILD_SCRIPT_CHECKSUM_LINUX_AMD64="1060b7246b3902b4b4b81afae37296cefb9c6d0079e605d70f7b42267b473665"


### PR DESCRIPTION
## Summary

Automated propagation Sync from `automation-core` branch:

- .gitignore
- Makefile
- .github/workflows
- .github/CODEOWNERS
- scripts/pull-scripts
- scripts/version

---

Built for charts-build-scripts version: 1.9.27

2026-07-25