### PR TITLE
[dev-v2.16] Removing legacy csp-adapter

### DIFF
--- a/packages/rancher-csp-adapter/package.yaml
+++ b/packages/rancher-csp-adapter/package.yaml
@@ -1,3 +1,0 @@
-url: https://github.com/rancher/csp-adapter/releases/download/v10.0.0/rancher-csp-adapter-10.0.0.tgz
-version: 110.0.0
-

--- a/release.yaml
+++ b/release.yaml
@@ -158,8 +158,6 @@ rancher-compliance-crd:
   - 107.11.0+up1.2.11
   - 108.8.0+up1.3.9
   - 109.4.0+up1.4.5
-rancher-csp-adapter:
-  - 110.0.0+up10.0.0
 rancher-eks-operator:
   - 110.0.0+up1.15.0
   - 106.12.0+up1.11.12


### PR DESCRIPTION
Legacy csp-adapter will run out of support on NOV/26.

---
##### Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed in your solution section. -->
[JIRA: CSE-638](https://jira.suse.com/browse/CSE-638)
##### Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain how this addresses the issue. -->
Remove the charts for the legacy csp-adapter on Rancher release/2.16 onwards.