### PR TITLE
[automation-core] rancher-monitoring-dashboards 110.0.0+up0.1.2 bump

### DIFF
--- a/release/2.15.0.yaml
+++ b/release/2.15.0.yaml
@@ -226,7 +226,7 @@ rancher-monitoring-crd:
     UnRC: true
     Released: false
 rancher-monitoring-dashboards:
-  110.0.0+up0.1.1:
+  110.0.0+up0.1.2:
     ToRelease: true
     QA: true
     UnRC: true


### PR DESCRIPTION
#8404 replaced 110.0.0+up0.1.1 with 110.0.0+up0.1.2 due to a missing annotation.