### PR TITLE
[automation-core] Fix QA field of SR charts

### DIFF
--- a/release/2.11.16.yaml
+++ b/release/2.11.16.yaml
@@ -263,13 +263,13 @@ rancher-pushprox:
 rancher-supportability-review:
   106.0.5+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-supportability-review-crd:
   106.0.5+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-turtles:

--- a/release/2.12.12.yaml
+++ b/release/2.12.12.yaml
@@ -268,13 +268,13 @@ rancher-pushprox:
 rancher-supportability-review:
   107.0.5+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-supportability-review-crd:
   107.0.5+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-turtles:

--- a/release/2.13.8.yaml
+++ b/release/2.13.8.yaml
@@ -268,13 +268,13 @@ rancher-pushprox:
 rancher-supportability-review:
   108.0.2+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-supportability-review-crd:
   108.0.2+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-turtles:

--- a/release/2.14.4.yaml
+++ b/release/2.14.4.yaml
@@ -256,13 +256,13 @@ rancher-pushprox:
 rancher-supportability-review:
   109.0.1+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-supportability-review-crd:
   109.0.1+up0.1.7:
     ToRelease: true
-    QA: false
+    QA: true
     UnRC: true
     Released: false
 rancher-turtles:


### PR DESCRIPTION
#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [x] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [x] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [x] The `index.yaml` file has an entry for your new chart version.
- [x] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [x] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->