### PR TITLE
[automation-core] Rename file from 2.12.3 to 2.12.13 and set QA flag to true for fleet components for version 2.12.13

### DIFF
--- a/release/2.12.13.yaml
+++ b/release/2.12.13.yaml
@@ -25,19 +25,19 @@ epinio-crd:
 fleet:
   107.0.15+up0.13.15:
     ToRelease: false
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 fleet-agent:
   107.0.15+up0.13.15:
     ToRelease: false
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 fleet-crd:
   107.0.15+up0.13.15:
     ToRelease: false
-    QA: false
+    QA: true
     UnRC: false
     Released: false
 harvester-cloud-provider:

--- a/release/2.12.13.yaml
+++ b/release/2.12.13.yaml
@@ -23,19 +23,19 @@ epinio-crd:
     UnRC: false
     Released: false
 fleet:
-  <version>:
+  107.0.15+up0.13.15:
     ToRelease: false
     QA: false
     UnRC: false
     Released: false
 fleet-agent:
-  <version>:
+  107.0.15+up0.13.15:
     ToRelease: false
     QA: false
     UnRC: false
     Released: false
 fleet-crd:
-  <version>:
+  107.0.15+up0.13.15:
     ToRelease: false
     QA: false
     UnRC: false


### PR DESCRIPTION
#### Pull Requests Rules

- `Never remove an already released chart!`
  - This does not apply to RC's because they are not released.
- Each Pull Request should only modify one chart with its dependencies.

- Pull request title:

    ```
    [dev-v2.X] <chart> <version> <action>
    ```

  - `<action>`: 1 of (bump; remove; UnRC)

---

##### Checkpoints for Chart Bumps

`release.yaml`:

- [ ] Each chart version in release.yaml DOES NOT modify an already released chart. If so, stop and modify the versions so that it releases a net-new chart.
- [ ] Each chart version in release.yaml IS exactly 1 more patch or minor version than the last released chart version. If not, stop and modify the versions so that it releases a net-new chart.

`Chart.yaml and index.yaml`:

- [ ] The `index.yaml` file has an entry for your new chart version.
- [ ] The `index.yaml` entries for each chart matches the `Chart.yaml` for each chart.
- [ ] Each chart has ALL required annotations
  - kube-version annotation
  - rancher-version annotation
  - permits-os annotation (indicates Windows and/or Linux)

---

Fill the following only if required by your manager.

##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->

##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->

##### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->