### PR TITLE
[automation-core] neuvector 5.6.1 charts for 2.11-2.15

### DIFF
--- a/release/2.11.7.yaml
+++ b/release/2.11.7.yaml
@@ -71,22 +71,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  106.1.0+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  106.1.0+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  106.1.0+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   <version>:

--- a/release/2.12.3.yaml
+++ b/release/2.12.3.yaml
@@ -71,22 +71,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  107.1.0+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  107.1.0+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  107.1.0+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   <version>:

--- a/release/2.13.9.yaml
+++ b/release/2.13.9.yaml
@@ -71,22 +71,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  108.0.8+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  108.0.8+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  108.0.8+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   108.0.2+up5.0.3:

--- a/release/2.14.5.yaml
+++ b/release/2.14.5.yaml
@@ -71,22 +71,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  109.0.5+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  109.0.5+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  109.0.5+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   109.0.1+up6.0.3:

--- a/release/2.15.1.yaml
+++ b/release/2.15.1.yaml
@@ -71,22 +71,22 @@ longhorn-crd:
     UnRC: false
     Released: false
 neuvector:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  110.0.1+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-crd:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  110.0.1+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 neuvector-monitor:
-  <version>:
-    ToRelease: false
-    QA: false
-    UnRC: false
+  110.0.1+up2.11.1:
+    ToRelease: true
+    QA: true
+    UnRC: true
     Released: false
 prometheus-federator:
   <version>:


### PR DESCRIPTION
Mark neuvector, neuvector-crd, and neuvector-monitor for release tracking across the 2.11–2.15 lines.

| Release file | Version |
|---|---|
| release/2.15.1.yaml | 110.0.1+up2.11.1 |
| release/2.14.5.yaml | 109.0.5+up2.11.1 |
| release/2.13.9.yaml | 108.0.8+up2.11.1 |
| release/2.12.3.yaml | 107.1.0+up2.11.1 |
| release/2.11.7.yaml | 106.1.0+up2.11.1 |

For each: `ToRelease`, `QA`, `UnRC` set to `true`; `Released` left `false` (set automatically by GHA).